### PR TITLE
Quick QoL and fixes to Departmental Announcements

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -1275,6 +1275,10 @@ public sealed partial class ChatSystem : SharedChatSystem
             }
             if (TryComp<ActiveRadioComponent>(uid.Value, out var ActiveRadio))
             {
+                if (ActiveRadio.ReceiveAllChannels)
+                {
+                    return false;
+                }
                 foreach (var id in ActiveRadio.Channels)
                 {
                     if (channel == id)

--- a/Content.Server/Communications/CommunicationsConsoleComponent.cs
+++ b/Content.Server/Communications/CommunicationsConsoleComponent.cs
@@ -29,6 +29,14 @@ namespace Content.Server.Communications
         public LocId Title = "comms-console-announcement-title-station";
 
         /// <summary>
+        /// Fluent ID for the announcement title
+        /// If a Fluent ID isn't found, just uses the raw string
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField(required: true)]
+        public LocId TitleAlt = "comms-console-announcement-title-station-alt";
+
+        /// <summary>
         /// Announcement color
         /// </summary>
         [ViewVariables]

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -331,7 +331,9 @@ namespace Content.Server.Communications
             }
             else
             {
-                _chatSystem.DispatchFilteredCommunicationsConsoleAnnouncement(comp.CurrentChannel, uid, msg, title, announcementSound: comp.Sound, colorOverride: comp.Color, Global: comp.Global); // 🌟Starlight🌟
+                Loc.TryGetString(comp.TitleAlt, out var titlealt);
+                titlealt ??= comp.TitleAlt;
+                _chatSystem.DispatchFilteredCommunicationsConsoleAnnouncement(comp.CurrentChannel, uid, msg, titlealt, announcementSound: comp.Sound, colorOverride: comp.Color, Global: comp.Global); // 🌟Starlight🌟
                 _adminLogger.Add(LogType.Chat, LogImpact.Low, $"{ToPrettyString(message.Actor):player} has sent the following departmental announcement to {comp.CurrentChannel}: {msg}");
                 return;
             }

--- a/Resources/Locale/en-US/communications/communications-console-component.ftl
+++ b/Resources/Locale/en-US/communications/communications-console-component.ftl
@@ -32,3 +32,10 @@ comms-console-announcement-title-centcom = Central Command
 comms-console-announcement-title-nukie = Syndicate Nuclear Operative
 comms-console-announcement-title-station-ai = Station AI
 comms-console-announcement-title-wizard = Wizard
+
+# Comms console variant titles alts
+comms-console-announcement-title-station-alt = Communications Console Departmental
+comms-console-announcement-title-centcom-alt = Central Command Departmental
+comms-console-announcement-title-nukie-alt = Syndicate Nuclear Operative Departmental
+comms-console-announcement-title-station-ai-alt = Station AI Departmental
+comms-console-announcement-title-wizard-alt = Wizard Departmental

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -73,6 +73,7 @@
   - type: CommunicationsConsole
     canShuttle: false
     title: comms-console-announcement-title-station-ai
+    titleAlt: comms-console-announcement-title-station-ai-alt
     sound: /Audio/_Starlight/Announcements/announce2.ogg #Starlight
     color: "#00a2ff"
     channels:

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -695,6 +695,7 @@
     access: [[ "Command" ]]
   - type: CommunicationsConsole
     title: comms-console-announcement-title-station
+    titleAlt: comms-console-announcement-title-station-alt
     sound: /Audio/_Starlight/Announcements/announce2.ogg #Starlight
   - type: DeviceNetwork
     deviceNetId: Wireless    
@@ -763,6 +764,7 @@
     access: [[ "NuclearOperative" ]]
   - type: CommunicationsConsole
     title: comms-console-announcement-title-nukie
+    titleAlt: comms-console-announcement-title-nukie-alt
     color: "#ff0000"
     canShuttle: false
     global: true #announce to everyone they're about to fuck shit up
@@ -821,6 +823,7 @@
     access: [[ "Wizard" ]]
   - type: CommunicationsConsole
     title: comms-console-announcement-title-wizard
+    titleAlt: comms-console-announcement-title-wizard-alt
     color: "#ff00ff"
     canShuttle: false
     global: true #announce to everyone they're about to fuck shit up
@@ -879,6 +882,7 @@
     access: [[ "CentralCommand" ]]
   - type: CommunicationsConsole
     title: comms-console-announcement-title-centcom
+    titleAlt: comms-console-announcement-title-centcom-alt
     color: "#1d8bad"
     canShuttle: false
     global: true


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds different titles depending if its a station wide broadcast or departmental.
Also adds the ability for observers to see the announcements (whoops).

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Just small improvements to the current system.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Forgor but trust.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Athena
- add: Added different announcement titles setting depending on station or departmental announcement.
- fix: Fixed Observers not being able to see the departmental announcements.
