### PR TITLE
Add natural spawns for shipyard tools

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -160,6 +160,7 @@
     - id: RCDAmmo
     - id: AirGrenade
     - id: ClothingOuterCoverallsAtmos
+    - id: IntegrityAnalyzer # Far Horizons
 
 - type: entityTable
   id: FillAtmosphericsHardsuit
@@ -204,6 +205,7 @@
     - id: RCDAmmo
     - id: MetalFoamGrenade
     - id: ClothingOuterCoverallsEngi # Far Horizons
+    - id: IntegrityAnalyzer # Far Horizons
 
 - type: entityTable
   id: FillEngineerHardsuit

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -25,6 +25,7 @@
     - id: RadioHandheldExpedition #starlight
     - id: ClothingOuterHardsuitLuxmax #starlight
     - id: SalvageShuttleConsoleCircuitboard #starlight
+    - id: ShipLabeler # Far Horizons
 
 - type: entity
   id: LockerQuarterMasterFilled
@@ -177,11 +178,13 @@
     - id: ClothingHeadsetAltEngineering
     - id: DoorRemoteEngineering
     - id: CargoRequestEngineeringComputerCircuitboard
-    - id: RCD
+    - id: ShipyardRCD # Far Horizons
     - id: RCDAmmo
     - id: RubberStampCE
     - id: MetalFoamGrenade
     - id: PlushieMatthew #starlight
+    - id: IntegrityAnalyzer # Far Horizons
+    - id: ShipLabeler # Far Horizons
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds spawns for shipyard tools in job lockers:
* Integrity Analyzer in engi, atmos and CE locker
* Ship Labeler in CE and QM locker
* Shipyard RCD in CE locker, replacing normal RCD

## Why we need to add this
To get new tools into players hands and gather feedback

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Far Horizons
- add: Added shipyard tools into job lockers.
