### PR TITLE
Adds a description and name to syndi uplink ammo.

### DIFF
--- a/Resources/Locale/en-US/_Starlight/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Starlight/store/uplink-catalog.ftl
@@ -11,7 +11,7 @@ uplink-deagle-desc = A robust magnum handgun.
 uplink-stechkin-name = Stechkin pistol
 uplink-stechkin-desc = A small, easily concealable 10mm handgun. Has a threaded barrel for suppressors.
 uplink-pistol-magnum-magazine-name = Pistol Magazine (.45 magnum)
-uplink-pistol-magnum-magazine-desc = Pistol magazine with 10 cartridges. Compatible with the Desert Eagle.
+uplink-pistol-magnum-magazine-desc = Pistol magazine with 7 cartridges. Compatible with the Desert Eagle.
 uplink-magillitis-serum-implanter-name = Magillitis Serum Implanter
 uplink-magillitis-serum-implanter-desc = An experimental biochip which causes irreversable rapid muscular growth in Hominidae. Side-affects may include hypertrichosis, violent outbursts, and an unending affinity for bananas.
 

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -91,6 +91,15 @@ uplink-shrapnel-grenade-desc = Launches a spray of sharp fragments dealing great
 uplink-pistol-magazine-name = Pistol Magazine (.35 auto)
 uplink-pistol-magazine-desc = Pistol magazine with 10 cartridges. Compatible with the Viper.
 
+uplink-pistol-magazine-nameFMJ = Pistol Magazine (.35 FMJ)
+uplink-pistol-magazine-descFMJ = Pistol magazine with 10 cartridges
+
+uplink-pistol-magazine-nameSP = Pistol Magazine (.35 SP)
+uplink-pistol-magazine-descSP = Pistol magazine with 10 cartridges.
+
+uplink-pistol-magazine-nameHP = Pistol Magazine (.35 HP)
+uplink-pistol-magazine-descHP = Pistol magazine with 10 cartridges.
+
 uplink-pistol-magazine-c20r-name = SMG magazine (.35 auto)
 uplink-pistol-magazine-c20r-desc = Rifle magazine with 30 cartridges. Compatible with C-20r.
 


### PR DESCRIPTION
## Short description
Changes the ammo description and name in the syndicate uplink.

## Why we need to add this
It breaks the game immersion and is really just an easy fix. 

## Media (Video/Screenshots)
<img width="367" height="120" alt="image" src="https://github.com/user-attachments/assets/a176e491-ca80-40f1-ae57-6a228d2b2367" />

<img width="369" height="122" alt="image" src="https://github.com/user-attachments/assets/f5b1804a-c3ca-44c9-a292-752a4ce8eca3" />

<img width="371" height="118" alt="image" src="https://github.com/user-attachments/assets/85bdcddb-abe8-4b2a-925f-9e21429a0f3a" />


## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: ScorchFollower

- fix: Fixed uplink ammo description and name

