### PR TITLE
Changed the laser cap on X-49 and removed alert restraint.

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -46,17 +46,9 @@
       magState: disable
       visualState: disable-unshaded
     - proto: RedLaserBeam
-      fireCost: 200
+      fireCost: 175
       magState: kill
       visualState: kill-unshaded
-      conditions:
-      - !type:AlertLevelCondition
-        alertLevels:
-        - blue
-        - violet
-        - yellow
-        - red
-        - gamma
   - type: Battery
     maxCharge: 1500
     startingCharge: 1500


### PR DESCRIPTION
## Short description
Removed the alert levels and increased the amount of laser shots you have in the battery storage.

## Why we need to add this
People in the community find this gun "weak" and it's alert level too annoying to deal with so I just increased the cap amount of lasers and removed the alert level restraint on the gun. Lets see how this goes.

Notes: Draft momentarily as I test it in-game. Making this draft now so I don't forget it or get lazy.

## Media (Video/Screenshots)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: ScorchFollower
- remove: Removed the alert level restraint system on the X-49 multiphase rifle "Rushdown"
- tweak: Increased the amount of laser shots the X-49 can hold when fully charged.

