### PR TITLE
Reworks how bullets shoot! (Merge before playtest plz, Abby gave greenlight)

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -125,16 +125,9 @@
   parent: BulletTrace
   damage:
     types:
-<<<<<<< Updated upstream
-      Blunt: 35
-      Piercing: 10 # +30%
-  staminaDamage: 10    
-  armorPenetration: -0.55
-=======
       Piercing: 45 # +30%  #FH
   staminaDamage: 10    
   armorPenetration: -1  #FH
->>>>>>> Stashed changes
   pierceChance: 0.03
   derivation: 0.05
   ricochetChance: 0.15
@@ -258,14 +251,8 @@
   parent: BulletTrace
   damage:
     types:
-<<<<<<< Updated upstream
-      Blunt: 16
-      Piercing: 5 # +30%
-  armorPenetration: -0.55
-=======
       Piercing: 21 # +30% #FH
   armorPenetration: -1  #FH
->>>>>>> Stashed changes
   staminaDamage: 5
   pierceChance: 0.03
   derivation: 0.2
@@ -372,27 +359,15 @@
   staminaDamage: 7.5  #FH
   damage:
     types:
-<<<<<<< Updated upstream
-      Blunt: 20
-      Piercing: 6 # +30%
-=======
       Piercing: 33  #FH
->>>>>>> Stashed changes
   bullet:
     sprite:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
       state: bullet
-<<<<<<< Updated upstream
-  armorPenetration: -0.55
-  pierceChance: 0.02
-  derivation: 0.15
-  ricochetChance: 0.10
-=======
   armorPenetration: -1  #FH
   pierceChance: 0.03  #FH
   derivation: 0.12  #FH
   ricochetChance: 0.15  #FH
->>>>>>> Stashed changes
   
 - type: hitscan
   id: BulletPistolTrace40FMJ
@@ -502,16 +477,9 @@
   parent: BulletTrace
   damage:
     types:
-<<<<<<< Updated upstream
-      Blunt: 19
-      Piercing: 6 # +30%
-  pierceLevel: Wood
-  armorPenetration: -0.55
-=======
       Piercing: 25 # +30% #FH
   pierceLevel: Wood
   armorPenetration: -1 #FH
->>>>>>> Stashed changes
   staminaDamage: 6
   pierceChance: 0.03
   derivation: 0.05
@@ -619,14 +587,8 @@
   parent: BulletTrace
   damage:
     types:
-<<<<<<< Updated upstream
-      Blunt: 17
-      Piercing: 6 # +30%
-  armorPenetration: -0.55
-=======
       Piercing: 23 # +30% #FH
   armorPenetration: -1
->>>>>>> Stashed changes
   staminaDamage: 5
   pierceChance: 0.03
   ricochetChance: 0.15

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -125,10 +125,16 @@
   parent: BulletTrace
   damage:
     types:
+<<<<<<< Updated upstream
       Blunt: 35
       Piercing: 10 # +30%
   staminaDamage: 10    
   armorPenetration: -0.55
+=======
+      Piercing: 45 # +30%  #FH
+  staminaDamage: 10    
+  armorPenetration: -1  #FH
+>>>>>>> Stashed changes
   pierceChance: 0.03
   derivation: 0.05
   ricochetChance: 0.15
@@ -169,7 +175,7 @@
   igniteOnCollision: true
   damage:
     types:
-      Blunt: 3
+      Piercing: 3  #FH
       Heat: 32
   pierceChance: 0.69
   derivation: 0.05
@@ -184,9 +190,10 @@
   parent: BulletTrace
   damage:
     types:
-      Radiation: 15
-      Piercing: 20
-  pierceChance: 0.69
+      Radiation: 15 #FH
+      Piercing: 10  #FH
+  armorPenetration: 0.35  #FH
+  pierceChance: 0.75  #FH
   derivation: 0.05
   ricochetChance: 0.80
   pierceLevel: HardenedMetal
@@ -251,9 +258,14 @@
   parent: BulletTrace
   damage:
     types:
+<<<<<<< Updated upstream
       Blunt: 16
       Piercing: 5 # +30%
   armorPenetration: -0.55
+=======
+      Piercing: 21 # +30% #FH
+  armorPenetration: -1  #FH
+>>>>>>> Stashed changes
   staminaDamage: 5
   pierceChance: 0.03
   derivation: 0.2
@@ -269,7 +281,7 @@
   pierceChance: 0.69
   derivation: 0.2
   ricochetChance: 0.80
-  pierceLevel: Wood
+  pierceLevel: Metal #FH
   bullet:
     sprite:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
@@ -295,7 +307,7 @@
   igniteOnCollision: true
   damage:
     types:
-      Blunt: 2
+      Piercing: 2 #FH
       Heat: 14
   pierceChance: 0.69
   derivation: 0.2
@@ -310,9 +322,10 @@
   parent: BulletTrace
   damage:
     types:
-      Radiation: 6
-      Piercing: 10
-  pierceChance: 0.69
+      Radiation: 8 #FH
+      Piercing: 3 #FH
+  armorPenetration: 0.35 #FH
+  pierceChance: 0.75 #FH
   derivation: 0.2
   ricochetChance: 0.80
   pierceLevel: HardenedMetal
@@ -340,51 +353,62 @@
 - type: hitscan
   id: BulletPistolTrace40SP
   parent: BulletTrace
-  staminaDamage: 3
+  staminaDamage: 3  #FH
   damage:
     types:
-      Piercing: 25
+      Piercing: 25  #FH
   bullet:
     sprite:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
       state: sp
-  armorPenetration: -0.25
-  pierceChance: 0.40
-  derivation: 0.12
-  ricochetChance: 0.30
+  armorPenetration: -0.13 #FH
+  pierceChance: 0.40  #FH
+  derivation: 0.12  #FH
+  ricochetChance: 0.30  #FH
   
 - type: hitscan
   id: BulletPistolTrace40HP
   parent: BulletTrace
-  staminaDamage: 7.5
+  staminaDamage: 7.5  #FH
   damage:
     types:
+<<<<<<< Updated upstream
       Blunt: 20
       Piercing: 6 # +30%
+=======
+      Piercing: 33  #FH
+>>>>>>> Stashed changes
   bullet:
     sprite:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
       state: bullet
+<<<<<<< Updated upstream
   armorPenetration: -0.55
   pierceChance: 0.02
   derivation: 0.15
   ricochetChance: 0.10
+=======
+  armorPenetration: -1  #FH
+  pierceChance: 0.03  #FH
+  derivation: 0.12  #FH
+  ricochetChance: 0.15  #FH
+>>>>>>> Stashed changes
   
 - type: hitscan
   id: BulletPistolTrace40FMJ
   parent: BulletTrace
   damage:
     types:
-      Piercing: 20
+      Piercing: 20  #FH
   bullet:
     sprite:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
       state: fmj
-  armorPenetration: 0.25
-  pierceChance: 0.69
-  derivation: 0.12
-  ricochetChance: 0.80
-  pierceLevel: Metal
+  armorPenetration: 0.25  #FH
+  pierceChance: 0.69  #FH
+  derivation: 0.12  #FH
+  ricochetChance: 0.80  #FH
+  pierceLevel: HardenedMetal
   
 - type: hitscan
   id: BulletPistolTrace40AP
@@ -392,16 +416,16 @@
   staminaDamage: 10
   damage:
     types:
-      Piercing: 14
+      Piercing: 20
   bullet:
     sprite:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
       state: ap
-  armorPenetration: 0.50
-  pierceChance: 0.63
-  derivation: 0.15
-  ricochetChance: 0.35
-  pierceLevel: Metal
+  armorPenetration: 0.69 #FH
+  pierceChance: 0.63 #FH
+  derivation: 0.15 #FH
+  ricochetChance: 0.35 #FH
+  pierceLevel: HardenedMetal #FH
 
 ### caseless rifle <<<<<<<<<<<<<<<
 
@@ -478,10 +502,16 @@
   parent: BulletTrace
   damage:
     types:
+<<<<<<< Updated upstream
       Blunt: 19
       Piercing: 6 # +30%
   pierceLevel: Wood
   armorPenetration: -0.55
+=======
+      Piercing: 25 # +30% #FH
+  pierceLevel: Wood
+  armorPenetration: -1 #FH
+>>>>>>> Stashed changes
   staminaDamage: 6
   pierceChance: 0.03
   derivation: 0.05
@@ -539,7 +569,7 @@
   igniteOnCollision: true
   damage:
     types:
-      Blunt: 3
+      Piercing: 3 #FH
       Heat: 16
   pierceChance: 0.69
   derivation: 0.05
@@ -554,9 +584,10 @@
   parent: BulletTrace
   damage:
     types:
-      Radiation: 9
-      Piercing: 10
-  pierceChance: 0.69
+      Radiation: 9 #FH
+      Piercing: 4 #FH
+  armorPenetration: 0.35 #FH
+  pierceChance: 0.75 #FH
   derivation: 0.05
   ricochetChance: 0.80
   pierceLevel: HardenedMetal
@@ -588,9 +619,14 @@
   parent: BulletTrace
   damage:
     types:
+<<<<<<< Updated upstream
       Blunt: 17
       Piercing: 6 # +30%
   armorPenetration: -0.55
+=======
+      Piercing: 23 # +30% #FH
+  armorPenetration: -1
+>>>>>>> Stashed changes
   staminaDamage: 5
   pierceChance: 0.03
   ricochetChance: 0.15
@@ -644,7 +680,7 @@
   igniteOnCollision: true
   damage:
     types:
-      Blunt: 2
+      Piercing: 2 #FH
       Heat: 15
   pierceChance: 0.69
   ricochetChance: 0.48
@@ -658,9 +694,10 @@
   parent: BulletTrace
   damage:
     types:
-      Radiation: 7
-      Piercing: 8
-  pierceChance: 0.69
+      Radiation: 8 #FH
+      Piercing: 4 #FH
+  armorPenetration: 0.35 #FH
+  pierceChance: 0.75 #FH
   ricochetChance: 0.80
   pierceLevel: HardenedMetal
   bullet:
@@ -688,8 +725,10 @@
   damage:
     types:
       Piercing: 40
-      Structural: 15
-  pierceChance: 0.08
+      Structural: 80 #Breaching rounds at home (Based on syndie breaching rounds, which do 240 per shot. Buckshot does 60 for reference.), FH
+  armorPenetration: 0.25 #FH
+  pierceLevel: Metal #FH
+  pierceChance: 0.69 #FH
   bullet:
     sprite:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
@@ -727,7 +766,7 @@
   parent: BulletTrace
   damage:
     types:
-      Blunt: 2
+      Piercing: 2 #FH
       Heat: 3
   pierceChance: 0.02
   igniteOnCollision: true
@@ -768,16 +807,16 @@
       state: shard
 
 - type: hitscan
-  id: PelletShotgunUraniumSpreadTrace
+  id: PelletShotgunUraniumSpreadTrace # No longer Pellet but Slug. Not changing proto because that would fuck a lot of things, FH
   parent: BulletTrace
   damage:
     types:
-      Radiation: 2
-      Piercing: 3
-  pierceChance: 0.05
+      Radiation: 25 #FH
+      Piercing: 15 #FH
+      Structural: 140 #Breaching rounds at home, FH
+  pierceChance: 0.75 #FH
   pierceLevel: HardenedMetal
-  count: 10
-  spread: 6
+  armorPenetration: 0.35 #FH
   bullet:
     sprite:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Cherry picks upstream commit (https://github.com/ss14Starlight/space-station-14/pull/1552) and fixes HP being objectively better, as well as raising uranium up to standard. 

Also gives slug/uranium slug shotgun rounds AP and structural damage values.

Merges
- New SP/FMJ/HP/AP values from Upstream (see linked PR for information)

Changes

- Uranium/Incind/HP values
Uranium damage is lowered, but given AP value. It's better than FMJ but weaker than AP.
Incind blunt damage moved to pierce
HP blunt damage moved to pierce, -1 modifier against armor re-added.
- Uranium shotgun rounds turned into slugs
Pellets never really made sense. They're now stronger slugs and can destroy a door in 4 shots.
Also given AP, and yes I tested it. Doesn't appear to be overpowered compared to my newly minted Uranium bullets & The FMJ bullets.
- Slugs given AP & Increased structural damage
Buckshot used to do more structural damage than a damn slug against a metal door. For many reasons, this is wrong. Destroys a door in 8 shots.
Given AP value. Doesn't appear to be overpowered compared to FMJ bullets
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Upstream fixed the eternal problem with FMJ being better than everything else, but overbuffed HP by making it inherently AP most armor through blunt damage. I fixed this, and also reworked how uranium rounds work while I'm at it- making the bullet type actually useful and competitive against other damage types. Did you know uranium never had ANY AP? Wild.

I also brought shotgun rounds into the modern age by giving proper structural damage values & AP values to appropriate rounds. They should be viable in combat now against armored targets, if you use slugs or uranium slugs.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.
-->
:cl: Killer Tamashi
- add: Added Upstream Bullet Changes
- tweak: Turned all instances of blunt bullet damage into pierce (minus improv ammo)
- tweak: Uranium shotgun rounds turned into slugs.
- tweak: Uranium & Slug rounds now have AP values, making them viable in combat.
- tweak: Uranium & Slug rounds now have proper structural damage values, making them a viable way to breach doors. (8 for slug, 4 for uranium)
- tweak: Normal Uranium bullets given inherent AP, better than FMJ 
- fix: Fixed HP being objectively better than SP against armor.