### PR TITLE
Vitals Monitor circuit board/construction, cleaned up comments in VM

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -83,6 +83,7 @@
   - ChemMasterMachineCircuitboard
   - CondenserMachineCircuitBoard
   - HotplateMachineCircuitboard
+  - VitalsMonitorMachineCircuitboard #Far Horizons
 
 ## Dynamic
 

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/Circuitboards/Machine/vitalsmonitor.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/Circuitboards/Machine/vitalsmonitor.yml
@@ -1,0 +1,12 @@
+- type: entity
+  id: VitalsMonitorMachineCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Vitals Monitor Machine board
+  description: A machine printed circuit board for a vitals monitor.
+  components:
+    - type: MachineBoard
+      prototype: VitalsMonitor
+      stackRequirements:
+        Manipulator: 4
+        Cable: 4
+        Glass: 2

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Machines/Computers/computers.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: BaseComputerAiAccess
   id: VitalsMonitor
-  name: Vitals Monitor # Starlight-edit
+  name: Vitals Monitor
   description: A device that monitors the vitals of whoever is laying next to it.
   components:
   - type: ApcPowerReceiver
@@ -12,7 +12,6 @@
     radius: 1.5
     energy: 1.6
     color: "#1f8c28"
-  # Starlight-start: Surgery body scanner
   - type: Sprite
     sprite: _FarHorizons/Structures/Machines/Computers/vitalmonitor.rsi
     layers:
@@ -37,4 +36,5 @@
     range: 2
     ports:
       - VitalsMonitorSender
-  # Starlight-end
+  - type: Machine
+    board: VitalsMonitorMachineCircuitboard

--- a/Resources/Prototypes/_FarHorizons/Recipes/Lathes/machine_boards.yml
+++ b/Resources/Prototypes/_FarHorizons/Recipes/Lathes/machine_boards.yml
@@ -1,0 +1,4 @@
+- type: latheRecipe
+  parent: [ BaseCircuitboardRecipe, BaseMedicalMachineRecipeCategory ]
+  id: VitalsMonitorMachineCircuitboard
+  result: VitalsMonitorMachineCircuitboard


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Added a lathe circuit board recipe for the Vitals Monitor board that can be installed into a machine frame.
In case they get destroyed... they can be rebuilt.
Cleaned up comments in VM file.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Small oversight because I'm tired.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/7407b33d-7dba-459c-bcc8-c36fd530184c


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: CorruptOmega
- add: Vitals Monitor circuit board craftable in Lathe
- add: Vitals Monitor construction using Machine Frame
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
