### PR TITLE
Secborg no longer selectable

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -57,6 +57,18 @@
     interactSuccessSound:
       path: /Audio/Ambience/Objects/periodic_beep.ogg
   - type: FlashImmunity
+  - type: IntrinsicRadioTransmitter
+  channels:
+  - Binary
+  - Common
+  - Science
+  - Security
+- type: ActiveRadio
+  channels:
+  - Binary
+  - Common
+  - Science
+  - Security
   # - type: ActionGrant
   #   actions:
   #   - ActionBorgToggleSirens
@@ -65,13 +77,21 @@
   - type: SiliconLawProvider
     laws: Robocop
   - type: BorgChassis
+    maxModules: 6
     hasMindState: borg_e
     noMindState: borg_e_r
-  - type: BorgSwitchableType
-    selectedBorgType: security # This gives me locked modules.
-    inherentRadioChannels:
-    - Binary
-    - Common
+
+- type: entity
+  parent: BorgChassisSecurity
+  id: BorgChassisSecurityModule
+  suffix: Module
+  components:
+  - type: ContainerFill
+    containers:
+      borg_module:
+      - BorgModuleTool
+      - BorgModuleBaton
+      - BorgModuleDominator
 
 - type: entity
   parent: BaseBorgChassisNotIonStormable

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -26,14 +26,13 @@
     sprite: _FarHorizons/Mobs/Silicon/Chassis/security.rsi
     layers:
       - state: borg
-        map: [ "enum.BorgVisualLayers.Body", "movement" ]
-      - state: borg_e_r
-        map: [ "enum.BorgVisualLayers.Light" ]
+      - state: borg_e
+        map: ["enum.BorgVisualLayers.Light"]
         shader: unshaded
         visible: false
       - state: borg_l
         shader: unshaded
-        map: [ "light","enum.BorgVisualLayers.LightStatus" ]
+        map: ["light"]
         visible: false
       # - state: borg_siren_on
       #   map: [ "enum.BorgVisualLayers.Siren", "siren" ]

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -58,17 +58,17 @@
       path: /Audio/Ambience/Objects/periodic_beep.ogg
   - type: FlashImmunity
   - type: IntrinsicRadioTransmitter
-  channels:
-  - Binary
-  - Common
-  - Science
-  - Security
-- type: ActiveRadio
-  channels:
-  - Binary
-  - Common
-  - Science
-  - Security
+    channels:
+    - Binary
+    - Common
+    - Science
+    - Security
+  - type: ActiveRadio
+    channels:
+    - Binary
+    - Common
+    - Science
+    - Security
   # - type: ActionGrant
   #   actions:
   #   - ActionBorgToggleSirens

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Player/silicon.yml
@@ -8,6 +8,10 @@
     containers:
       borg_brain:
       - PositronicBrain
+      borg_module:
+      - BorgModuleTool
+      - BorgModuleBaton
+      - BorgModuleDominator
   - type: ItemSlots
     slots:
       cell_slot:

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -30,7 +30,7 @@
 - type: entity
   parent: [BaseBorgModuleSecurity,BaseProviderBorgModule,BaseSecurityContraband]
   id: BorgModuleBaton
-  name: Baton Cyborg module.
+  name: Baton Cyborg module
   description: Now even cyborgs can enjoy harm batong.
   components:
   - type: Sprite
@@ -55,7 +55,7 @@
 - type: entity
   parent: [BaseBorgModuleSecurity,BaseProviderBorgModule,BaseSecurityContraband]
   id: BorgModuleDominator
-  name: Dominator Cyborg module.
+  name: Dominator Cyborg module
   description: Module with a dominator specifically designed for cyborgs.
   components:
   - type: Sprite
@@ -71,7 +71,7 @@
 - type: entity
   parent: [BaseBorgModuleSecurity,BaseProviderBorgModule,BaseSecurityContraband]
   id: BorgModuleLaserCarbine
-  name: Laser Carbine Cyborg module.
+  name: Laser Carbine Cyborg module
   description: Module with a Laser Carbine specifically designed for cyborgs.
   components:
   - type: Sprite
@@ -116,7 +116,7 @@
 - type: entity
   parent: [BaseBorgModuleCentcomm,BaseProviderBorgModule,BaseCentcommContraband]
   id: CentcommLaserModule
-  name: CentComm cyborg laser module.
+  name: CentComm cyborg laser module
   description: Module with a standard issue HAW laser.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_FarHorizons/Recipes/Construction/Graphs/machines/secborg.yml
+++ b/Resources/Prototypes/_FarHorizons/Recipes/Construction/Graphs/machines/secborg.yml
@@ -33,7 +33,7 @@
         doAfter: 0.5
 
   - node: secborg
-    entity: BorgChassisSecurity
+    entity: BorgChassisSecurityModule
 
   # - node: derelictsecborg # todo derelict security borg
   #   entity: BorgChassisDerelictSecurity

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -208,34 +208,3 @@
   # Pet
   petSuccessString: petting-success-service-cyborg
   petFailureString: petting-failure-service-cyborg
-
-# Far Horizons
-# Generic borg
-- type: borgType
-  id: security
-
-  # Description
-  dummyPrototype: BorgChassisSecurity
-
-  # Functional
-  extraModuleCount: 3
-  moduleWhitelist:
-    tags:
-    - BorgModuleGeneric
-    - BorgModuleSecurity
-
-  defaultModules:
-  - BorgModuleTool
-  - BorgModuleBaton
-  - BorgModuleDominator
-  radioChannels:
-  - Science
-  - Security
-
-  # Visual
-  inventoryTemplateId: borgShort
-  spritePath: _FarHorizons/Mobs/Silicon/Chassis/security.rsi
-
-  # Pet
-  petSuccessString: petting-success-generic-cyborg
-  petFailureString: petting-failure-generic-cyborg  


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Makes secborg no longer selectable

## Why we need to add this
Whilst trying to make the sec borg have locked modules, I made it selectable by normal borgs. This reverts that commit.

## Media (Video/Screenshots)
Don't make me spin up the server it's literally a revert of one of my own commits

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RoadTrain
- fix: Secborg no longer selectable