### PR TITLE
Secborg - job spawner

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Markers/Spawners/jobs.yml
@@ -1,0 +1,14 @@
+- type: entity
+  id: SpawnPointSecBorg
+  parent: SpawnPointJobBase
+  name: security cyborg
+  components:
+  - type: SpawnPoint
+    job_id: SecBorg
+  - type: Sprite
+    layers:
+    - state: green
+    - sprite: _FarHorizons/Mobs/Silicon/Chassis/security.rsi
+      state: borg
+    - sprite: _FarHorizons/Mobs/Silicon/Chassis/security.rsi
+      state: borg_e


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds a job spawner for the security cyborg.

## Why we need to add this
Allows mappers to add the security cyborg job spawn to maps, meaning it won't spawn at arrivals. I wish I could also add the job spawns to the maps but I am too dumb to figure out how to properly save maps and PR them. I do code. Not mapping.

For mappers: Suggest adding the security robotics control console to the warden's office as it is for now armory locked. The borg can go anywhere in security, maybe put it in Armory? I'll leave that up to you.

## Media (Video/Screenshots)
<img width="338" height="39" alt="image" src="https://github.com/user-attachments/assets/28b3d76e-6324-4ddb-b5a3-8b01859a309e" />
<img width="73" height="72" alt="image" src="https://github.com/user-attachments/assets/e5686af5-be79-4bc2-a12a-2e86f3836961" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RoadTrain
- add: Adds a job spawner for the security cyborg. This, and the security cyborg control console need to be added to every map.
