### PR TITLE
Update rsi-diff.yml

### DIFF
--- a/.github/workflows/rsi-diff.yml
+++ b/.github/workflows/rsi-diff.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
+        with:
+          token: ${{ github.token }}
 
       - name: Get changed files
         id: files
@@ -41,6 +43,7 @@ jobs:
           issue-number: ${{ github.event.number }}
           comment-author: 'github-actions[bot]'
           body-includes: RSI Diff Bot
+          token: ${{ github.token }}
 
       - name: Create comment if it doesn't exist
         if: steps.fc.outputs.comment-id == ''
@@ -49,6 +52,7 @@ jobs:
           issue-number: ${{ github.event.number }}
           body: |
             ${{ steps.diff.outputs.summary-details }}
+          token: ${{ github.token }}
 
       - name: Update comment if it exists
         if: steps.fc.outputs.comment-id != ''


### PR DESCRIPTION
Looks like we were missing github token in a few spots

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Attempting to fix the diff bot

## Why we need to add this
Less false errors!

## Media (Video/Screenshots)
soonTM

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RoadTrain
- fix: rsi diff bot
