### PR TITLE
Disable Whitelist Requirement to Spawn Roles

### DIFF
--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Law/Magistrate.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Law/Magistrate.yml
@@ -10,8 +10,8 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 36000 # 10h
-    - !type:RolesRequirement
-      proto: ExtRolesReq
+#    - !type:RolesRequirement                #Far Horizons Disabled Currently Till Whitelist Added
+#      proto: ExtRolesReq
   startingGear: MagistrateGear
   icon: "JobIconMagistrate"
   rules: job-rules-corporate-aligned

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/blueshield.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/blueshield.yml
@@ -10,8 +10,8 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 72000 # 20 hrs
-    - !type:RolesRequirement
-      proto: ExtRolesReq
+#    - !type:RolesRequirement    #Far Horizons Disabled Currently Till Whitelist Added
+#      proto: ExtRolesReq
   startingGear: BlueShieldGear
   icon: JobIconBlueShield
   rules: job-rules-corporate-aligned

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/nanotrasenrepresentative.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/nanotrasenrepresentative.yml
@@ -7,8 +7,8 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 72000 # 20 hrs
-    - !type:RolesRequirement
-      proto: ExtRolesReq
+#    - !type:RolesRequirement        #Far Horizons Disabled Currently Till Whitelist Added
+#      proto: ExtRolesReq
   startingGear: NanoTrasenRepresentativeGear
   icon: JobIconNanotrasen
   rules: job-rules-corporate-aligned


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
All roles are currently open for everyone to play but for some reason people couldn't spawn in as them.
That's been fixed by disabling the role requirement.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
To enable these roles round start instead of being required to late join after the fact.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/53919431-93f4-403a-9509-c0803af52950


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: CorruptOmega
- tweak: Whitelisted roles on Starlight were available but wouldn't spawn anyone round start. Now they will.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
