### PR TITLE
Add InteractRestriction component for prototypers

### DIFF
--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Content.Shared._FarHorizons.Util;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
 using Content.Shared.CCVar;
@@ -536,6 +537,12 @@ namespace Content.Shared.Interaction
         {
             if (IsDeleted(user) || IsDeleted(used) || IsDeleted(target))
                 return;
+            
+            // Far Horizons, whitelist/blacklists for usable items
+            var ev = new CheckItemCanBeUsedEvent(user, target);
+            RaiseLocalEvent(used, ev, true);
+            if (ev.Cancelled)
+                return;
 
             if (target != null)
             {
@@ -1038,6 +1045,12 @@ namespace Content.Shared.Interaction
             if (checkCanUse && !_actionBlockerSystem.CanUseHeldEntity(user, used))
                 return false;
 
+            // Far Horizons, whitelist/blacklists for usable items
+            var ev = new CheckItemCanBeUsedEvent(user, target);
+            RaiseLocalEvent(used, ev, true);
+            if (ev.Cancelled)
+                return false;
+
             _adminLogger.Add(
                 LogType.InteractUsing,
                 LogImpact.Low,
@@ -1216,6 +1229,13 @@ namespace Content.Shared.Interaction
                 return false;
 
             if (checkCanUse && !_actionBlockerSystem.CanUseHeldEntity(user, used))
+                return false;
+            
+            // Far Horizons, whitelist/blacklists for usable items
+            // We set both source and target as user, because it's user using item on themselves
+            var ev = new CheckItemCanBeUsedEvent(user, user);
+            RaiseLocalEvent(used, ev, true);
+            if (ev.Cancelled)
                 return false;
 
             var useMsg = new UseInHandEvent(user);

--- a/Content.Shared/_FarHorizons/Util/CheckItemCanBeUsedEvent.cs
+++ b/Content.Shared/_FarHorizons/Util/CheckItemCanBeUsedEvent.cs
@@ -1,0 +1,18 @@
+namespace Content.Shared._FarHorizons.Util;
+
+/// <summary>
+///     Raised before an interaction by a user while holding an object in their hand.
+///     Cancels interaciton if necessary.
+/// </summary>
+public sealed class CheckItemCanBeUsedEvent(EntityUid user, EntityUid? target) : CancellableEntityEventArgs
+{
+    /// <summary>
+    ///     Entity that triggered the interaction.
+    /// </summary>
+    public EntityUid User { get; } = user;
+
+    /// <summary>
+    ///     Entity that was interacted on.
+    /// </summary>
+    public EntityUid? Target { get; } = target;
+}

--- a/Content.Shared/_FarHorizons/Util/Components/InteractRestrictionComponent.cs
+++ b/Content.Shared/_FarHorizons/Util/Components/InteractRestrictionComponent.cs
@@ -1,0 +1,24 @@
+using Content.Shared.Tag;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._FarHorizons.Util.Components;
+
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true), Access(typeof(InteractRestrictionSystem))]
+public sealed partial class InteractRestrictionComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public InteractRestrictionList? RestrictInteractionSource;
+    [DataField, AutoNetworkedField]
+    public InteractRestrictionList? RestrictInteractionTarget;
+}
+
+[DataDefinition, Serializable, NetSerializable]
+public sealed partial class InteractRestrictionList {
+    [DataField]
+    public HashSet<ProtoId<TagPrototype>>? Blacklist;
+    [DataField]
+    public HashSet<ProtoId<TagPrototype>>? Whitelist;
+}

--- a/Content.Shared/_FarHorizons/Util/IteractRestrictionSystem.cs
+++ b/Content.Shared/_FarHorizons/Util/IteractRestrictionSystem.cs
@@ -1,4 +1,6 @@
 ﻿using Content.Shared._FarHorizons.Util.Components;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Popups;
 using Content.Shared.Tag;
 
 namespace Content.Shared._FarHorizons.Util;
@@ -6,6 +8,7 @@ namespace Content.Shared._FarHorizons.Util;
 public sealed class InteractRestrictionSystem : EntitySystem
 {
     [Dependency] private readonly TagSystem _tagSystem = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
 
     public override void Initialize()
     {
@@ -30,6 +33,9 @@ public sealed class InteractRestrictionSystem : EntitySystem
             if (targetRestrict.Whitelist != null &&
                 !_tagSystem.HasAnyTag(target.Value, targetRestrict.Whitelist))
                     ev.Cancel();
+            
+            if (ev.Cancelled)
+                _popupSystem.PopupClient(Loc.GetString("interact-restriction-restricted-target", ("item", Identity.Entity(ent, EntityManager)), ("target", Identity.Entity(target.Value, EntityManager))), user);
         }
 
         if (ent.Comp.RestrictInteractionSource is InteractRestrictionList sourceRestrict) {
@@ -40,6 +46,9 @@ public sealed class InteractRestrictionSystem : EntitySystem
             if (sourceRestrict.Whitelist != null &&
                 !_tagSystem.HasAnyTag(user, sourceRestrict.Whitelist))
                     ev.Cancel();
+            
+            if (ev.Cancelled)
+                _popupSystem.PopupClient(Loc.GetString("interact-restriction-restricted-source", ("item", Identity.Entity(ent, EntityManager))), user);
         }
     }
 }

--- a/Content.Shared/_FarHorizons/Util/SharedIteractRestrictionSystem.cs
+++ b/Content.Shared/_FarHorizons/Util/SharedIteractRestrictionSystem.cs
@@ -1,0 +1,45 @@
+﻿using Content.Shared._FarHorizons.Util.Components;
+using Content.Shared.Tag;
+
+namespace Content.Shared._FarHorizons.Util;
+
+public sealed class InteractRestrictionSystem : EntitySystem
+{
+    [Dependency] private readonly TagSystem _tagSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<InteractRestrictionComponent, CheckItemCanBeUsedEvent>(CheckItemCanBeUsed);
+    }
+
+    private void CheckItemCanBeUsed(Entity<InteractRestrictionComponent> ent, ref CheckItemCanBeUsedEvent ev)
+    {
+        if (ev.Cancelled)
+            return;
+
+        var target = ev.Target;
+        var user = ev.User;
+
+        if (target != null && ent.Comp.RestrictInteractionTarget is InteractRestrictionList targetRestrict) {
+            if (targetRestrict.Blacklist != null &&
+                _tagSystem.HasAnyTag(target.Value, targetRestrict.Blacklist))
+                    ev.Cancel();
+            
+            if (targetRestrict.Whitelist != null &&
+                !_tagSystem.HasAnyTag(target.Value, targetRestrict.Whitelist))
+                    ev.Cancel();
+        }
+
+        if (ent.Comp.RestrictInteractionSource is InteractRestrictionList sourceRestrict) {
+            if (sourceRestrict.Blacklist != null &&
+                _tagSystem.HasAnyTag(user, sourceRestrict.Blacklist))
+                    ev.Cancel();
+            
+            if (sourceRestrict.Whitelist != null &&
+                !_tagSystem.HasAnyTag(user, sourceRestrict.Whitelist))
+                    ev.Cancel();
+        }
+    }
+}

--- a/Resources/Locale/en-US/_FarHorizons/util/interact-restriction.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/util/interact-restriction.ftl
@@ -1,0 +1,2 @@
+interact-restriction-restricted-target = You can't use {$item} on {$target}
+interact-restriction-restricted-source = You don't know how to use {$item}

--- a/Resources/Prototypes/_FarHorizons/Testing/test_objects.yml
+++ b/Resources/Prototypes/_FarHorizons/Testing/test_objects.yml
@@ -33,3 +33,26 @@
     restrictInteractionSource:
       whitelist:
         - Resomi
+
+- type: entity
+  name: bird sword
+  parent: EnergySword
+  id: BirdSword
+  description: A sword for a bird
+  components:
+  - type: InteractRestriction
+    restrictInteractionSource:
+      whitelist:
+        - Resomi
+
+
+- type: entity
+  name: bird gun
+  parent: WeaponPistolViper
+  id: WeaponPistolViperBird
+  description: Bird gun
+  components:
+  - type: InteractRestriction
+    restrictInteractionSource:
+      whitelist:
+        - Resomi

--- a/Resources/Prototypes/_FarHorizons/Testing/test_objects.yml
+++ b/Resources/Prototypes/_FarHorizons/Testing/test_objects.yml
@@ -10,49 +10,28 @@
         - Resomi
 
 - type: entity
-  name: gauze that only Resomi know how to use
+  name: gauze that birds don't know how to use
   description: It's complicated, alright?
   parent: Gauze
-  id: ResomiOnlyGauze
+  id: NoBirdGauze
   components:
   - type: InteractRestriction
     restrictInteractionSource:
-      whitelist:
+      blacklist:
         - Resomi
+        - Avali
 
 - type: entity
-  name: gauze that only Resomi know how to use that doesn't heal resomi
+  name: gauze that only birds know how to use that only heals Resomi
   description: For situation when you need one
   parent: Gauze
-  id: AntiResomiOnlyGauze
+  id: BirdGauze
   components:
   - type: InteractRestriction
     restrictInteractionTarget:
-      blacklist:
+      whitelist:
         - Resomi
     restrictInteractionSource:
       whitelist:
         - Resomi
-
-- type: entity
-  name: bird sword
-  parent: EnergySword
-  id: BirdSword
-  description: A sword for a bird
-  components:
-  - type: InteractRestriction
-    restrictInteractionSource:
-      whitelist:
-        - Resomi
-
-
-- type: entity
-  name: bird gun
-  parent: WeaponPistolViper
-  id: WeaponPistolViperBird
-  description: Bird gun
-  components:
-  - type: InteractRestriction
-    restrictInteractionSource:
-      whitelist:
-        - Resomi
+        - Avali

--- a/Resources/Prototypes/_FarHorizons/Testing/test_objects.yml
+++ b/Resources/Prototypes/_FarHorizons/Testing/test_objects.yml
@@ -1,0 +1,35 @@
+- type: entity
+  name: gauze that doesn't heal Resomi
+  description: It just doesn't
+  parent: Gauze
+  id: AntiResomiGauze
+  components:
+  - type: InteractRestriction
+    restrictInteractionTarget:
+      blacklist:
+        - Resomi
+
+- type: entity
+  name: gauze that only Resomi know how to use
+  description: It's complicated, alright?
+  parent: Gauze
+  id: ResomiOnlyGauze
+  components:
+  - type: InteractRestriction
+    restrictInteractionSource:
+      whitelist:
+        - Resomi
+
+- type: entity
+  name: gauze that only Resomi know how to use that doesn't heal resomi
+  description: For situation when you need one
+  parent: Gauze
+  id: AntiResomiOnlyGauze
+  components:
+  - type: InteractRestriction
+    restrictInteractionTarget:
+      blacklist:
+        - Resomi
+    restrictInteractionSource:
+      whitelist:
+        - Resomi


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
A component allowing prototypers to stop usable item from being used based on whitelist/blackist of tags on user/target, or combination of all. 

Also added entities to test it, not to be used in game

## Why we need to add this
Prototypers asked for it

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/7d748c9b-2c75-4bf3-818f-f0929915f787



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: princess_gurchi
- add: InteractRestriction component for prototypers
