### PR TITLE
Added YML for CADfilled lockers and CSDfilled lockers.

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Catalog/Fills/Lockers/centcomm.yml
+++ b/Resources/Prototypes/_FarHorizons/Catalog/Fills/Lockers/centcomm.yml
@@ -1,0 +1,75 @@
+- type: entity
+  id: CADFilled
+  name: Central Administrative Division Secretary Locker
+  suffix: Filled
+  parent: LockerBaseSecure
+  components:
+  - type: Appearance
+  - type: Sprite
+    sprite: _Starlight/Structures/Storage/closet.rsi
+  - type: EntityStorageVisuals
+    stateBaseClosed: bssecure
+    stateDoorOpen: bssecure_open
+    stateDoorClosed: bssecure_door
+  - type: AccessReader
+    access: [ [ "BlueShield" ] ]
+  - type: WiresPanelSecurity
+    securityLevel: medSecurity
+
+  - type: StorageFill
+    contents:
+    - id: ClothingBackpackSatchelLeather
+    - id: MagazineMagnum
+      amount: 2
+    - id: ClothingEyesHudCommand
+    - id: MindShieldImplanter
+    - id: DeathRattleImplanterCentcomm
+    - id: ClothingUniformJumpskirtCentcommAdminFormalWear
+    - id: ClothingEyesGlassesCommand
+    - id: ClothingHandsGlovesHop
+    - id: CentcomPDA
+    - id: WeaponPistolN1984
+    - id: ClothingBeltSheathFilled
+    - id: ClothingHeadHatCentcomcap
+    - id: ClothingShoesBootsLaceup
+    - id: ClothingOuterArmorCentcommCarapace
+    - id: ClothingHeadsetCentCom
+    - id: ClothingMaskGasCentcom
+
+- type: entity
+  id: CSDFilled
+  name: Central Security Division Cadet Locker
+  suffix: Filled
+  parent: LockerBaseSecure
+  components:
+  - type: Appearance
+  - type: Sprite
+    sprite: _Starlight/Structures/Storage/closet.rsi
+  - type: EntityStorageVisuals
+    stateBaseClosed: bssecure
+    stateDoorOpen: bssecure_open
+    stateDoorClosed: bssecure_door
+  - type: AccessReader
+    access: [ [ "BlueShield" ] ]
+  - type: WiresPanelSecurity
+    securityLevel: medSecurity
+
+  - type: StorageFill
+    contents:
+    - id: ClothingBackpackSatchelSecurity
+    - id: MagazineMagnum
+      amount: 2
+    - id: ClothingEyesHudCommand
+    - id: MindShieldImplanter
+    - id: DeathRattleImplanterCentcomm
+    - id: ClothingUniformJumpskirtCentcommSecurityFormalWear
+    - id: ClothingEyesGlassesCentComm
+    - id: ClothingHandsGlovesCombat
+    - id: CentcomPDA
+    - id: WeaponPistolN1984
+    - id: ClothingBeltSecurityFilled
+    - id: ClothingHeadHatBeretSecurity
+    - id: ClothingShoesBootsJackFilled
+    - id: ClothingOuterVestWebEliteCentcomm
+    - id: ClothingHeadsetAltCentComDS
+    - id: ClothingMaskGasCentcom


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Add filled lockers for CC divisions as requested (no locker sprite, BSO placeholder)

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Requested change by lighteningorb

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://imgur.com/JBFDZuZ

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Morrie
- add: Adds filled lockers for CAD and CSD divisions
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
