### PR TITLE
Hotfix - Making airlocks spray paintable

### DIFF
--- a/Resources/Locale/en-US/_FarHorizons/spray-painter/spray-painter.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/spray-painter/spray-painter.ftl
@@ -1,6 +1,6 @@
 ﻿# Groups (subtabs)
 spray-painter-tab-group-fhairlockstandard = Standard
-spray-painter-tab-group-fhairlockglass = Standard
+spray-painter-tab-group-fhairlockglass = Glass
 
 # Airlocks
 spray-painter-style-fhairlockstandard-atmospherics = Atmospheric

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Doors/Airlocks/fh_basic_airlock.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Doors/Airlocks/fh_basic_airlock.yml
@@ -46,9 +46,7 @@
 
 
 - type: entity
-  parent:
-    - CMBaseDoor
-    - FHBaseDoorConstructible
+  parent: [ CMBaseDoor, FHBaseDoorConstructible ]
   id: FHAirlock
   name: airlock
   description: It opens, it closes, and maybe crushes you.
@@ -74,6 +72,8 @@
         path: /Audio/_RMC14/Machines/airlock.ogg
       denySound:
         path: /Audio/Machines/airlock_deny.ogg
+    - type: Paintable
+      group: FHAirlockStandard
 
 - type: entity
   id: FHAirlockGlass


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Making the airlocks spray paintable. They had the components in there to do so, but weren't quite connected. They are now connected.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Making doors spray paintable again.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/19fba6f1-f238-4929-9872-b1ae425266ca


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: CorruptOmega
- tweak: Airlocks are now spray paintable again. Rejoice!
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: FAR HORIZONS TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
