### PR TITLE
Armor buffs & Nukeops ammo fix

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -155,14 +155,16 @@
       - id: SpeedLoaderMagnumSP #FH
         amount: 2 #FH
       - id: MagazinePistolCaselessRifle #FH
-        amount: 4 #FH
+        amount: 5 #FH
       - id: MagazinePistolSP #FH
-        amount: 4 #FH
+        amount: 5 #FH
       - id: MagazinePistol40FMJ #FH
-        amount: 4 #FH
+        amount: 5 #FH
       - id: MagazinePistolSubMachineGunUzi #FH
         amount: 4 #FH
       - id: MagazineBoxAntiMateriel #FH
+        amount: 4 #FH
+      - id: MagazineMagnum #FH
         amount: 4 #FH
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -134,28 +134,36 @@
   parent: ClothingBackpackDuffelSyndicateAmmo
   id: ClothingBackpackDuffelSyndicateAmmoFilled
   name: ammo bundle
-  description: "Reloading! Contains 4 magazines for the C-20r, 4 drums for the Bulldog, and 3 ammo boxes for the L6 SAW."
+  description: "Reloading! Contains 4-5 magazines for all avaliable nuclear operative weapons, minus the China-Lake." #FH
   components:
   - type: StorageFill
     contents:
-      - id: MagazinePistolSubMachineGunSP
-        amount: 4
-      - id: MagazineShotgun
-        amount: 4
-      - id: MagazineRifleSP
-        amount: 3
-      - id: MagazineRifleSP #Starlight, for the estoc
-        amount: 2 
-      - id: MagazineLightRifleBoxSP
-        amount: 3
-      - id: MagazineShotgunSlug
-        amount: 1
-      - id: MagazineBoxLightRifleSP
-        amount: 1
-      - id: MagazineBoxLightRifleHP
-        amount: 1
-      - id: MagazineBoxLightRifleFMJ
-        amount: 1
+      - id: MagazinePistolSubMachineGunSP  #FH
+        amount: 5  #FH
+      - id: MagazineShotgun  #FH
+        amount: 5  #FH
+      - id: MagazineRifleSP  #FH
+        amount: 4  #FH
+      - id: MagazineMagnumRifleSP #FH
+        amount: 4 #FH
+      - id: MagazineLightRifleBoxSP #FH
+        amount: 4 #FH
+      - id: MagazineShotgunSlug #FH
+        amount: 2 #FH
+      - id: SpeedLoaderMagnumAP #FH
+        amount: 2 #FH
+      - id: SpeedLoaderMagnumSP #FH
+        amount: 2 #FH
+      - id: MagazinePistolCaselessRifle #FH
+        amount: 4 #FH
+      - id: MagazinePistolSP #FH
+        amount: 4 #FH
+      - id: MagazinePistol40FMJ #FH
+        amount: 4 #FH
+      - id: MagazinePistolSubMachineGunUzi #FH
+        amount: 4 #FH
+      - id: MagazineBoxAntiMateriel #FH
+        amount: 4 #FH
 
 - type: entity
   parent: ClothingBackpackDuffelClown

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -206,7 +206,7 @@
   - type: Storage  # FH
     maxItemSize: Huge  # FH
     grid:  # FH
-    - 0,0,10,9  # FH
+    - 0,0,11,10 # FH
   - type: ClothingSpeedModifier # FH - Prevents abuse of bigger bag
     walkModifier: 0.2  # FH
     sprintModifier: 0.2  # FH

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -206,7 +206,7 @@
   - type: Storage  # FH
     maxItemSize: Huge  # FH
     grid:  # FH
-    - 0,0,10,8  # FH
+    - 0,0,10,9  # FH
   - type: ClothingSpeedModifier # FH - Prevents abuse of bigger bag
     walkModifier: 0.2  # FH
     sprintModifier: 0.2  # FH

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -203,6 +203,13 @@
     state: icon-ammo
   - type: Item
     heldPrefix: ammo
+  - type: Storage  # FH
+    maxItemSize: Huge  # FH
+    grid:  # FH
+    - 0,0,10,8  # FH
+  - type: ClothingSpeedModifier # FH - Prevents abuse of bigger bag
+    walkModifier: 0.2  # FH
+    sprintModifier: 0.2  # FH
   - type: Clothing
     equippedPrefix: ammo
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -43,6 +43,7 @@
         Slash: 0.70 #FH
         Piercing: 0.70 #FH
         Heat: 0.80 #FH
+  - type: Tag
     tags:
     - CorgiWearable
     - WhitelistChameleon

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -33,6 +33,9 @@
   id: ClothingOuterArmorBasic
   components:
   - type: Tag
+    tags:
+    - CorgiWearable
+    - WhitelistChameleon
   - type: Armor #FH
     modifiers: #FH
       flatReductions: #FH
@@ -43,10 +46,6 @@
         Slash: 0.70 #FH
         Piercing: 0.70 #FH
         Heat: 0.80 #FH
-  - type: Tag
-    tags:
-    - CorgiWearable
-    - WhitelistChameleon
 
 #Alternate / slim basic armor vest
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -33,6 +33,16 @@
   id: ClothingOuterArmorBasic
   components:
   - type: Tag
+  - type: Armor #FH
+    modifiers: #FH
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
+      coefficients: #FH
+        Blunt: 0.70 #FH
+        Slash: 0.70 #FH
+        Piercing: 0.70 #FH
+        Heat: 0.80 #FH
     tags:
     - CorgiWearable
     - WhitelistChameleon
@@ -64,6 +74,8 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
       coefficients:
         Blunt: 0.9
         Slash: 0.9
@@ -86,6 +98,8 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.9
         Slash: 0.9
@@ -108,6 +122,16 @@
     sprite: Clothing/OuterClothing/Vests/detvest.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Vests/detvest.rsi
+  - type: Armor #FH
+    modifiers: #FH
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
+      coefficients: #FH
+        Blunt: 0.70 #FH
+        Slash: 0.70 #FH
+        Piercing: 0.70 #FH
+        Heat: 0.80 #FH
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
@@ -116,6 +140,9 @@
   components:
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.5
         Slash: 0.5
@@ -171,6 +198,8 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
       coefficients:
         Blunt: 0.6 #ballistic plates = better protection
         Slash: 0.6
@@ -198,6 +227,8 @@
     coolingCoefficient: 0.1
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.5
         Slash: 0.5
@@ -228,6 +259,8 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
       coefficients:
         Blunt: 0.7 #slightly better overall protection but slightly worse than bulletproof armor against bullets seems sensible
         Slash: 0.7
@@ -257,6 +290,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.45
         Slash: 0.45
@@ -359,6 +395,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.5
         Slash: 0.5
@@ -380,6 +419,8 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
       coefficients:
         Blunt: 0.2
         Slash: 0.2
@@ -449,6 +490,8 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
       coefficients:
         Blunt: 0.5
         Slash: 0.5
@@ -479,6 +522,8 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
       coefficients:
         Blunt: 0.6
         Slash: 0.8
@@ -510,6 +555,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.5
         Slash: 0.5
@@ -554,6 +602,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.5
         Slash: 0.5

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -66,6 +66,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.65
         Slash: 0.65
@@ -84,6 +87,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.65
         Slash: 0.65
@@ -437,6 +443,8 @@
     zombificationResistanceCoefficient: 0.60 #FH
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
       coefficients:
         Blunt: 0.8
         Slash: 0.85

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -278,6 +278,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.6
         Slash: 0.6
@@ -317,6 +320,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.7
         Slash: 0.7 #FH edit
@@ -353,6 +359,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.4
         Slash: 0.5
@@ -387,6 +396,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.8
         Slash: 0.8
@@ -550,6 +562,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.6
         Slash: 0.5
@@ -653,6 +668,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.5
         Slash: 0.5
@@ -767,6 +785,8 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.70 #SL EDIT
         Slash: 0.70 #SL EDIT
@@ -821,6 +841,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.4
         Slash: 0.4
@@ -902,10 +925,11 @@
   - type: ExplosionResistance
     damageCoefficient: 0.3
   # - type: StaminaResistance # Should not have stamina resistance, this is purely so people know it was not forgotten.
-  - type: Pierceable
-    level: Rock
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.2
         Slash: 0.2
@@ -954,6 +978,9 @@
     level: Rock
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.6
         Slash: 0.6
@@ -993,6 +1020,8 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.95
         Slash: 0.95

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/OuterClothing/coats.yml
@@ -17,6 +17,9 @@
     zombificationResistanceCoefficient: 0.50
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.75
         Slash: 0.75

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -52,6 +52,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.65
         Slash: 0.65

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/armor.yml
@@ -12,6 +12,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.6
         Slash: 0.6
@@ -71,6 +74,9 @@
           level: Metal
         - type: Armor
           modifiers:
+            flatReductions: #FH
+              Piercing: 5 #FH
+              Heat: 4 #FH
             coefficients:
               Blunt: 0.5
               Slash: 0.5
@@ -96,6 +102,8 @@
     sprite: _Starlight/Clothing/OuterClothing/Armor/platecarrier.rsi
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
       coefficients:
         Blunt: 0.85
         Slash: 0.85
@@ -138,6 +146,8 @@
     sprite: _Starlight/Clothing/OuterClothing/Armor/heatabsorbent.rsi
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.85
         Slash: 0.85
@@ -207,6 +217,8 @@
     level: Metal
   - type: Armor 
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
       coefficients:
         Blunt: 0.75
         Slash: 0.65
@@ -229,6 +241,8 @@
     level: Metal
   - type: Armor 
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
       coefficients:
         Blunt: 0.70
         Slash: 0.50


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Buffs all applicable armors to have either flat pierce reduction, flat heat reduction, or both.
(Applied on a case-by-case basis, if an armor specializes in heat, it gets the flat heat reduction and the reverse is also true. If the armor stats are even or close to being even they get both.)

Also fixes a long standing issue of the ammo bundle not providing ammunition to the majority of nuclear operative guns, as despite the many new additions, no one seems to have bothered to actually.. add the magazines or respective bullets to the bundle, making buying those weapons generally seen as a "bad idea"

This is likely not going to be the final numbers, as this is the initial version of the concept and I'm starting off gentle with a small increase in TTK rather than a big one.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It's generally agreed upon that the TTK is too fast for any meaningful gunplay, as no matter what gun you use the person in front of you generally drops dead VERY quickly. This PR aims to provide a creative solution to that by simply giving flat damage reductions to armor to make gunfights last longer, without also making guns feel too weak, or taking away syndicate agent options on their unarmored target kills by directly nerfing bullet damage.

Ya wear armor? Ya can take a few hits. No armor? Tough shit.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Before
<img width="328" height="161" alt="dtguyjuyk" src="https://github.com/user-attachments/assets/592c7560-d4d5-4f0e-a39c-5e49eaa8e8d6" />
After
<img width="389" height="330" alt="tydjkduytjgk" src="https://github.com/user-attachments/assets/7af3796f-4260-460c-a7f4-cf6d37ff2b32" />
Current STC (shots-to-crit) vs New STC
Not exhaustive, other armors were modified but not listed here (As I didn't want to count bullets for every single one after I noticed the general theme.) Heat STC not listed because it generally had the same values as the Ballistic STC.
Testing is done with .20 SP/FMJ, with the Urist in "Full Armor" (Helm, mask, vest)
<img width="545" height="329" alt="duytkuyij" src="https://github.com/user-attachments/assets/cd3b2cae-17cb-4d80-8163-5190adb7bde8" />
You can now kill jugsuits with SP.. In theory..
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.
-->
:cl: Killer Tamashi
- tweak: Changed all applicable armor values by either flat -5 pierce damage reduction, or -4 heat reduction, or both. Making gunfights longer.
- tweak: Gave Nuclear Operative Ammo Bundle more ammunition to compensate. (+1 every existing mag)
- tweak: Changed Jugsuit material type to no longer be ROCK, no longer immune to SP, but not super weak to FMJ either.
- tweak: Changed Ammo Bundle duffel bag to have 80% slowdown, due to massively increased storage space.
- fix: Fixed Nuclear Operatives not having enough DAKKA in their ammo bundle. Any gun a nukie can buy will have magazines for it in the ammo bundle.