### PR TITLE
fix television spawner

### DIFF
--- a/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Spawners.Components;
 using Content.Shared.EntityTable;
 using Content.Shared.GameTicking.Components;
 using JetBrains.Annotations;
+using Robust.Server.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Random;
 
@@ -15,6 +16,7 @@ namespace Content.Server.Spawners.EntitySystems
         [Dependency] private readonly IRobustRandom _robustRandom = default!;
         [Dependency] private readonly GameTicker _ticker = default!;
         [Dependency] private readonly EntityTableSystem _entityTable = default!;
+        [Dependency] private readonly TransformSystem _transform = default!;
 
         public override void Initialize()
         {
@@ -116,9 +118,19 @@ namespace Content.Server.Spawners.EntitySystems
             var xOffset = _robustRandom.NextFloat(-offset, offset);
             var yOffset = _robustRandom.NextFloat(-offset, offset);
 
-            var coordinates = Transform(uid).Coordinates.Offset(new Vector2(xOffset, yOffset));
+            // Far Horizons start
+            // Making spawners rotateable and rotation is transferred to spawned entity
+            if (TryComp(uid, out TransformComponent? transform))
+            {
+                var coordinates = _transform.GetMapCoordinates(uid, transform).Offset(new Vector2(xOffset, yOffset));
 
-            Spawn(_robustRandom.Pick(component.Prototypes), coordinates);
+                Spawn(_robustRandom.Pick(component.Prototypes), coordinates, null, transform.LocalRotation);
+            } else {
+            // Far Horizons end
+                var coordinates = Transform(uid).Coordinates.Offset(new Vector2(xOffset, yOffset));
+
+                Spawn(_robustRandom.Pick(component.Prototypes), coordinates);
+            }
         }
 
         private void Spawn(Entity<EntityTableSpawnerComponent> ent)

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Wallmounts/WallmountMachines/Monitors/televisions.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Wallmounts/WallmountMachines/Monitors/televisions.yml
@@ -126,4 +126,6 @@
         - WallmountTelevisionLMC
         - WallmountTelevisionNTWorlds
       offset: 0.0
+    - type: Transform
+      anchored: true
   


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Spawner had no transform component or no way to account for having it when spawning entitites

Fixed random spawner system to handle transform component on spawner

## Why we need to add this
televisions were weird

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: princess-gurchi
- fix: Fixed television spawner spawning unrotated televisions