### PR TITLE
Fix shotgun pellet + Fix BSO armor not having flat reduction

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/coats.yml
@@ -12,6 +12,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.6
         Slash: 0.6

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -19,6 +19,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.6
         Slash: 0.5

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -713,10 +713,10 @@
   parent: BulletTrace
   damage:
     types:
-      Piercing: 5
-      Structural: 5
-  pierceChance: 0.03
-  count: 12
+      Piercing: 7 #FH - Adjustment for -5
+      Structural: 7 #FH - Adjustment for less pellet count
+  pierceChance: 0.04 #FH - Adjustment for less pellet count
+  count: 10 #FH ~ 70. Technicaly a buff, not an easy way to divide 60 evenly and still have a lot of pellets.
   spread: 15
   bullet:
     sprite:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
-5 pierce broke shotgun pellets because they do exactly 5 pierce. The simple solution was to increase damage and reduce pellet count, which seems to have worked well. They are still better than other firearms to kill people in terms of speed, taking 2-3 shots less with raw buckshot against armor. You really ought to use slugs against armor, though.

Also adds flat reductions to BSO armor because I genuinely forgot to do it.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.
-->
:cl: Killer Tamashi
- fix: Fixed Buckshot not doing anything (reduced pellet count and increased individual pellet damage)
- fix: Fixed BSO armor not having flat reduction (forgor)