### PR TITLE
Changes crew monitor coordinates

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringNavMapControl.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringNavMapControl.cs
@@ -12,6 +12,7 @@ public sealed partial class CrewMonitoringNavMapControl : NavMapControl
 
     private Label _trackedEntityLabel;
     private PanelContainer _trackedEntityPanel;
+    private readonly SharedTransformSystem _transformSystem; //FarHorizons
 
     public CrewMonitoringNavMapControl() : base()
     {
@@ -42,6 +43,7 @@ public sealed partial class CrewMonitoringNavMapControl : NavMapControl
 
         _trackedEntityPanel.AddChild(_trackedEntityLabel);
         this.AddChild(_trackedEntityPanel);
+        _transformSystem = EntManager.System<SharedTransformSystem>();//FarHorizons
     }
 
     protected override void FrameUpdate(FrameEventArgs args)
@@ -65,8 +67,8 @@ public sealed partial class CrewMonitoringNavMapControl : NavMapControl
                 name = "Unknown";
 
             var message = name + "\n" + Loc.GetString("navmap-location",
-                ("x", MathF.Round(blip.Coordinates.X)),
-                ("y", MathF.Round(blip.Coordinates.Y)));
+                ("x", MathF.Round(_transformSystem.ToMapCoordinates(blip.Coordinates).X)), //FarHorizons
+                ("y", MathF.Round(_transformSystem.ToMapCoordinates(blip.Coordinates).Y)));//FarHorizons
 
             _trackedEntityLabel.Text = message;
             _trackedEntityPanel.Visible = true;


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Changes Coordinates shown in crew monitor from local coordinates to map coordinates.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Paramedics keep getting lost in space.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="614" height="140" alt="image" src="https://github.com/user-attachments/assets/8bd1f713-800b-4952-82f8-41513e6435b7" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: FAR HORIZONS TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: AthenaAI
- tweak: Makes the crew monitoring console coordinates actually gps coordinates.