### PR TITLE
Salvage missions

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -135,6 +135,7 @@ namespace Content.Client.Entry
             _prototypeManager.RegisterIgnore("ghostRoleRaffleDecider");
             _prototypeManager.RegisterIgnore("codewordGenerator");
             _prototypeManager.RegisterIgnore("codewordFaction");
+            _prototypeManager.RegisterIgnore("salvageMissionObjectiveHandler"); // Far Horizons
 
             _componentFactory.GenerateNetIds();
             _adminManager.Initialize();

--- a/Content.Client/Salvage/UI/SalvageExpeditionConsoleBoundUserInterface.cs
+++ b/Content.Client/Salvage/UI/SalvageExpeditionConsoleBoundUserInterface.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Client.Stylesheets;
+using Content.Shared._FarHorizons.Salvage;
 using Content.Shared.CCVar;
 using Content.Shared.Procedural;
 using Content.Shared.Salvage.Expeditions;
@@ -63,6 +64,37 @@ public sealed class SalvageExpeditionConsoleBoundUserInterface : BoundUserInterf
             var difficultyProto = _protoManager.Index<SalvageDifficultyPrototype>(difficultyId);
             var mission = salvage.GetMission(difficultyProto, missionParams.Seed);
 
+            // Far Horizons start
+            var objectiveProto = _protoManager.Index(mission.Objective);
+
+            offering.AddContent(new Label(){ Text = Loc.GetString("salvage-expedition-window-objective") });
+            offering.AddContent(new Label
+            {
+                Text = Loc.GetString(objectiveProto.Name),
+                FontColorOverride = objectiveProto.Color,
+                HorizontalAlignment = Control.HAlignment.Left,
+                Margin = new Thickness(0f, 0f, 0f, 5f),
+            });
+
+            offering.AddContent(new Label(){ Text = Loc.GetString("salvage-expedition-window-objective-description") });
+            offering.AddContent(new RichTextLabel
+            {
+                Text = $"[color={StyleNano.NanoGold.ToHex()}]{Loc.GetString(objectiveProto.Description)}[/color]",
+                MaxWidth = 200,
+                HorizontalAlignment = Control.HAlignment.Left,
+                Margin = new Thickness(0f, 0f, 0f, 5f),
+            });
+
+            offering.AddContent(new Label(){ Text = Loc.GetString("salvage-expedition-window-objective-reward") });
+            offering.AddContent(new Label
+            {
+                Text = objectiveProto.BaseReward.GetValueOrDefault(difficultyId, 0).ToString() + " tickets",
+                FontColorOverride = StyleNano.NanoGold,
+                HorizontalAlignment = Control.HAlignment.Left,
+                Margin = new Thickness(0f, 0f, 0f, 5f),
+            });
+            // Far Horizons end
+
             // Difficulty
             // Details
             offering.AddContent(new Label()
@@ -80,19 +112,20 @@ public sealed class SalvageExpeditionConsoleBoundUserInterface : BoundUserInterf
                 Margin = new Thickness(0f, 0f, 0f, 5f),
             });
 
-            offering.AddContent(new Label
-            {
-                Text = Loc.GetString("salvage-expedition-difficulty-players"),
-                HorizontalAlignment = Control.HAlignment.Left,
-            });
+            // Far Horizons - freeing some visual space in UI
+            // offering.AddContent(new Label
+            // {
+            //     Text = Loc.GetString("salvage-expedition-difficulty-players"),
+            //     HorizontalAlignment = Control.HAlignment.Left,
+            // });
 
-            offering.AddContent(new Label
-            {
-                Text = difficultyProto.RecommendedPlayers.ToString(),
-                FontColorOverride = StyleNano.NanoGold,
-                HorizontalAlignment = Control.HAlignment.Left,
-                Margin = new Thickness(0f, 0f, 0f, 5f),
-            });
+            // offering.AddContent(new Label
+            // {
+            //     Text = difficultyProto.RecommendedPlayers.ToString(),
+            //     FontColorOverride = StyleNano.NanoGold,
+            //     HorizontalAlignment = Control.HAlignment.Left,
+            //     Margin = new Thickness(0f, 0f, 0f, 5f),
+            // });
 
             // Details
             offering.AddContent(new Label
@@ -118,19 +151,20 @@ public sealed class SalvageExpeditionConsoleBoundUserInterface : BoundUserInterf
                 return Loc.GetString(_protoManager.Index<SalvageFactionPrototype>(faction).ID);
             }
 
+            // Far Horizons - freeing space in UI
             // Duration
-            offering.AddContent(new Label
-            {
-                Text = Loc.GetString("salvage-expedition-window-duration")
-            });
+            // offering.AddContent(new Label
+            // {
+            //     Text = Loc.GetString("salvage-expedition-window-duration")
+            // });
 
-            offering.AddContent(new Label
-            {
-                Text = mission.Duration.ToString(),
-                FontColorOverride = StyleNano.NanoGold,
-                HorizontalAlignment = Control.HAlignment.Left,
-                Margin = new Thickness(0f, 0f, 0f, 5f),
-            });
+            // offering.AddContent(new Label
+            // {
+            //     Text = mission.Duration.ToString(),
+            //     FontColorOverride = StyleNano.NanoGold,
+            //     HorizontalAlignment = Control.HAlignment.Left,
+            //     Margin = new Thickness(0f, 0f, 0f, 5f),
+            // });
 
             // Biome
             offering.AddContent(new Label

--- a/Content.Server/Salvage/Expeditions/SalvageExpeditionComponent.cs
+++ b/Content.Server/Salvage/Expeditions/SalvageExpeditionComponent.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Shared._FarHorizons.Salvage;
 using Content.Shared.Salvage;
 using Content.Shared.Salvage.Expeditions;
 using Robust.Shared.Audio;
@@ -57,4 +58,7 @@ public sealed partial class SalvageExpeditionComponent : SharedSalvageExpedition
     /// </summary>
     [DataField]
     public ResolvedSoundSpecifier SelectedSong;
+
+    // Far Horizons
+    public ProtoId<SalvageMissionObjectivePrototype> Objective;
 }

--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -33,6 +33,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Content.Server.Shuttles.Components;
+using Content.Server._FarHorizons.Salvage;
 
 namespace Content.Server.Salvage;
 
@@ -158,6 +159,7 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
         expedition.Station = Station;
         expedition.EndTime = _timing.CurTime + mission.Duration;
         expedition.MissionParams = _missionParams;
+        expedition.Objective = mission.Objective; // Far Horizons
 
         var landingPadRadius = 24;
         var minDungeonOffset = landingPadRadius + 4;
@@ -285,6 +287,13 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
                     throw new NotImplementedException();
             }
         }
+
+        // Far Horizons start
+        var objective = _prototypeManager.Index(mission.Objective);
+        if (objective.HandlerId != null &&
+            _prototypeManager.TryIndex<SalvageMissionObjectiveHandlerPrototype>(objective.HandlerId, out var handler))
+            handler.Handler?.Run(_sawmill, _entManager, _prototypeManager, random, objective, _anchorable, _map, difficultyProto, dungeon, (mapUid, grid));
+        // Far Horizons end
 
         return true;
     }

--- a/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionCapture.cs
+++ b/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionCapture.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+
+namespace Content.Server._FarHorizons.Salvage.Objectives;
+
+public sealed partial class SalvageMissionCapture : BaseSalvageMissionObjectiveHandler
+{
+    public override void AFterFTLToMap(EntityUid shuttle) => 
+        Announce(GetAnnouncement());
+    public override void BeforeFTLFromMap(EntityUid shuttle)
+    {
+        if (GetExpeditionConsole(shuttle) is not EntityUid expedConsole)
+            return;
+        
+        var allTargets = GetAllMarkedEntitiesOnShuttle(shuttle);
+        var aliveTargets = allTargets.Where(p => EntMan.TryGetComponent<MobStateComponent>(p, out var state) && state.CurrentState == MobState.Alive).ToHashSet();
+        SetRewardComponent(expedConsole, ResolveCompletion(aliveTargets.Count));
+        DeleteWithEffect(aliveTargets);
+    }
+    public override void BeforeFTLToMap(EntityUid shuttle){}
+
+    public override void OnMapCreated()
+    {
+        foreach(var mob in GetAllSpawnedMobs())
+            MarkEntity(mob);
+    }
+}

--- a/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionCapture.cs
+++ b/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionCapture.cs
@@ -18,7 +18,7 @@ public sealed partial class SalvageMissionCapture : BaseSalvageMissionObjectiveH
         SetRewardComponent(expedConsole, ResolveCompletion(aliveTargets.Count));
         DeleteWithEffect(aliveTargets);
     }
-    public override void BeforeFTLToMap(EntityUid shuttle){}
+    public override void BeforeFTLToMap(EntityUid shuttle){} // Override intentionally left empty
 
     public override void OnMapCreated()
     {

--- a/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionRecovery.cs
+++ b/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionRecovery.cs
@@ -1,0 +1,37 @@
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._FarHorizons.Salvage.Objectives;
+
+public sealed partial class SalvageMissionRecovery : BaseSalvageMissionObjectiveHandler
+{
+    private readonly List<EntProtoId> _recoveryTargets = ["CrateSalvageMissionObjective"];
+
+    public override void AFterFTLToMap(EntityUid shuttle) => 
+        Announce(GetAnnouncement());
+    public override void BeforeFTLFromMap(EntityUid shuttle)
+    {
+        if (GetExpeditionConsole(shuttle) is not EntityUid expedConsole)
+            return;
+        
+        var allTargets = GetAllMarkedEntitiesOnShuttle(shuttle);
+        SetRewardComponent(expedConsole, ResolveCompletion(allTargets.Count));
+        DeleteWithEffect(allTargets);
+    }
+    public override void BeforeFTLToMap(EntityUid shuttle){}
+
+    public override void OnMapCreated()
+    {
+        for (var i = 0; i < GetNumSpawnables(); i++)
+        {
+            var proto = _recoveryTargets[Rand.Next(_recoveryTargets.Count)];
+            if (GetRandomEmptyTileInDungeon() is not EntityCoordinates pos)
+                return;
+
+            SpawnAndMarkEntity(proto, pos);
+        }
+    }
+
+    private int GetNumSpawnables() => 
+        Objective.NumTargets.GetValueOrDefault(Difficulty, 0) + Objective.BonusCap;
+}

--- a/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionRecovery.cs
+++ b/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionRecovery.cs
@@ -18,7 +18,7 @@ public sealed partial class SalvageMissionRecovery : BaseSalvageMissionObjective
         SetRewardComponent(expedConsole, ResolveCompletion(allTargets.Count));
         DeleteWithEffect(allTargets);
     }
-    public override void BeforeFTLToMap(EntityUid shuttle){}
+    public override void BeforeFTLToMap(EntityUid shuttle){} // Override intentionally left empty
 
     public override void OnMapCreated()
     {

--- a/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionRescue.cs
+++ b/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionRescue.cs
@@ -1,0 +1,139 @@
+
+using System.Linq;
+using Content.Server.Humanoid;
+using Content.Server.Station.Systems;
+using Content.Shared._FarHorizons.Factions;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.Inventory;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Preferences;
+using Content.Shared.Preferences.Loadouts;
+using Microsoft.CodeAnalysis;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Server._FarHorizons.Salvage.Objectives;
+
+public sealed partial class SalvageMissionRescue : BaseSalvageMissionObjectiveHandler
+{
+    const int DecoyBodies = 20;
+    const int TotalDamageForBonus = 100;
+    static readonly EntProtoId GasMask = "ClothingMaskGas";
+    const string MaskSlot = "mask";
+
+    public override void AFterFTLToMap(EntityUid shuttle)
+    {
+        var targets = GetAllMarkedEntities();
+        List<string> names = [];
+        foreach (var uid in targets)
+        {
+            if(!EntMan.TryGetComponent<MetaDataComponent>(uid, out var metadata))
+                continue;
+
+            names.Add(metadata.EntityName);
+        }
+
+        if(names.Count == 1)
+        {
+            Announce(Loc.GetString(Objective.Announcement, ("names", names[0])));
+            return;
+        }
+
+        var namesString = $"{string.Join("; ", names[..^1])} and {names[^1]}";
+        Announce(Loc.GetString(Objective.Announcement, ("names", namesString)));
+    }
+    public override void BeforeFTLFromMap(EntityUid shuttle)
+    {
+        if (GetExpeditionConsole(shuttle) is not EntityUid expedConsole)
+            return;
+
+        var allTargets = GetAllMarkedEntitiesOnShuttle(shuttle);
+        var numBonus = 0;
+        foreach (var uid in allTargets)
+            if(EntMan.TryGetComponent<DamageableComponent>(uid, out var damage) &&
+               damage.TotalDamage <= TotalDamageForBonus)
+                numBonus++;
+        numBonus = Math.Min(numBonus, Objective.BonusCap);
+
+        var completion = (allTargets.Count >= Objective.NumTargets.GetValueOrDefault(Difficulty, 0),
+                          numBonus,
+                          Objective.BonusCap,
+                          allTargets.Count >= Objective.NumTargets.GetValueOrDefault(Difficulty, 0) ?
+                            Objective.BaseReward.GetValueOrDefault(Difficulty, 0) + Objective.Bonus * numBonus :
+                            0);
+        SetRewardComponent(expedConsole, completion);
+        DeleteWithEffect(allTargets);
+
+    }
+    public override void BeforeFTLToMap(EntityUid shuttle)
+    {
+
+    }
+    public override void OnMapCreated()
+    {
+        var factions = IoCManager.Resolve<ISharedFactionManager>();
+        var humanoid = EntMan.System<HumanoidAppearanceSystem>();
+        var metadata = EntMan.System<MetaDataSystem>();
+        var state = EntMan.System<MobStateSystem>();
+        var damageable = EntMan.System<DamageableSystem>();
+        var stationSpawning = EntMan.System<StationSpawningSystem>();
+        var inventory = EntMan.System<InventorySystem>();
+
+        var damageTypes = ProtoMan.EnumeratePrototypes<DamageTypePrototype>().ToList();
+
+        int objectivesSpawned = 0;
+
+        var possibleFactions = factions.ListPlayableFactions().Where(p => p.Major).ToList();
+        var selectedFaction = possibleFactions[Rand.Next(possibleFactions.Count)];
+
+        for (var i = 0; i < GetNumSpawnables(); i++)
+        {
+            var character = HumanoidCharacterProfile.Random();
+            var species = ProtoMan.Index(character.Species);
+
+            if (GetRandomEmptyTileInDungeon() is not EntityCoordinates pos)
+                return;
+
+            var ent = EntMan.SpawnAtPosition(species.Prototype, pos);
+            humanoid.LoadProfile(ent, character);
+            metadata.SetEntityName(ent, character.Name);
+            state.ChangeMobState(ent, MobState.Dead);
+
+            var damage = new DamageSpecifier();
+            damage.DamageDict.Add(damageTypes[Rand.Next(damageTypes.Count)].ID, Rand.Next(300));
+            if (Rand.Next(100) > 50)
+                damage.DamageDict.TryAdd(damageTypes[Rand.Next(damageTypes.Count)].ID, Rand.Next(300));
+            if (Rand.Next(100) > 75)
+                damage.DamageDict.TryAdd(damageTypes[Rand.Next(damageTypes.Count)].ID, Rand.Next(300));
+            damageable.TryChangeDamage(ent, damage);
+
+            var jobs = factions.ListFactionJobs().Where(p => p.Faction == selectedFaction).ToList();
+            var job = jobs[Rand.Next(jobs.Count)];
+            var loadoutProtoId = factions.OverrideJobLoadout(job);
+            var loadoutProto = ProtoMan.Index(loadoutProtoId);
+
+            var loadout = new RoleLoadout(loadoutProtoId);
+            loadout.SetDefault(character, null, ProtoMan);
+
+            stationSpawning.EquipRoleLoadout(ent, loadout, loadoutProto);
+
+            if (Rand.Prob(0.4))
+            {
+                var gasMaskEnt = EntMan.SpawnAtPosition(GasMask, pos);
+                inventory.TryEquip(ent, gasMaskEnt, MaskSlot, force: true);
+            }
+
+            if (objectivesSpawned < Objective.NumTargets.GetValueOrDefault(Difficulty, 0))
+            {
+                MarkEntity(ent);
+                objectivesSpawned++;
+            }
+        }
+    }
+
+    private int GetNumSpawnables() => 
+        Objective.NumTargets.GetValueOrDefault(Difficulty, 0) + DecoyBodies;
+}

--- a/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionRescue.cs
+++ b/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionRescue.cs
@@ -68,10 +68,7 @@ public sealed partial class SalvageMissionRescue : BaseSalvageMissionObjectiveHa
         DeleteWithEffect(allTargets);
 
     }
-    public override void BeforeFTLToMap(EntityUid shuttle)
-    {
-
-    }
+    public override void BeforeFTLToMap(EntityUid shuttle){} // Override intentionally left empty
     public override void OnMapCreated()
     {
         var factions = IoCManager.Resolve<ISharedFactionManager>();
@@ -123,7 +120,8 @@ public sealed partial class SalvageMissionRescue : BaseSalvageMissionObjectiveHa
             if (Rand.Prob(0.4))
             {
                 var gasMaskEnt = EntMan.SpawnAtPosition(GasMask, pos);
-                inventory.TryEquip(ent, gasMaskEnt, MaskSlot, force: true);
+                if (!inventory.TryEquip(ent, gasMaskEnt, MaskSlot, force: true))
+                    EntMan.DeleteEntity(gasMaskEnt);
             }
 
             if (objectivesSpawned < Objective.NumTargets.GetValueOrDefault(Difficulty, 0))

--- a/Content.Server/_FarHorizons/Salvage/SalvageMissionObjectiveHandler.cs
+++ b/Content.Server/_FarHorizons/Salvage/SalvageMissionObjectiveHandler.cs
@@ -1,0 +1,292 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Content.Server.Chat.Managers;
+using Content.Server.Chat.Systems;
+using Content.Shared._FarHorizons.Salvage;
+using Content.Shared._FarHorizons.Salvage.Components;
+using Content.Shared.Chat;
+using Content.Shared.Construction.EntitySystems;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Physics;
+using Content.Shared.Procedural;
+using Content.Shared.Salvage.Expeditions;
+using Robust.Server.Audio;
+using Robust.Server.GameObjects;
+using Robust.Shared.Collections;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Physics;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Server._FarHorizons.Salvage;
+
+[ImplicitDataDefinitionForInheritors]
+public abstract partial class BaseSalvageMissionObjectiveHandler
+{
+    public bool Initialized = false;
+
+    private static readonly Exception _uninitializedException = new("BaseSalvageMissionObjective unitialized");
+
+    private ISawmill? _sawmill;
+    protected ISawmill Log =>
+        Initialized ? _sawmill! : throw _uninitializedException;
+
+    private IEntityManager? _entityManager;
+    protected IEntityManager EntMan =>
+        Initialized ? _entityManager! : throw _uninitializedException;
+
+    private IPrototypeManager? _protoManager;
+    protected IPrototypeManager ProtoMan => 
+        Initialized ? _protoManager! : throw _uninitializedException;
+
+    private System.Random? _random;
+    protected System.Random Rand => 
+        Initialized ? _random! : throw _uninitializedException;
+
+    private SalvageMissionObjectivePrototype? _objective;
+    protected SalvageMissionObjectivePrototype Objective => 
+        Initialized ? _objective! : throw _uninitializedException;
+
+    private ProtoId<SalvageDifficultyPrototype>? _difficulty;
+    protected ProtoId<SalvageDifficultyPrototype> Difficulty => 
+        Initialized ? _difficulty!.Value : throw _uninitializedException;
+
+    private Dungeon? _dungeon;
+    protected Dungeon Dungeon => 
+        Initialized ? _dungeon! : throw _uninitializedException;
+
+    private Entity<MapGridComponent>? _map;
+    protected Entity<MapGridComponent> Map => 
+        Initialized ? _map!.Value : throw _uninitializedException;
+
+    private AnchorableSystem? _anchorable;
+    protected AnchorableSystem AnchorableSys => 
+        Initialized ? _anchorable! : throw _uninitializedException;
+
+    private SharedMapSystem? _mapSys;
+    protected SharedMapSystem MapSys => 
+        Initialized ? _mapSys! : throw _uninitializedException;
+
+    public virtual void Init(
+        ISawmill sawmill,
+        IEntityManager entMan, 
+        IPrototypeManager protoMan, 
+        System.Random random, 
+        SalvageMissionObjectivePrototype objective, 
+        AnchorableSystem anchorable, 
+        SharedMapSystem mapSys, 
+        ProtoId<SalvageDifficultyPrototype> difficulty,
+        Dungeon dungeon, 
+        Entity<MapGridComponent> map)
+    {
+        _sawmill = sawmill;
+        _entityManager = entMan;
+        _protoManager = protoMan;
+        _random = random;
+        _objective = objective;
+        _difficulty = difficulty;
+        _dungeon = dungeon;
+        _map = map;
+        _anchorable = anchorable;
+        _mapSys = mapSys;
+        Initialized = true;
+    }
+
+    public virtual void Shutdown()
+    {
+        Initialized = false;
+        _sawmill = null;
+        _entityManager = null;
+        _protoManager = null;
+        _random = null;
+        _objective = null;
+        _difficulty = null;
+        _dungeon = null;
+        _map = null;
+        _anchorable = null;
+        _mapSys = null;
+    }
+
+    public virtual void Run(
+        ISawmill sawmill,
+        IEntityManager entMan, 
+        IPrototypeManager protoMan, 
+        System.Random random, 
+        SalvageMissionObjectivePrototype objective, 
+        AnchorableSystem anchorable, 
+        SharedMapSystem mapSys, 
+        ProtoId<SalvageDifficultyPrototype> difficulty,
+        Dungeon dungeon, 
+        Entity<MapGridComponent> map)
+    {
+        sawmill.Info($"{this.GetType().Name} handler entered");
+        Init(sawmill, entMan, protoMan, random, objective, anchorable, mapSys, difficulty, dungeon, map);
+        OnMapCreated();
+    }
+
+    public virtual void Exit(EntityUid shuttle)
+    {
+        BeforeFTLFromMap(shuttle);
+        Shutdown();
+    }
+
+    public abstract void OnMapCreated();
+
+    public abstract void BeforeFTLToMap(EntityUid shuttle);
+    public abstract void AFterFTLToMap(EntityUid shuttle);
+    public abstract void BeforeFTLFromMap(EntityUid shuttle);
+
+    public virtual string GetAnnouncement() =>
+        !Initialized
+            ? ""
+            : Loc.GetString(
+                Objective.Announcement,
+                ("numTargets", Objective.NumTargets.GetValueOrDefault(Difficulty, 0)),
+                ("bonusCap", Objective.BonusCap));
+
+    protected EntityCoordinates? GetRandomEmptyTileInDungeon()
+    {
+        ValueList<DungeonRoom> availableRooms = [.. Dungeon.Rooms];
+        List<Vector2i> availableTiles = [];
+
+        while (availableRooms.Count > 0)
+        {
+            availableTiles.Clear();
+            var roomIndex = Rand.Next(availableRooms.Count);
+            var room = availableRooms.RemoveSwap(roomIndex);
+            availableTiles.AddRange(room.Tiles);
+
+            while (availableTiles.Count > 0)
+            {
+                var tile = availableTiles.RemoveSwap(Rand.Next(availableTiles.Count));
+
+                if (!AnchorableSys.TileFree(Map, tile, (int)CollisionGroup.MachineLayer,
+                        (int)CollisionGroup.MachineLayer))
+                    continue;
+
+                return MapSys.GridTileToLocal(Map, Map.Comp, tile);
+            }
+        }
+
+        return null;
+    }
+
+    protected HashSet<EntityUid> GetAllSpawnedMobs()
+    {
+        if (!EntMan.TryGetComponent<TransformComponent>(Map, out var mapTransform))
+            return [];
+
+        HashSet<EntityUid> result = [];
+        var enumerator = mapTransform.ChildEnumerator;
+        while(enumerator.MoveNext(out var uid))
+        {
+            if(EntMan.TryGetComponent<MobStateComponent>(uid, out _))
+                result.Add(uid);
+        }
+        return result;
+    }
+
+    protected void Announce(string text)
+    {
+        if (!EntMan.TryGetComponent<MapComponent>(Map, out var mapComp))
+            return;
+
+        var chat = IoCManager.Resolve<IChatManager>();
+
+        chat.ChatMessageToManyFiltered(
+            Filter.BroadcastMap(mapComp.MapId),
+            ChatChannel.Radio,
+            text,
+            text,
+            Map,
+            false,
+            true,
+            null);
+    }
+
+    protected void SetRewardComponent(EntityUid target, (bool completed, int bonuses, int maxBonuses, int totalReward) reward)
+    {
+        var comp = EntMan.EnsureComponent<SalvageMissionRewardComponent>(target);
+        comp.MissionCompleted = reward.completed;
+        comp.Bonuses = reward.bonuses;
+        comp.MaxBonuses = reward.maxBonuses;
+        comp.TotalReward = reward.totalReward;
+        comp.parentObjective = Objective.ID;
+    }
+
+    protected (bool completed, int bonuses, int maxBonuses, int totalReward) ResolveCompletion(int numCompletedTargets) =>
+        (
+            numCompletedTargets >= Objective.NumTargets.GetValueOrDefault(Difficulty, 0),
+            Math.Min(numCompletedTargets - Objective.NumTargets.GetValueOrDefault(Difficulty, 0), Objective.BonusCap),
+            Objective.BonusCap,
+            numCompletedTargets >= Objective.NumTargets.GetValueOrDefault(Difficulty, 0) ?
+                Objective.BaseReward.GetValueOrDefault(Difficulty, 0) + Objective.Bonus * Math.Min(numCompletedTargets - Objective.NumTargets.GetValueOrDefault(Difficulty, 0), Objective.BonusCap) :
+                0
+        );
+
+    protected EntityUid? GetExpeditionConsole(EntityUid shuttle)
+    {
+        if (!EntMan.TryGetComponent<TransformComponent>(shuttle, out var shuttleTransform))
+            return null;
+
+        var children = shuttleTransform.ChildEnumerator;
+        while (children.MoveNext(out var child))
+            if (EntMan.TryGetComponent<SalvageExpeditionConsoleComponent>(child, out _))
+                return child;
+
+        return null;
+    }
+
+    protected HashSet<EntityUid> GetAllMarkedEntitiesOnShuttle(EntityUid shuttle) =>
+        GetAllMarkedEntities()
+        .Where(p => EntMan.TryGetComponent<TransformComponent>(p, out var transform) && transform.GridUid == shuttle)
+        .ToHashSet();
+
+    protected HashSet<EntityUid> GetAllMarkedEntities()
+    {
+        HashSet<EntityUid> res = [];
+
+        var query = EntMan.AllEntityQueryEnumerator<SalvageMissionObjectiveTargetComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+            if (comp.OwnedBy == Objective.ID)
+                res.Add(uid);
+
+        return res;
+    }
+
+    protected void DeleteWithEffect(HashSet<EntityUid> entities)
+    {
+        foreach (var uid in entities)
+            DeleteWithEffect(uid);
+    }
+
+    protected void DeleteWithEffect(EntityUid uid)
+    {
+        var transform = EntMan.System<TransformSystem>();
+        var audio = EntMan.System<AudioSystem>();
+        
+        if (transform.TryGetMapOrGridCoordinates(uid, out var pos))
+        {
+            var effect = EntMan.SpawnAtPosition(Objective.DeleteTargetEffect, pos.Value);
+            audio.PlayPvs(Objective.DeleteTargetSound, effect);
+        }
+
+        EntMan.DeleteEntity(uid);
+    }
+
+    protected Entity<SalvageMissionObjectiveTargetComponent> SpawnAndMarkEntity(EntProtoId proto, EntityCoordinates pos)
+    {
+        var uid = EntMan.SpawnAtPosition(proto, pos);
+        var comp = MarkEntity(uid);
+        return (uid, comp);
+    }
+
+    protected SalvageMissionObjectiveTargetComponent MarkEntity(EntityUid uid)
+    {
+        var comp = EntMan.EnsureComponent<SalvageMissionObjectiveTargetComponent>(uid);
+        comp.OwnedBy = Objective.ID;
+        return comp;
+    }
+}

--- a/Content.Server/_FarHorizons/Salvage/SalvageMissionObjectiveHandlerPrototype.cs
+++ b/Content.Server/_FarHorizons/Salvage/SalvageMissionObjectiveHandlerPrototype.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._FarHorizons.Salvage;
+
+[Prototype]
+public sealed partial class SalvageMissionObjectiveHandlerPrototype : IPrototype
+{
+    [IdDataField] public string ID { get; private set; } = default!;
+    [DataField]
+    public BaseSalvageMissionObjectiveHandler? Handler;
+}

--- a/Content.Server/_FarHorizons/Salvage/SalvageMissionObjectiveSystem.cs
+++ b/Content.Server/_FarHorizons/Salvage/SalvageMissionObjectiveSystem.cs
@@ -1,0 +1,93 @@
+using Content.Server.Chat.Systems;
+using Content.Server.Salvage.Expeditions;
+using Content.Server.Shuttles.Events;
+using Content.Server.Stack;
+using Content.Shared._FarHorizons.Salvage;
+using Content.Shared._FarHorizons.Salvage.Components;
+using Content.Shared.Chat;
+using Content.Shared.Salvage.Expeditions;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._FarHorizons.Salvage;
+
+public sealed class SalvageMissionObjectiveSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _protoMan = default!;
+    [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly StackSystem _stack = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<FTLStartedEvent>(OnFTLStarted);
+        SubscribeLocalEvent<FTLCompletedEvent>(OnFTLCompleted);
+    }
+
+    private void OnFTLStarted(ref FTLStartedEvent ev)
+    {
+        SalvageExpeditionComponent? exped = null;
+        if (TryComp<SalvageExpeditionComponent>(ev.FromMapUid, out exped))
+        {
+            var handler = GetHandler(exped.Objective);
+            if (handler != null && handler.Initialized)
+                handler.Exit(ev.Entity);
+        } else if (TryComp<SalvageExpeditionComponent>(_transform.GetMap(ev.TargetCoordinates), out exped))
+        {
+            var handler = GetHandler(exped.Objective);
+            if (handler != null && handler.Initialized)
+                handler.BeforeFTLToMap(ev.Entity);
+        }
+    }
+
+    private void OnFTLCompleted(ref FTLCompletedEvent ev)
+    {
+        if (TryComp<SalvageExpeditionComponent>(ev.MapUid, out var exped))
+        {
+            var handler = GetHandler(exped.Objective);
+            if (handler != null && handler.Initialized)
+                handler.AFterFTLToMap(ev.Entity);
+            return;
+        }
+        
+        if (GetExpedConsole(ev.Entity) is Entity<SalvageExpeditionConsoleComponent> console &&
+            TryComp<SalvageMissionRewardComponent>(console, out var reward))
+            ProcessReward((console.Owner, reward));
+    }
+
+    private BaseSalvageMissionObjectiveHandler? GetHandler(ProtoId<SalvageMissionObjectivePrototype> objectiveId)
+    {
+        var objective = _protoMan.Index(objectiveId);
+        if (objective.HandlerId != null && 
+            _protoMan.Index<SalvageMissionObjectiveHandlerPrototype>(objective.HandlerId) is SalvageMissionObjectiveHandlerPrototype handlerProto &&
+            handlerProto.Handler != null)
+            return handlerProto.Handler;
+        return null;
+    }
+
+    private void ProcessReward(Entity<SalvageMissionRewardComponent> ent)
+    {
+        var objective = _protoMan.Index<SalvageMissionObjectivePrototype>(ent.Comp.parentObjective);
+        _chat.TrySendInGameICMessage(
+            ent, 
+            Loc.GetString(ent.Comp.MissionCompleted ? 
+                objective.CompletionText : 
+                objective.FailText, 
+            ("bonus", ent.Comp.Bonuses), ("maxBonus", ent.Comp.MaxBonuses), ("totalReward", ent.Comp.TotalReward)),
+            InGameICChatType.Speak, true);
+        
+        if(_transform.TryGetMapOrGridCoordinates(ent, out var pos))
+            _stack.SpawnMultiple(objective.RewardProto, ent.Comp.TotalReward, pos.Value);
+        EntityManager.RemoveComponent<SalvageMissionRewardComponent>(ent);
+    }
+
+    public Entity<SalvageExpeditionConsoleComponent>? GetExpedConsole(EntityUid shuttle)
+    {
+        var enumerator = Transform(shuttle).ChildEnumerator;
+        while(enumerator.MoveNext(out var uid))
+            if(TryComp<SalvageExpeditionConsoleComponent>(uid, out var comp))
+                return (uid, comp);
+        return null;
+    }
+}

--- a/Content.Shared/Salvage/Expeditions/SalvageExpeditions.cs
+++ b/Content.Shared/Salvage/Expeditions/SalvageExpeditions.cs
@@ -1,6 +1,8 @@
+using Content.Shared._FarHorizons.Salvage;
 using Content.Shared.Salvage.Expeditions.Modifiers;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
@@ -101,7 +103,8 @@ public sealed record SalvageMission(
     float Temperature,
     Color? Color,
     TimeSpan Duration,
-    List<string> Modifiers)
+    List<string> Modifiers,
+    ProtoId<SalvageMissionObjectivePrototype> Objective)  // Far Horizons
 {
     /// <summary>
     /// Seed used for the mission.
@@ -147,6 +150,11 @@ public sealed record SalvageMission(
     /// Modifiers (outside of the above) applied to the mission.
     /// </summary>
     public List<string> Modifiers = Modifiers;
+
+    /// <summary>
+    /// Far Horizons mission objective
+    /// </summary>
+    public ProtoId<SalvageMissionObjectivePrototype> Objective = Objective;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Salvage/SharedSalvageSystem.FarHorizons.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.FarHorizons.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using Content.Shared._FarHorizons.Salvage;
+using Content.Shared.Procedural;
+using Content.Shared.Salvage.Expeditions;
+using Content.Shared.Salvage.Expeditions.Modifiers;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Shared.Salvage;
+
+public abstract partial class SharedSalvageSystem
+{
+    const string FallbackObjective = "MissionObjectiveFree";
+
+    private SalvageMissionObjectivePrototype _fallbackObjectiveProto => 
+        _proto.Index<SalvageMissionObjectivePrototype>(FallbackObjective);
+
+    public SalvageMissionObjectivePrototype GetMissionObjective(System.Random rand, ProtoId<SalvageDifficultyPrototype> difficulty, ProtoId<SalvageBiomeModPrototype> biome, ProtoId<SalvageFactionPrototype> faction, ProtoId<SalvageDungeonModPrototype> dungeon)
+    {
+        var objectives = _proto.EnumeratePrototypes<SalvageMissionObjectivePrototype>()
+                            .Where(p => 
+                                (p.AllowedDifficulties == null || p.AllowedDifficulties.Contains(difficulty)) &&
+                                (p.AllowedBiomes == null || p.AllowedBiomes.Contains(biome)) && 
+                                (p.AllowedFactions == null || p.AllowedFactions.Contains(faction)) &&
+                                (p.AllowedDungeons == null || p.AllowedDungeons.Contains(dungeon)))
+                            .ToList();
+        
+        objectives.Sort((x, y) => string.Compare(x.ID, y.ID, StringComparison.Ordinal)); // yes, it is bullshit
+
+        if (objectives.Count == 0)
+            return _fallbackObjectiveProto;
+
+        if (objectives.Count == 1)
+            return objectives[0];
+
+        rand.Shuffle(objectives);
+        return objectives[0];
+    }
+        
+}

--- a/Content.Shared/Salvage/SharedSalvageSystem.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.cs
@@ -52,6 +52,9 @@ public abstract partial class SharedSalvageSystem : EntitySystem
         factionProtos.Sort((x, y) => string.Compare(x.ID, y.ID, StringComparison.Ordinal)); //bullshit
         var faction = factionProtos[rand.Next(factionProtos.Count)];
 
+        // Far Horizons
+        var objective = GetMissionObjective(rand, difficulty.ID, biome.ID, faction.ID, dungeon.ID);
+
         var mods = new List<string>();
 
         if (air.Description != string.Empty)
@@ -72,7 +75,8 @@ public abstract partial class SharedSalvageSystem : EntitySystem
 
         var duration = TimeSpan.FromSeconds(CfgManager.GetCVar(CCVars.SalvageExpeditionDuration));
 
-        return new SalvageMission(seed, dungeon.ID, faction.ID, biome.ID, air.ID, temp.Temperature, light.Color, duration, mods);
+        // Far Horizons: objective
+        return new SalvageMission(seed, dungeon.ID, faction.ID, biome.ID, air.ID, temp.Temperature, light.Color, duration, mods, objective);
     }
 
     public T GetBiomeMod<T>(string biome, System.Random rand, ref float rating, string difficultyId) where T : class, IPrototype, IBiomeSpecificMod

--- a/Content.Shared/_FarHorizons/Salvage/Components/SalvageMissionObjectiveTargetComponent.cs
+++ b/Content.Shared/_FarHorizons/Salvage/Components/SalvageMissionObjectiveTargetComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._FarHorizons.Salvage.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SalvageMissionObjectiveTargetComponent : Component
+{
+    public ProtoId<SalvageMissionObjectivePrototype>? OwnedBy = null;
+}

--- a/Content.Shared/_FarHorizons/Salvage/Components/SalvageMissionRewardComponent.cs
+++ b/Content.Shared/_FarHorizons/Salvage/Components/SalvageMissionRewardComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._FarHorizons.Salvage.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SalvageMissionRewardComponent : Component
+{
+    [ViewVariables]
+    public bool MissionCompleted = false;
+    [ViewVariables]
+    public int Bonuses = 0;
+    [ViewVariables]
+    public int MaxBonuses = 0;
+    [ViewVariables]
+    public int TotalReward = 0;
+    [ViewVariables]
+    public ProtoId<SalvageMissionObjectivePrototype> parentObjective = "";
+}

--- a/Content.Shared/_FarHorizons/Salvage/SalvageMissionObjectivePrototype.cs
+++ b/Content.Shared/_FarHorizons/Salvage/SalvageMissionObjectivePrototype.cs
@@ -1,0 +1,54 @@
+using Content.Shared.Procedural;
+using Content.Shared.Salvage.Expeditions;
+using Content.Shared.Salvage.Expeditions.Modifiers;
+using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._FarHorizons.Salvage;
+
+[Prototype]
+public sealed partial class SalvageMissionObjectivePrototype : IPrototype
+{
+    [IdDataField] public string ID { get; private set; } = default!;
+
+    [DataField]
+    public List<ProtoId<SalvageDifficultyPrototype>>? AllowedDifficulties;
+    [DataField]
+    public List<ProtoId<SalvageBiomeModPrototype>>? AllowedBiomes;
+    [DataField]
+    public List<ProtoId<SalvageFactionPrototype>>? AllowedFactions;
+    [DataField]
+    public List<ProtoId<SalvageDungeonModPrototype>>? AllowedDungeons;
+    [DataField]
+    public EntProtoId DeleteTargetEffect = "CryoPortal";
+    [DataField]
+    public SoundSpecifier DeleteTargetSound = new SoundPathSpecifier("/Audio/Effects/teleport_departure.ogg");
+    [DataField]
+    public LocId CompletionText = "salvage-mission-objective-completed-message";
+    [DataField]
+    public LocId FailText = "salvage-mission-objective-failed-message";
+    [DataField]
+    public EntProtoId RewardProto = "SalvageTicket";
+
+    [DataField(required: true)]
+    public LocId Name;
+    [DataField]
+    public Color Color = Color.FromHex("#A88B5E");
+    [DataField(required: true)]
+    public LocId Description;
+    [DataField(required: true)]
+    public LocId Announcement;
+    [DataField]
+    public Dictionary<ProtoId<SalvageDifficultyPrototype>, int> BaseReward = [];
+    [DataField]
+    public Dictionary<ProtoId<SalvageDifficultyPrototype>, int> NumTargets = [];
+
+    [DataField]
+    public int Bonus = 0;
+    [DataField]
+    public int BonusCap = 0;
+
+    [DataField]
+    public string? HandlerId;
+
+}

--- a/Resources/Locale/en-US/_FarHorizons/salvage/mission_objectives.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/salvage/mission_objectives.ftl
@@ -1,0 +1,22 @@
+salvage-expedition-window-objective = Mission:
+salvage-expedition-window-objective-description = Objective:
+salvage-expedition-window-objective-reward = Reward:
+
+salvage-mission-objective-name-free = Found coordinates
+salvage-mission-objective-description-free = Anomalus signature detected. Explore at your own peril.
+salvage-mission-objective-announcement-free = There are no objectives for this expedition.
+
+salvage-mission-objective-name-recover = Recovery
+salvage-mission-objective-description-recover = Important cargo has been left behind. Looking for freelancers to recover it.
+salvage-mission-objective-announcement-recover = Your mission is to collect {$numTargets} lost crates and bring them with you when you leave. You will also be paid for up to {$bonusCap} additional crates you find.
+
+salvage-mission-objective-name-capture = Capture
+salvage-mission-objective-description-capture = Exotic pets are in fashion. Looking for reliable suppliers.
+salvage-mission-objective-announcement-capture = Your mission is to capture {$numTargets} exotic pets and bring them with you when you leave. Alive. We offer extra reward for up to {$bonusCap} pets.
+
+salvage-mission-objective-name-rescue = Rescue
+salvage-mission-objective-description-rescue = Planetary base went off comms. Body recovery bounties available.
+salvage-mission-objective-announcement-rescue = Your mission is to secure following bodies: {$names}. You will get additional rewards based on condition of the bodies.
+
+salvage-mission-objective-completed-message = Salvage mission completed. {$bonus}/{$maxBonus} bonus objectives completed. Total payout: {$totalReward} tickets
+salvage-mission-objective-failed-message = Salvage mission failed.

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1433,6 +1433,9 @@
       access: [["Salvage"]]
     - type: StealTarget
       stealGroup: SalvageExpeditionsComputerCircuitboard
+    # Far Horizons
+    - type: Speech
+      speechVerb: Robotic
 
 - type: entity
   parent: BaseComputer

--- a/Resources/Prototypes/Procedural/dungeon_configs.yml
+++ b/Resources/Prototypes/Procedural/dungeon_configs.yml
@@ -79,6 +79,9 @@
   id: Haunted
   layers:
   - !type:PrefabDunGen
+    roomWhitelist:
+      tags:
+      - Haunted
     presets:
     - Bucket
     - Wow

--- a/Resources/Prototypes/_FarHorizons/Salvage/mission_objective_targets.yml
+++ b/Resources/Prototypes/_FarHorizons/Salvage/mission_objective_targets.yml
@@ -1,0 +1,43 @@
+- type: entity
+  id: CrateSalvageMissionObjective
+  parent: BaseStructureDynamic
+  name: Lost crate
+  description: Someone is paying you to deliver it.
+  components:
+    - type: InteractionOutline
+    - type: Transform
+      noRot: true
+    - type: Sprite
+      sprite: Structures/Storage/Crates/command.rsi
+      layers:
+        - state: base
+        - state: closed
+    - type: Icon
+      sprite: Structures/Storage/Crates/command.rsi
+      state: icon
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape:
+            !type:PhysShapeAabb
+            bounds: "-0.4,-0.4,0.4,0.29"
+          density: 50
+          mask:
+          - CrateMask
+          layer:
+          - MachineLayer
+    - type: Damageable
+      damageContainer: Inorganic
+      damageModifierSet: Metallic
+    - type: Destructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 30
+        behaviors:
+        - !type:DoActsBehavior
+          acts: ["Destruction"]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalBreak

--- a/Resources/Prototypes/_FarHorizons/Salvage/mission_objectives.yml
+++ b/Resources/Prototypes/_FarHorizons/Salvage/mission_objectives.yml
@@ -1,0 +1,67 @@
+- type: salvageMissionObjective
+  id: MissionObjectiveFree
+  name: salvage-mission-objective-name-free
+  description: salvage-mission-objective-description-free
+  announcement: salvage-mission-objective-announcement-free
+
+- type: salvageMissionObjective
+  id: MissionObjectiveRecover
+  handlerId: "MissionObjectiveRecoverHandler"
+  name: salvage-mission-objective-name-recover
+  description: salvage-mission-objective-description-recover
+  announcement: salvage-mission-objective-announcement-recover
+  baseReward:
+    Easy: 700
+    Moderate: 900
+    Challenging: 1100
+  numTargets:
+    Easy: 2
+    Moderate: 4
+    Challenging: 6
+  bonus: 95
+  bonusCap: 4
+  allowedDungeons:
+    - Experiment
+    - LavaBrig
+    - SnowyLabs
+
+- type: salvageMissionObjective
+  id: MissionObjectiveCapture
+  handlerId: "MissionObjectiveCaptureHandler"
+  name: salvage-mission-objective-name-capture
+  description: salvage-mission-objective-description-capture
+  announcement: salvage-mission-objective-announcement-capture
+  baseReward:
+    Easy: 800
+    Moderate: 950
+    Challenging: 1150
+  numTargets:
+    Easy: 1
+    Moderate: 2
+    Challenging: 2
+  bonus: 75
+  bonusCap: 5
+  allowedFactions:
+    - Xenos
+    - Carps
+
+- type: salvageMissionObjective
+  id: MissionObjectiveRescue
+  handlerId: "MissionObjectiveRescueHandler"
+  name: salvage-mission-objective-name-rescue
+  description: salvage-mission-objective-description-rescue
+  announcement: salvage-mission-objective-announcement-rescue
+  baseReward:
+    Easy: 1000
+    Moderate: 1250
+    Challenging: 1450
+  numTargets:
+    Easy: 2
+    Moderate: 2
+    Challenging: 3
+  bonus: 300
+  bonusCap: 3
+  allowedDungeons:
+    - Experiment
+    - LavaBrig
+    - SnowyLabs

--- a/Resources/Prototypes/_FarHorizons/Salvage/objective_handlers.yml
+++ b/Resources/Prototypes/_FarHorizons/Salvage/objective_handlers.yml
@@ -1,0 +1,11 @@
+- type: salvageMissionObjectiveHandler
+  id: MissionObjectiveRecoverHandler
+  handler: !type:SalvageMissionRecovery
+
+- type: salvageMissionObjectiveHandler
+  id: MissionObjectiveCaptureHandler
+  handler: !type:SalvageMissionCapture
+
+- type: salvageMissionObjectiveHandler
+  id: MissionObjectiveRescueHandler
+  handler: !type:SalvageMissionRescue

--- a/Resources/Prototypes/_StarLight/Procedural/salvage_difficulties.yml
+++ b/Resources/Prototypes/_StarLight/Procedural/salvage_difficulties.yml
@@ -2,8 +2,8 @@
 - type: salvageDifficulty
   id: Easy
   lootPrototype: "SalvageLootEasy"
-  lootBudget: 15
-  mobBudget: 15
+  lootBudget: 20 # Far Horizons
+  mobBudget: 25 # Far Horizons
   modifierBudget: 1
   color: "#9FED5896"
   recommendedPlayers: 1
@@ -12,8 +12,8 @@
 - type: salvageDifficulty
   id: Moderate
   lootPrototype: "SalvageLootModerate"
-  lootBudget: 30
-  mobBudget: 25
+  lootBudget: 50 # Far Horizons
+  mobBudget: 60 # Far Horizons
   modifierBudget: 2
   color: "#52B4E996"
   recommendedPlayers: 2
@@ -22,8 +22,8 @@
 - type: salvageDifficulty
   id: Challenging
   lootPrototype: "SalvageLootChallenging"
-  lootBudget: 90
-  mobBudget: 75
+  lootBudget: 100 # Far Horizons
+  mobBudget: 115 # Far Horizons
   modifierBudget: 3
   color: "#9FED5896"
   recommendedPlayers: 3


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Added framework for creating salvage mission objectives. Also added 3 mission types using this framework. Also buffed mission difficulty a bit

## Why we need to add this
Le gameplay

## Media (Video/Screenshots)
<img width="1328" height="678" alt="image" src="https://github.com/user-attachments/assets/6167a49f-947b-443f-9940-45b48eb9776c" />
<img width="508" height="124" alt="image" src="https://github.com/user-attachments/assets/96db4e0d-c831-4c1b-863b-ed0461a95eb0" />
<img width="593" height="322" alt="image" src="https://github.com/user-attachments/assets/bab707ee-8151-41d1-88c0-8b8134f8012a" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: princess_gurchi
- add: Salvage expeditions might now have objectives attached to them that will reward tickets for completion.
- add: 3 mission types for salvage: capture, recover and rescue.
- tweak: buffed difficulty of salvage missions at difficulties easy, moderate and challenging. Buffed loot slightly to account for that.
