### PR TITLE
Commander/Personnel Chief Light Changed to Green

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -81,7 +81,7 @@
   - type: PointLight
     color: green
     radius: 3.5
-    energy: 4
+    energy: 5
   - type: Tag
     tags:
     - CorgiWearable
@@ -102,4 +102,4 @@
   - type: PointLight
     color: green
     radius: 3.5
-    energy: 4
+    energy: 5

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -56,8 +56,6 @@
     sprite: _FarHorizons/Clothing/Head/Hardsuits/hopspace.rsi
   - type: Clothing
     sprite: _FarHorizons/Clothing/Head/Hardsuits/hopspace.rsi
-  - type: PointLight
-    color: "#f4ffad"
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
@@ -80,6 +78,10 @@
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
+  - type: PointLight
+    color: green
+    radius: 3.5
+    energy: 4
   - type: Tag
     tags:
     - CorgiWearable
@@ -97,3 +99,7 @@
     sprite: _FarHorizons/Clothing/Head/Hardsuits/syndihopspace.rsi
   - type: Clothing
     sprite: _FarHorizons/Clothing/Head/Hardsuits/syndihopspace.rsi
+  - type: PointLight
+    color: green
+    radius: 3.5
+    energy: 4


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Small update to hardsuit lighting to be green.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Requested by Abby during playtesting.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1653" height="504" alt="image" src="https://github.com/user-attachments/assets/6454157b-8ab4-47c8-88ab-6f7d98467e91" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: CorruptOmega
- tweak: Commander and Personnel Chief now have a green light on their hardsuits
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: FAR HORIZONS TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
