### PR TITLE
Disabling Holopad Collision - Removing Duplicate HoP ID Clipboard from Locker, since they spawn with one in bag.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -205,7 +205,7 @@
     - id: RubberStampHop
     - id: ClothingEyesHudCommand
     - id: ClothingEyesGlassesCommand #Far Horizons
-    - id: BoxFolderHoPClipboard #Starlight Change
+    #- id: BoxFolderHoPClipboard #Starlight Change - #Far Horizons disabled - HoP already spawns with one.
     - id: PrintedDocumentGreenshiftAlert #SL
       conditions: #SL
       - !type:GamemodeCondition #SL

--- a/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
@@ -6,14 +6,16 @@
   components:
   - type: Transform
     anchored: true
-  - type: Fixtures
+  - type: Fixtures      
     fixtures:
       fix1:
         shape:
           !type:PhysShapeCircle
           radius: 0.25
         mask:
-        - Impassable
+        - LowImpassable #Far Horizons - Holopad should be LowImpassable, not Impassable....
+  - type: Physics #Far Horizons - Stop blocking hallways and everything else you punk.
+    canCollide: false #Far Horizons - That's right. No more collisions for you punk.
   - type: ApcPowerReceiver
     powerLoad: 300
   - type: StationAiVision

--- a/Resources/Prototypes/_FarHorizons/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_FarHorizons/Catalog/Fills/Lockers/heads.yml
@@ -120,7 +120,6 @@
     - id: RubberStampHop
     - id: ClothingEyesGlassesCommandSyndi
     - id: ClothingEyesHudCommandSyndi
-    - id: BoxFolderHoPClipboard
     - id: PrintedDocumentGreenshiftAlert
       conditions:
       - !type:GamemodeCondition


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Disabled Holopad collision due to request in this bug report. Also disabled duplicate HoP ID Card Clipboard in HoP Locker from same bug thread.
https://discord.com/channels/1407077238876147783/1436483764971634758

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Small changes.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/69116f06-b949-4e98-a3f4-0aef140e8250


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: CorruptOmega
- remove: Holopad will no longer hold the door. You can shuffle stuff over them again.
- remove: Removed duplicate HoP ID Card computer clipboard from HoP Locker. You already spawn with one on your person.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: FAR HORIZONS TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
