### PR TITLE
Minor adjustment to Reduced bloat of medical borg modules

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -841,6 +841,7 @@
   - type: ItemBorgModule
     hands:
     - item: HandheldHealthAnalyzerUnpowered
+    - item: DefibrillatorOneHandedUnpowered
     - item: Gauze
       hand:
         emptyLabel: borg-slot-topicals-empty
@@ -932,6 +933,7 @@
         whitelist:
           components:
           - FitsInDispenser
+    - item: HandLabeler
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: chem-module }
 
@@ -986,6 +988,7 @@
           - FitsInDispenser
           tags:
           - ChemDispensable
+    - item: HandLabeler
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: adv-chem-module }
 

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -161,7 +161,6 @@
   - BorgModuleTool
   - BorgModuleChemical
   - BorgModuleTopicals
-  - BorgModuleRescue
 
   radioChannels:
   - Science


### PR DESCRIPTION
## Short description
Moving the Rescue modules tools to other modules to improve module management and reduce repeated tools

## Why we need to add this
https://discord.com/channels/1407077238876147783/1436730247155548180
Removing unecesary items fom medical chassis to reduce their bloat to inprove module management
## Media (Video/Screenshots)
<img width="1972" height="1348" alt="image" src="https://github.com/user-attachments/assets/561ad013-3ff5-4546-a2fc-fbc778fe7cd2" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: FAR HORIZONS TEAM
- remove: Medical borgs whit rescue module (rescue module still exist on derelicts and others) 
- tweak: added labelers to chemistry modules , and defib to topicals
-->
