### PR TITLE
Tweaked medical borg tools layout to make them feel less bloated

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -841,6 +841,7 @@
   - type: ItemBorgModule
     hands:
     - item: HandheldHealthAnalyzerUnpowered
+    - item: DefibrillatorOneHandedUnpowered
     - item: Gauze
       hand:
         emptyLabel: borg-slot-topicals-empty
@@ -932,6 +933,7 @@
         whitelist:
           components:
           - FitsInDispenser
+    - item: HandLabeler
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: chem-module }
 
@@ -986,6 +988,7 @@
           - FitsInDispenser
           tags:
           - ChemDispensable
+    - item: HandLabeler
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: adv-chem-module }
 

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -161,7 +161,6 @@
   - BorgModuleTool
   - BorgModuleChemical
   - BorgModuleTopicals
-  - BorgModuleRescue
 
   radioChannels:
   - Science


### PR DESCRIPTION
## Short description
moving some tools in the default medical borg chassis 

## Why we need to add this
soo their bloat of repeated tools or frequent change of modules decreases and geting some space freed for future surgery tools 

## Media (Video/Screenshots)
<img width="2081" height="1348" alt="proof" src="https://github.com/user-attachments/assets/1c754b43-c339-4b3f-a79e-5ba6be973dfe" />

## Checks


- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: FAR HORIZONS TEAM
- tweak: Medical borg default modules and their layout
