### PR TITLE
New salvage mission: Purge

### DIFF
--- a/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionPurge.cs
+++ b/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionPurge.cs
@@ -1,0 +1,88 @@
+using System.Linq;
+using Content.Server.Humanoid;
+using Content.Server.Station.Systems;
+using Content.Shared._FarHorizons.Factions;
+using Content.Shared.Damage;
+using Content.Shared.Inventory;
+using Content.Shared.Mobs.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Server._FarHorizons.Salvage.Objectives;
+
+public sealed partial class SalvageMissionPurge : BaseSalvageMissionObjectiveHandler
+{
+    private readonly List<EntProtoId> _purgeTargets = ["FolderSalvageMissionObjective"];
+    private readonly double _inPocketChance = 0.3;
+    static readonly List<string> _pocketSlots = ["pocket1", "pocket2"];
+    static readonly List<EntProtoId> _stuffProtos = ["Pen", "LuxuryPen", "Lighter", "CheapLighter", "FlippoLighter", "CigPackBlue", "CigPackRed", "CigPackBlack", "Cigar", "CigarGold"];
+
+    public override void AFterFTLToMap(EntityUid shuttle) => 
+        Announce(GetAnnouncement());
+    public override void BeforeFTLFromMap(EntityUid shuttle)
+    {
+        if (GetExpeditionConsole(shuttle) is not EntityUid expedConsole)
+            return;
+        
+        var allTargets = GetAllMarkedEntities();
+        var targetsDestroyed = GetNumSpawnables() - allTargets.Count();
+        SetRewardComponent(expedConsole, ResolveCompletion(targetsDestroyed));
+    }
+    public override void BeforeFTLToMap(EntityUid shuttle){} // Override intentionally left empty
+
+    public override void OnMapCreated()
+    {
+        var factions = IoCManager.Resolve<ISharedFactionManager>();
+        var humanoid = EntMan.System<HumanoidAppearanceSystem>();
+        var metadata = EntMan.System<MetaDataSystem>();
+        var state = EntMan.System<MobStateSystem>();
+        var damageable = EntMan.System<DamageableSystem>();
+        var stationSpawning = EntMan.System<StationSpawningSystem>();
+        var inventory = EntMan.System<InventorySystem>();
+
+        int bodiesSpawned = 0;
+
+        var possibleFactions = factions.ListPlayableFactions().Where(p => p.Major).ToList();
+        var selectedFaction = possibleFactions[Rand.Next(possibleFactions.Count)];
+
+        for (var i = 0; i < GetNumSpawnables(); i++)
+        {
+            if (GetRandomEmptyTileInDungeon() is not EntityCoordinates pos)
+                return;
+
+            var proto = _purgeTargets[Rand.Next(_purgeTargets.Count)];
+            var spawned = SpawnAndMarkEntity(proto, pos);
+
+            if (Rand.Prob(_inPocketChance))
+            {
+                var slot = _pocketSlots[Rand.Next(_pocketSlots.Count)];
+                var damage = SalvageMissionRescue.RandomDamage(ProtoMan, Rand, 100, 200, 4);
+                var body = SalvageMissionRescue.SpawnRandomBody(ProtoMan, EntMan, Rand, pos, humanoid, metadata, state, damageable, factions, stationSpawning, selectedFaction, true, damage, true);
+                if (!inventory.TryEquip(body, spawned, slot, force: true))
+                    EntMan.DeleteEntity(body);
+                else{
+                    bodiesSpawned++;
+                }
+            }
+        }
+
+        for (var i = 0; i < bodiesSpawned * 2; i++)
+        {
+            if (GetRandomEmptyTileInDungeon() is not EntityCoordinates pos)
+                return;
+
+            var slot = _pocketSlots[Rand.Next(_pocketSlots.Count)];
+            var item = _stuffProtos[Rand.Next(_stuffProtos.Count)];
+
+            var damage = SalvageMissionRescue.RandomDamage(ProtoMan, Rand, 100, 200, 4);
+            var body = SalvageMissionRescue.SpawnRandomBody(ProtoMan, EntMan, Rand, pos, humanoid, metadata, state, damageable, factions, stationSpawning, selectedFaction, true, damage, true);
+            var itemEnt = EntMan.SpawnAtPosition(item, pos);
+            if (!inventory.TryEquip(body, itemEnt, slot, force: true))
+                EntMan.DeleteEntity(itemEnt);
+        }
+    }
+
+    private int GetNumSpawnables() => 
+        Objective.NumTargets.GetValueOrDefault(Difficulty, 0) + Objective.BonusCap;
+}

--- a/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionRescue.cs
+++ b/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionRescue.cs
@@ -79,8 +79,6 @@ public sealed partial class SalvageMissionRescue : BaseSalvageMissionObjectiveHa
         var stationSpawning = EntMan.System<StationSpawningSystem>();
         var inventory = EntMan.System<InventorySystem>();
 
-        var damageTypes = ProtoMan.EnumeratePrototypes<DamageTypePrototype>().ToList();
-
         int objectivesSpawned = 0;
 
         var possibleFactions = factions.ListPlayableFactions().Where(p => p.Major).ToList();
@@ -88,48 +86,104 @@ public sealed partial class SalvageMissionRescue : BaseSalvageMissionObjectiveHa
 
         for (var i = 0; i < GetNumSpawnables(); i++)
         {
-            var character = HumanoidCharacterProfile.Random();
-            var species = ProtoMan.Index(character.Species);
-
             if (GetRandomEmptyTileInDungeon() is not EntityCoordinates pos)
                 return;
 
-            var ent = EntMan.SpawnAtPosition(species.Prototype, pos);
-            humanoid.LoadProfile(ent, character);
-            metadata.SetEntityName(ent, character.Name);
-            state.ChangeMobState(ent, MobState.Dead);
-
-            var damage = new DamageSpecifier();
-            damage.DamageDict.Add(damageTypes[Rand.Next(damageTypes.Count)].ID, Rand.Next(300));
-            if (Rand.Next(100) > 50)
-                damage.DamageDict.TryAdd(damageTypes[Rand.Next(damageTypes.Count)].ID, Rand.Next(300));
-            if (Rand.Next(100) > 75)
-                damage.DamageDict.TryAdd(damageTypes[Rand.Next(damageTypes.Count)].ID, Rand.Next(300));
-            damageable.TryChangeDamage(ent, damage);
-
-            var jobs = factions.ListFactionJobs().Where(p => p.Faction == selectedFaction).ToList();
-            var job = jobs[Rand.Next(jobs.Count)];
-            var loadoutProtoId = factions.OverrideJobLoadout(job);
-            var loadoutProto = ProtoMan.Index(loadoutProtoId);
-
-            var loadout = new RoleLoadout(loadoutProtoId);
-            loadout.SetDefault(character, null, ProtoMan);
-
-            stationSpawning.EquipRoleLoadout(ent, loadout, loadoutProto);
+            var damage = RandomDamage(ProtoMan, Rand, 100, 200, 4);
+            var body = SpawnRandomBody(ProtoMan, EntMan, Rand, pos, humanoid, metadata, state, damageable, factions, stationSpawning, selectedFaction, true, damage, true);
 
             if (Rand.Prob(0.4))
             {
                 var gasMaskEnt = EntMan.SpawnAtPosition(GasMask, pos);
-                if (!inventory.TryEquip(ent, gasMaskEnt, MaskSlot, force: true))
+                if (!inventory.TryEquip(body, gasMaskEnt, MaskSlot, force: true))
                     EntMan.DeleteEntity(gasMaskEnt);
             }
 
             if (objectivesSpawned < Objective.NumTargets.GetValueOrDefault(Difficulty, 0))
             {
-                MarkEntity(ent);
+                MarkEntity(body);
                 objectivesSpawned++;
             }
         }
+    }
+
+    public static EntityUid SpawnRandomBody(
+        IPrototypeManager ProtoMan,
+        IEntityManager EntMan,
+        Random Rand,
+        EntityCoordinates pos, 
+        HumanoidAppearanceSystem humanoidAppearance, 
+        MetaDataSystem metadata,
+        MobStateSystem? state = null,
+        DamageableSystem? damageable = null,
+        ISharedFactionManager? factions = null,
+        StationSpawningSystem? stationSpawning = null,
+        FactionPrototype? faction = null,
+        bool dead = true,
+        DamageSpecifier? damage = null,
+        bool randomLoadout = true)
+    {
+        var character = HumanoidCharacterProfile.Random();
+        var species = ProtoMan.Index(character.Species);
+
+        var ent = EntMan.SpawnAtPosition(species.Prototype, pos);
+        humanoidAppearance.LoadProfile(ent, character);
+        metadata.SetEntityName(ent, character.Name);
+
+        if (dead && state != null)
+            state.ChangeMobState(ent, MobState.Dead);
+        
+        if (damage != null && damageable != null)
+            damageable.TryChangeDamage(ent, damage);
+        
+        if (randomLoadout && faction != null && factions != null && stationSpawning != null)
+        {
+            var jobs = factions.ListFactionJobs().Where(p => p.Faction == faction ).ToList();
+            var valid = false;
+
+            RoleLoadout loadout;
+            RoleLoadoutPrototype loadoutProto;
+
+            do
+            {
+                var job = jobs[Rand.Next(jobs.Count)];
+                var jobProto = ProtoMan.Index(job.Job);
+
+                valid = string.IsNullOrEmpty(jobProto.JobEntity);
+
+                var loadoutProtoId = factions.OverrideJobLoadout(job);
+                loadoutProto = ProtoMan.Index(loadoutProtoId);
+                loadout = new RoleLoadout(loadoutProtoId);
+            } while (!valid);
+
+            loadout.SetDefault(character, null, ProtoMan);
+
+            stationSpawning.EquipRoleLoadout(ent, loadout, loadoutProto);
+        }
+
+        return ent;
+    }
+
+    public static DamageSpecifier RandomDamage(IPrototypeManager ProtoMan, Random Rand, int minDamage, int maxDamage, int maxDamageTypes)
+    {
+        var damageTypes = ProtoMan.EnumeratePrototypes<DamageTypePrototype>().ToList();
+
+        var damage = new DamageSpecifier();
+        float chance = 1;
+        for (var i = 0; i < maxDamageTypes; i++)
+        {
+            if(Rand.Prob(chance))
+            {
+                var type = damageTypes[Rand.Next(damageTypes.Count)].ID;
+                if (damage.DamageDict.ContainsKey(type))
+                    continue;
+
+                damage.DamageDict.Add(type, Rand.Next(minDamage, maxDamage));       
+            }
+            chance -= 1 / maxDamageTypes;
+        }
+
+        return damage;
     }
 
     private int GetNumSpawnables() => 

--- a/Content.Server/_FarHorizons/Salvage/SalvageMissionObjectiveSystem.cs
+++ b/Content.Server/_FarHorizons/Salvage/SalvageMissionObjectiveSystem.cs
@@ -69,17 +69,18 @@ public sealed class SalvageMissionObjectiveSystem : EntitySystem
     private void ProcessReward(Entity<SalvageMissionRewardComponent> ent)
     {
         var objective = _protoMan.Index<SalvageMissionObjectivePrototype>(ent.Comp.parentObjective);
+        
+        if(ent.Comp.TotalReward > 0 && _transform.TryGetMapOrGridCoordinates(ent, out var pos))
+            _stack.SpawnMultiple(objective.RewardProto, ent.Comp.TotalReward, pos.Value);
+        EntityManager.RemoveComponent<SalvageMissionRewardComponent>(ent);
+
         _chat.TrySendInGameICMessage(
             ent, 
             Loc.GetString(ent.Comp.MissionCompleted ? 
                 objective.CompletionText : 
                 objective.FailText, 
             ("bonus", ent.Comp.Bonuses), ("maxBonus", ent.Comp.MaxBonuses), ("totalReward", ent.Comp.TotalReward)),
-            InGameICChatType.Speak, true);
-        
-        if(ent.Comp.TotalReward > 0 && _transform.TryGetMapOrGridCoordinates(ent, out var pos))
-            _stack.SpawnMultiple(objective.RewardProto, ent.Comp.TotalReward, pos.Value);
-        EntityManager.RemoveComponent<SalvageMissionRewardComponent>(ent);
+            InGameICChatType.Speak, ChatTransmitRange.GhostRangeLimit, false); // Since apparently errors on listeners can prevent rest of the event from running, moving chat message to the end
     }
 
     public Entity<SalvageExpeditionConsoleComponent>? GetExpedConsole(EntityUid shuttle)

--- a/Resources/Locale/en-US/_FarHorizons/salvage/mission_objectives.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/salvage/mission_objectives.ftl
@@ -18,5 +18,9 @@ salvage-mission-objective-name-rescue = Rescue
 salvage-mission-objective-description-rescue = Planetary base went off comms. Body recovery bounties available.
 salvage-mission-objective-announcement-rescue = Your mission is to secure following bodies: {$names}. You will get additional rewards based on condition of the bodies.
 
+salvage-mission-objective-name-purge = Purge
+salvage-mission-objective-description-purge = Base destruction left behind inconvenient records. Purge them.
+salvage-mission-objective-announcement-purge = Your mission is to destroy {$numTargets} document folders left around the base. If you recover any additional folder, you will be paid for their destruction as well.
+
 salvage-mission-objective-completed-message = Salvage mission completed. {$bonus}/{$maxBonus} bonus objectives completed. Total payout: {$totalReward} tickets
 salvage-mission-objective-failed-message = Salvage mission failed.

--- a/Resources/Prototypes/_FarHorizons/Salvage/mission_objective_targets.yml
+++ b/Resources/Prototypes/_FarHorizons/Salvage/mission_objective_targets.yml
@@ -41,3 +41,45 @@
         - !type:PlaySoundBehavior
           sound:
             collection: MetalBreak
+
+- type: entity
+  id: FolderSalvageMissionObjective
+  parent: BaseItem
+  name: Document folder
+  description: Secrets inside are meant to be forgotten.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/folders.rsi
+    layers:
+    - state: folder-colormap
+      color: "#3f3f3f"
+    - state: folder-base
+  - type: Item
+    sprite: Objects/Misc/folders.rsi
+    size: Small
+    shape: null
+  - type: Appearance
+  - type: Flammable
+    fireSpread: true
+    alwaysCombustible: true
+    damage:
+      types:
+        Heat: 1
+  - type: FireVisuals
+    sprite: Effects/fire.rsi
+    normalState: fire
+  - type: Damageable
+    damageModifierSet: Wood
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 30
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Ash:
+            min: 1
+            max: 4
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]

--- a/Resources/Prototypes/_FarHorizons/Salvage/mission_objectives.yml
+++ b/Resources/Prototypes/_FarHorizons/Salvage/mission_objectives.yml
@@ -32,9 +32,9 @@
   description: salvage-mission-objective-description-capture
   announcement: salvage-mission-objective-announcement-capture
   baseReward:
-    Easy: 800
-    Moderate: 950
-    Challenging: 1150
+    Easy: 1000
+    Moderate: 1150
+    Challenging: 1350
   numTargets:
     Easy: 1
     Moderate: 2
@@ -52,15 +52,36 @@
   description: salvage-mission-objective-description-rescue
   announcement: salvage-mission-objective-announcement-rescue
   baseReward:
-    Easy: 1000
-    Moderate: 1250
-    Challenging: 1450
+    Easy: 950
+    Moderate: 1100
+    Challenging: 1250
   numTargets:
     Easy: 2
     Moderate: 2
     Challenging: 3
   bonus: 300
   bonusCap: 3
+  allowedDungeons:
+    - Experiment
+    - LavaBrig
+    - SnowyLabs
+
+- type: salvageMissionObjective
+  id: MissionObjectivePurge
+  handlerId: "MissionObjectivePurgeHandler"
+  name: salvage-mission-objective-name-purge
+  description: salvage-mission-objective-description-purge
+  announcement: salvage-mission-objective-announcement-purge
+  baseReward:
+    Easy: 800
+    Moderate: 1050
+    Challenging: 1200
+  numTargets:
+    Easy: 4
+    Moderate: 5
+    Challenging: 6
+  bonus: 150
+  bonusCap: 2
   allowedDungeons:
     - Experiment
     - LavaBrig

--- a/Resources/Prototypes/_FarHorizons/Salvage/objective_handlers.yml
+++ b/Resources/Prototypes/_FarHorizons/Salvage/objective_handlers.yml
@@ -9,3 +9,7 @@
 - type: salvageMissionObjectiveHandler
   id: MissionObjectiveRescueHandler
   handler: !type:SalvageMissionRescue
+
+- type: salvageMissionObjectiveHandler
+  id: MissionObjectivePurgeHandler
+  handler: !type:SalvageMissionPurge


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
New salvage mission requiring you to find and destroy secret documents. Also some minor tweaks/fixes.

## Why we need to add this
I never intended to stop on just 3 missions

## Media (Video/Screenshots)
<img width="1161" height="547" alt="image" src="https://github.com/user-attachments/assets/d5c5e983-b3a9-43e3-9753-6cda89b23b37" />
<img width="290" height="242" alt="image" src="https://github.com/user-attachments/assets/39e78070-c7d9-468d-8a90-361615316ab9" />
<img width="524" height="138" alt="image" src="https://github.com/user-attachments/assets/93365d68-9330-4ef0-8481-fca2d867efd8" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: princess_gurchi
- add: New salvage mission: Purge. Find and burn secret records spread around the base and its former inhabitants' pockets
- tweak: Expedition computer's text about mission completion will now log in chat
- tweak: Buffed capture mission rewards
- tweak: Nerfed rescue mission rewards
- fix: Salvage expeditions that spawn bodies will no longer spawn naked people with borg names
