### PR TITLE
Don't spawn exped bodies with IDs

### DIFF
--- a/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionPurge.cs
+++ b/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionPurge.cs
@@ -58,7 +58,7 @@ public sealed partial class SalvageMissionPurge : BaseSalvageMissionObjectiveHan
             {
                 var slot = _pocketSlots[Rand.Next(_pocketSlots.Count)];
                 var damage = SalvageMissionRescue.RandomDamage(ProtoMan, Rand, 100, 200, 4);
-                var body = SalvageMissionRescue.SpawnRandomBody(ProtoMan, EntMan, Rand, pos, humanoid, metadata, state, damageable, factions, stationSpawning, selectedFaction, true, damage, true);
+                var body = SalvageMissionRescue.SpawnRandomBody(ProtoMan, EntMan, Rand, pos, humanoid, metadata, state, damageable, factions, stationSpawning, inventory, selectedFaction, true, damage, true);
                 if (!inventory.TryEquip(body, spawned, slot, force: true))
                     EntMan.DeleteEntity(body);
                 else{
@@ -76,7 +76,7 @@ public sealed partial class SalvageMissionPurge : BaseSalvageMissionObjectiveHan
             var item = _stuffProtos[Rand.Next(_stuffProtos.Count)];
 
             var damage = SalvageMissionRescue.RandomDamage(ProtoMan, Rand, 100, 200, 4);
-            var body = SalvageMissionRescue.SpawnRandomBody(ProtoMan, EntMan, Rand, pos, humanoid, metadata, state, damageable, factions, stationSpawning, selectedFaction, true, damage, true);
+            var body = SalvageMissionRescue.SpawnRandomBody(ProtoMan, EntMan, Rand, pos, humanoid, metadata, state, damageable, factions, stationSpawning, inventory, selectedFaction, true, damage, true);
             var itemEnt = EntMan.SpawnAtPosition(item, pos);
             if (!inventory.TryEquip(body, itemEnt, slot, force: true))
                 EntMan.DeleteEntity(itemEnt);

--- a/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionRescue.cs
+++ b/Content.Server/_FarHorizons/Salvage/Objectives/SalvageMissionRescue.cs
@@ -90,7 +90,7 @@ public sealed partial class SalvageMissionRescue : BaseSalvageMissionObjectiveHa
                 return;
 
             var damage = RandomDamage(ProtoMan, Rand, 100, 200, 4);
-            var body = SpawnRandomBody(ProtoMan, EntMan, Rand, pos, humanoid, metadata, state, damageable, factions, stationSpawning, selectedFaction, true, damage, true);
+            var body = SpawnRandomBody(ProtoMan, EntMan, Rand, pos, humanoid, metadata, state, damageable, factions, stationSpawning, inventory, selectedFaction, true, damage, true);
 
             if (Rand.Prob(0.4))
             {
@@ -118,6 +118,7 @@ public sealed partial class SalvageMissionRescue : BaseSalvageMissionObjectiveHa
         DamageableSystem? damageable = null,
         ISharedFactionManager? factions = null,
         StationSpawningSystem? stationSpawning = null,
+        InventorySystem? inventory = null,
         FactionPrototype? faction = null,
         bool dead = true,
         DamageSpecifier? damage = null,
@@ -159,6 +160,10 @@ public sealed partial class SalvageMissionRescue : BaseSalvageMissionObjectiveHa
             loadout.SetDefault(character, null, ProtoMan);
 
             stationSpawning.EquipRoleLoadout(ent, loadout, loadoutProto);
+
+            if (inventory != null)
+                if (inventory.TryUnequip(ent, "id", out var id, true, true))
+                    EntMan.DeleteEntity(id);
         }
 
         return ent;


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Removed IDs from spawned exped bodies

## Why we need to add this
so sec don't stress over dead sec suddenly appearing on station

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: princess_gurchi
- fix: Expedition bodies will no longer spawn with IDs
