### PR TITLE
fix heal modifier to no longer permanently alter healing sources

### DIFF
--- a/Content.Shared/_FarHorizons/Damage/UniversalHealModifierSystem.cs
+++ b/Content.Shared/_FarHorizons/Damage/UniversalHealModifierSystem.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Damage;
+
 namespace Content.Shared._FarHorizons.Damage;
 
 public sealed class UniversalHealModifierSystem : EntitySystem
@@ -11,8 +13,11 @@ public sealed class UniversalHealModifierSystem : EntitySystem
 
     private void OnHealModify(Entity<UniversalHealModifierComponent> ent, ref HealModifyEvent args)
     {
+        DamageSpecifier damage = new();
         foreach (var (key, value) in args.Damage.DamageDict)
             if (value < 0)
-                args.Damage.DamageDict[key] *= ent.Comp.Modifier;
+                damage.DamageDict[key] = value * ent.Comp.Modifier;
+
+        args.Damage = damage;
     }
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
an oopsie caused protogens to only heal from welding about 4 times a round

## Why we need to add this
bugfix

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: princess_gurchi
- fix: Fixed an issue causing each weld on a protogen to permanently cut healing effectiveness of welding in half
