### PR TITLE
Adds the Telecom (Trinary) Prototype for Mapping

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
@@ -282,4 +282,3 @@
     containers:
       key_slots:
       - EncryptionKeyCommand
-      - EncryptionKeyTrinary #FH

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Machines/telecomms.yml
@@ -1,0 +1,9 @@
+- type: entity
+  parent: TelecomServer
+  id: TelecomServerFilledTrinary
+  suffix: Trinary
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyTrinary


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Pretty much what it says on the tin.
Maps use manually filled telecom severs anyway so there wasn't much point in keeping it in the command telecom server.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.
-->
:cl: Killer Tamashi
- add: Added Telecom Server (Trinary)
- tweak: Removed Trinary from the Telecom Server (Command)