### PR TITLE
Language fix for IPC/Protogen/Silicons

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
@@ -7,7 +7,6 @@
   - type: LanguageKnowledge
     speaks:
     - GalacticCommon
-    - Machine
     - Trinary
     understands:
     - GalacticCommon

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
@@ -9,7 +9,6 @@
   - type: LanguageKnowledge
     speaks:
     - GalacticCommon
-    - Machine
     - Trinary
     understands:
     - GalacticCommon

--- a/Resources/Prototypes/_StarLight/Entities/Base/language.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Base/language.yml
@@ -24,6 +24,7 @@
       - VoxPidgin
       - Scratch
       - Thaveyan
+      - Trinary # Far Horizons
 
 - type: entity
   id: BaseBorgiLanguages
@@ -52,6 +53,7 @@
       - VoxPidgin
       - Scratch
       - Thaveyan
+      - Trinary # Far Horizons
       - Dog
 
 - type: entity
@@ -66,3 +68,4 @@
     understands:
     - GalacticCommon
     - Machine
+    - Trinary # Far Horizons


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Removes the ability for Protogen/IPC's to speak Machine. Adds the ability for Silicons to understand Trinary.

## Why we need to add this
Silicons are meant to understand every race-specific language. Given that Trinary is essentially still a machine language, I added it to the brain too seeing as it made sense. At the same time, it makes very little sense for IPC/Protogen to be able to speak both Machine and Trinary. They can still _understand_ Machine, but cannot speak it anymore. The end result is simple: Silicons of all kind can still understand one another, it's just some speak a slightly different language now.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: R3v3l4t1on
- remove: IPC/Protogen can no longer speak Machine. They can still understand it however.
- fix: Silicons can now understand Trinary.
