### PR TITLE
More Proot/IPC fixes

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -250,6 +250,9 @@
     - prefRoles: [ Changeling ]
       max: 3
       playerRatio: 15
+      blacklist: #FH
+        tags: #FH
+          - IPC #FH
       briefing:
         text: changeling-role-greeting
         color: Red
@@ -378,6 +381,8 @@
         components:
         - ZombieImmune
         - AntagImmune
+        tags: #FH
+          - IPC #FH
       briefing:
         text: zombie-patientzero-role-greeting
         color: Plum

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -48,6 +48,9 @@
     - prefRoles: [ Changeling ]
       max: 3
       playerRatio: 10
+      blacklist: #FH
+        tags: #FH
+          - IPC #FH
       lateJoinAdditional: true
       allowNonHumans: false
       multiAntagSetting: None
@@ -68,6 +71,9 @@
     definitions:
     - prefRoles: [ Vampire ]
       max: 7
+      blacklist: #FH
+        tags: #FH
+          - IPC #FH
       playerRatio: 10
       lateJoinAdditional: true
       allowNonHumans: false

--- a/Resources/Prototypes/_FarHorizons/Body/Prototypes/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Prototypes/protogen.yml
@@ -300,7 +300,7 @@
       - right leg
       - left leg
       organs:
-        heart: OrganProtogenHeart
+        heart: OrganProtoAvaliHeart
         lungs: OrganProtogenLungs
         stomach: OrganProtogenStomach
         liver: OrganProtogenLiver


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Just more fixes. Blacklists IPCs from Vamp/Zombies/Changelings as those are not roles you can be a "robot" in.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
fixes
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.
-->
:cl: Killer Tamashi
- fix: Fixed IPCs rolling incorrect antags (Vamp/II/Ling) you can still pick them in the menu, but the game won't select you as one.
- fix: Fixed Proto-Resomi being poisoned by Amox. Didn't have an Avali organ, they do now.