### PR TITLE
buff exped bonus rewards

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Salvage/mission_objectives.yml
+++ b/Resources/Prototypes/_FarHorizons/Salvage/mission_objectives.yml
@@ -18,7 +18,7 @@
     Easy: 2
     Moderate: 4
     Challenging: 6
-  bonus: 95
+  bonus: 225
   bonusCap: 4
   allowedDungeons:
     - Experiment
@@ -39,7 +39,7 @@
     Easy: 1
     Moderate: 2
     Challenging: 2
-  bonus: 75
+  bonus: 375
   bonusCap: 5
   allowedFactions:
     - Xenos
@@ -59,7 +59,7 @@
     Easy: 2
     Moderate: 2
     Challenging: 3
-  bonus: 300
+  bonus: 450
   bonusCap: 3
   allowedDungeons:
     - Experiment
@@ -80,7 +80,7 @@
     Easy: 4
     Moderate: 5
     Challenging: 6
-  bonus: 150
+  bonus: 275
   bonusCap: 2
   allowedDungeons:
     - Experiment


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Still trying to figure out exped missions place in the world. But after actually playing a few rounds, it does feel really unrewarding to catch 2 whole ass xenos and only get extra 150 tickets as reward. Or 4 extra crates for just 300-something.

## Why we need to add this
It makes no sense to actually do bonuses when they don't reward you

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: princess_gurchi
- tweak: Buffed bonus rewards from salvage missions across the board. They should no longer feel like a waste of time