### PR TITLE
Fix paramedic backpack loadout + tweak CMO backpack loadout

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_FarHorizons/Loadouts/loadout_groups.yml
@@ -24,12 +24,12 @@
   id: CMOBackpack
   name: loadout-group-cmo-backpack
   loadouts:
-    - ChemistBackpack
-    - ChemistSatchel
-    - ChemistDuffel
     - MedicalDoctorBackpack
     - MedicalDoctorSatchel
     - MedicalDoctorDuffel
+    - ChemistBackpack
+    - ChemistSatchel
+    - ChemistDuffel
     - ParamedicBackpack
     - ParamedicDuffel
     - ParamedicSatchel
@@ -239,7 +239,6 @@
 - type: loadoutGroup
   id: ParamedicBackpack
   name: loadout-group-paramedic-backpack
-  minLimit: 0
   loadouts:
     - ParamedicBackpack
     - ParamedicDuffel


### PR DESCRIPTION
## Short description
Fixes paramedics not having backpacks on the round start

## Why we need to add this
> fixes

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="748" height="706" alt="image" src="https://github.com/user-attachments/assets/94e54253-1b23-462c-9a21-94b71085d614" />
<img width="410" height="208" alt="image" src="https://github.com/user-attachments/assets/8df0097a-3e5c-4e9e-a503-1075c875fc82" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: FAR HORIZONS TEAM
- fix: Fixed paramedic backpack loadout on round start.
- tweak: set default CMO backpack to medical backpack.
-->
:cl: FAR HORIZONS TEAM
- fix: Fixed paramedic backpack loadout on round start.
- tweak: set default CMO backpack to medical backpack.
