### PR TITLE
skinwalker update

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Body/Organs/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Organs/ipc.yml
@@ -32,6 +32,14 @@
   - type: OrganVisualization
     layer: Eyes
     prototype: MobHumanoidEyes
+  - type: HumanoidEMPCompositeElement
+    effect:
+      stunAmount: 0.5
+      additionalEffects:
+        StatusEffectBlinded: 10.0
+      damageAmount:
+        types:
+          Shock: 1
 
 - type: entity
   id: OrganIPCTongue

--- a/Resources/Prototypes/_FarHorizons/Body/Parts/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Parts/ipc.yml
@@ -46,6 +46,15 @@
   - type: Sprite
     sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: "l_arm"
+  - type: HumanoidEMPCompositeElement
+    effect:
+      stunAmount: 0.25
+      dropItemsFrom:
+      - body_part_slot_left hand
+      damageAmount:
+        types:
+          Shock: 3
+          Heat: 1
 
 - type: entity
   id: RightArmIPC
@@ -55,6 +64,15 @@
   - type: Sprite
     sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: "r_arm"
+  - type: HumanoidEMPCompositeElement
+    effect:
+      stunAmount: 0.25
+      dropItemsFrom:
+      - body_part_slot_right hand
+      damageAmount:
+        types:
+          Shock: 3
+          Heat: 2
 
 - type: entity
   id: LeftHandIPC
@@ -64,6 +82,15 @@
   - type: Sprite
     sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: "l_hand"
+  - type: HumanoidEMPCompositeElement
+    effect:
+      stunAmount: 0.25
+      dropItemsFrom:
+      - body_part_slot_left hand
+      damageAmount:
+        types:
+          Shock: 3
+          Heat: 2
 
 - type: entity
   id: RightHandIPC
@@ -73,6 +100,15 @@
   - type: Sprite
     sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: "r_hand"
+  - type: HumanoidEMPCompositeElement
+    effect:
+      stunAmount: 0.25
+      dropItemsFrom:
+      - body_part_slot_right hand
+      damageAmount:
+        types:
+          Shock: 3
+          Heat: 1
 
 - type: entity
   id: LeftLegIPC
@@ -82,6 +118,17 @@
   - type: Sprite
     sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: "l_leg"
+  - type: HumanoidEMPCompositeElement
+    effect:
+      stunAmount: 0.25
+      knockdownAmount: 0.5
+      slowdownAmount: 2.5
+      walkSpeedModifier: 0.5
+      sprintSpeedModifier: 0.5
+      damageAmount:
+        types:
+          Shock: 3
+          Heat: 2
 
 - type: entity
   id: RightLegIPC
@@ -91,6 +138,17 @@
   - type: Sprite
     sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: "r_leg"
+  - type: HumanoidEMPCompositeElement
+    effect:
+      stunAmount: 0.25
+      knockdownAmount: 0.5
+      slowdownAmount: 2.5
+      walkSpeedModifier: 0.5
+      sprintSpeedModifier: 0.5
+      damageAmount:
+        types:
+          Shock: 3
+          Heat: 2
 
 - type: entity
   id: LeftFootIPC
@@ -100,6 +158,17 @@
   - type: Sprite
     sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: "l_foot"
+  - type: HumanoidEMPCompositeElement
+    effect:
+      stunAmount: 0.25
+      knockdownAmount: 0.5
+      slowdownAmount: 2.5
+      walkSpeedModifier: 0.5
+      sprintSpeedModifier: 0.5
+      damageAmount:
+        types:
+          Shock: 3
+          Heat: 1
 
 - type: entity
   id: RightFootIPC
@@ -109,3 +178,14 @@
   - type: Sprite
     sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: "r_foot"
+  - type: HumanoidEMPCompositeElement
+    effect:
+      stunAmount: 0.25
+      knockdownAmount: 0.5
+      slowdownAmount: 2.5
+      walkSpeedModifier: 0.5
+      sprintSpeedModifier: 0.5
+      damageAmount:
+        types:
+          Shock: 3
+          Heat: 1

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
@@ -234,23 +234,19 @@
     damage:
       groups:
         Brute: -30 # 10 for each type
+  - type: HumanoidEMPComposite # Composite effect will include HumanoidEMP values, but also collect values from all limbs/organs
   - type: HumanoidEMP
     effect:
-      stunAmount: 5.0
-      knockdownAmount: 2.0
-      slowdownAmount: 15.0
+      stunAmount: 2.5
+      slowdownAmount: 5.0
       walkSpeedModifier: 0.5
       sprintSpeedModifier: 0.5
-      dropItemsFrom:
-        - body_part_slot_right hand
-        - body_part_slot_left hand
       additionalEffects:
-        StatusEffectBlinded: 10.0
         StatusEffectIPCFanDisabled: 20.0
       damageAmount:
         types:
-          Shock: 30
-          Heat: 10
+          Shock: 2
+          Heat: 2
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Splits EMP damage IPCs take between each of their limbs, indirectly encouraging robots to augment themselves with human parts

## Why we need to add this
horrors beyond my comprehension

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: princess_gurchi
- tweak: Split EMP effects that IPCs take between all of their limbs. That means robots can augment themselves with human parts to be better protected against EMP