### PR TITLE
Armor cleanups and other stuff

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -23,6 +23,16 @@
     contents:
     - id: SmokingPipeFilledTobacco
     - id: FlippoEngravedLighter
+  - type: Armor #FH
+    modifiers: #FH
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
+      coefficients: #FH
+        Blunt: 0.70 #FH
+        Slash: 0.70 #FH
+        Piercing: 0.70 #FH
+        Heat: 0.80 #FH
   - type: ExplosionResistance
     damageCoefficient: 1 #its a coat. it doesnt do shit
 
@@ -36,6 +46,16 @@
     sprite: Clothing/OuterClothing/Coats/detective_grey.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Coats/detective_grey.rsi
+  - type: Armor #FH
+    modifiers: #FH
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
+      coefficients: #FH
+        Blunt: 0.70 #FH
+        Slash: 0.70 #FH
+        Piercing: 0.70 #FH
+        Heat: 0.80 #FH
 
 - type: entity
   parent: ClothingOuterCoatDetective

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -725,13 +725,16 @@
       - state: SEC-inhand-right
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
-        Blunt: 0.85
-        Slash: 0.75
-        Piercing: 0.95
-        Heat: 0.65
+        Blunt: 0.70 #FH
+        Slash: 0.70 #FH
+        Piercing: 0.70 #FH
+        Heat: 0.80 #FH
   - type: ExplosionResistance
-    damageCoefficient: 0.85
+    damageCoefficient: 0.9 #FH
   - type: Clothing
     sprite: Clothing/OuterClothing/WinterCoats/coat.rsi
     clothingVisuals:

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -56,6 +56,8 @@
     sprite: Clothing/Shoes/Boots/combatboots.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Boots/combatboots.rsi
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.5
 
 - type: entity
   parent: ClothingShoesMilitaryBase
@@ -159,6 +161,8 @@
     sprite: Clothing/Shoes/Boots/winterbootssec.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Boots/winterbootssec.rsi
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.5
 
 - type: entity
   parent: [ClothingShoesBaseWinterBoots, BaseSyndicateContraband]

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -390,6 +390,7 @@
   - SecurityBackpack
   - SecurityBelt
   - SecurityNonLethalWeapon #Starlight
+  - SecuritySidearm #FH
   - HeadofSecurityOuterClothing
   - SecurityEyewear
   - SecurityShoes
@@ -406,6 +407,7 @@
   - WardenJumpsuit
   - SecurityBackpack
   - SecurityBelt
+  - SecurityNonLethalWeapon #FH
   - WardenOuterClothing
   - SecurityEyewear
   - SecurityShoes
@@ -444,6 +446,7 @@
   - SecurityEyewear
   - DetectiveOuterClothing
   - DetectiveShoes # 🌟Starlight🌟
+  - SecurityNonLethalWeapon #FH
   - SurvivalSecurity
   - Trinkets
   - Scarves # Starlight

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -189,9 +189,16 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
+        Blunt: 0.9 #FH
+        Slash: 0.9 #FH
+        Piercing: 0.9 #FH
+  - type: Hailer #FH
+    hailMessage: "Death to NanoTrasen!!"
+    hailSound:
+      path: /Audio/_Starlight/Effects/nano_death.ogg
+      params:
+        variation: 0.09
+    cooldownDuration: 30
 
 # USSP
 - type: entity

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/armor.yml
@@ -269,6 +269,9 @@
     coolingCoefficient: 0.1
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.5
         Slash: 0.5
@@ -296,6 +299,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.6
         Slash: 0.6

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/coats.yml
@@ -178,6 +178,9 @@
     sprite: _Starlight/Clothing/OuterClothing/Coats/windbreaker_security
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.65
         Slash: 0.80
@@ -289,6 +292,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.4
         Slash: 0.4

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/coats.yml
@@ -152,13 +152,18 @@
     sprite: _Starlight/Clothing/OuterClothing/Coats/security_bomber.rsi
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
-        Blunt: 0.85
-        Slash: 0.75
-        Piercing: 0.95
-        Heat: 0.65
+        Blunt: 0.70 #FH
+        Slash: 0.70 #FH
+        Piercing: 0.70 #FH
+        Heat: 0.80 #FH
   - type: ExplosionResistance
-    damageCoefficient: 0.85
+    damageCoefficient: 0.90 #FH
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.75 #FH
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterSecurityBomber]
@@ -182,10 +187,12 @@
         Piercing: 5 #FH
         Heat: 4 #FH
       coefficients:
-        Blunt: 0.65
-        Slash: 0.80
-        Piercing: 0.70 
-        Heat: 0.90
+        Blunt: 0.70 #FH
+        Slash: 0.70 #FH
+        Piercing: 0.70 #FH
+        Heat: 0.80 #FH
+  - type: ExplosionResistance
+    damageCoefficient: 0.90 #FH
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.75
 

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -235,13 +235,13 @@
   - type: PressureProtection
     highPressureMultiplier: 0.525
     lowPressureMultiplier: 10000
-  - type: ClothingSpeedModifier
-    walkModifier: 1
-    sprintModifier: 1
   - type: Pierceable
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 4 #FH
+        Heat: 3 #FH
       coefficients:
         Blunt: 0.6
         Slash: 0.6
@@ -250,6 +250,9 @@
         Radiation: 0.6
         Caustic: 0.6
     staminaModifier: 0.3
+  - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: ToggleClothing
@@ -423,6 +426,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.5
         Slash: 0.5


### PR DESCRIPTION
Adding flat resists to armors and hardsuits that were missing them, tweaking Infiltrator hardsuit and adding missing loadout options for Detective, HoS and Warden.

## Short description
Flat resists for some armor and hardsuits, adding in some missing loadout options for security, tweaking Infiltrator hardsuit slightly while also giving it its missing flat resists. Combat and Sec winter boots now function as Jackboots, since they didnt do anything really before beside being somewhere to store a knife or gun.

## Why we need to add this
Keeping armors on par with one another, adding these loadout options to Det, HoS and Ward cus like, why not, HoS gets an MK (maybe add more options later that ARENT just DP and enforcer since those are direct upgrades rather than variants, options there), Det and Ward getting nonlethal options in loadout. Infiltrator hardsuit gets a slowdown because with its new flat resists it was literally just invis, no slowdown and very solid armor for 10TC.

## Media (Video/Screenshots)

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Roro
- tweak: Added flat resists to Detective coats, Infiltrator hardsuit, Experimental security hardsuit and other armors/coats so they can keep up with with existing armor values.
- tweak: Added nonlethal loadout options for Detective and Warden, as well as Sidearm option (just a MK58 anyway) for HoS.
- tweak: Added a 10% slowdown to Infiltrator hardsuit since it had none and having no slowdown on a hardsuit is silly, now more of a variant rather than a direct upgrade over the default bloodred.
- tweak: Added a hailer to Infiltrator hardsuit since it didnt have one.
- tweak: Combat boots and Sec winter boots are now effectively jackboots (less slowdown on lower health)
