### PR TITLE
fix access for miners + contra crate for salv

### DIFF
--- a/Resources/Maps/_FarHorizons/Shuttles/suggestedone9-NT-34-Expeditioneer.yml
+++ b/Resources/Maps/_FarHorizons/Shuttles/suggestedone9-NT-34-Expeditioneer.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 12/03/2025 18:25:07
-  entityCount: 437
+  time: 12/06/2025 11:11:46
+  entityCount: 439
 maps: []
 grids:
 - 2
@@ -1307,6 +1307,18 @@ entities:
     components:
     - type: Transform
       pos: -0.5,11.5
+      parent: 2
+- proto: CrateSalvageContrabandStorageSecure
+  entities:
+  - uid: 438
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 2
+  - uid: 439
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
       parent: 2
 - proto: CrateTrashCart
   entities:

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -652,7 +652,7 @@
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsSalvage ]
+      board: [ DoorElectronicsSalvageMining ] # Far Horizons temporary change until shuttles are resprited and we can use 3d doors
 
 - type: entity
   parent: AirlockMiningGlass
@@ -661,7 +661,7 @@
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsSalvage ]
+      board: [ DoorElectronicsSalvageMining ] # Far Horizons temporary change until shuttles are resprited and we can use 3d doors
 
 - type: entity
   parent: AirlockChemistryGlass


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Gives miners access to their own ship, gives salvagers contra crates

## Why we need to add this
fixes

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: FAR HORIZONS TEAM
- fix: Added mining access to old style doors that mining shuttle uses
- tweak: Added contra crates to new salvage shuttle. An important tool for catching fish.
