### PR TITLE
Tweak admin/staff chat role

### DIFF
--- a/Content.Server/Chat/Managers/ChatManager.cs
+++ b/Content.Server/Chat/Managers/ChatManager.cs
@@ -316,8 +316,11 @@ internal sealed partial class ChatManager : IChatManager
         }
 
         var clients = _adminManager.ActiveAdmins.Select(p => p.Channel);
+
+        var prefix = GetAdminTitle(player);
+        
         var wrappedMessage = Loc.GetString("chat-manager-send-admin-chat-wrap-message",
-                                        ("adminChannelName", Loc.GetString("chat-manager-admin-channel-name")),
+                                        ("adminChannelName", prefix),
                                         ("playerName", player.Name), ("message", FormattedMessage.EscapeText(message)));
 
         foreach (var client in clients)
@@ -436,6 +439,17 @@ internal sealed partial class ChatManager : IChatManager
         }
 
         return isOverLength;
+    }
+
+    // Far Horizons
+    public string GetAdminTitle(ICommonSession player)
+    {
+        // TODO: make FHManager and move this to it
+        var prefix = Loc.GetString("chat-manager-staff-channel-name");
+        var roles = _playerRoles.GetUserRoles(player.UserId);
+        if (roles != null && roles.Contains<ulong>(1407078784611385534))  // Game Admin role
+            prefix = Loc.GetString("chat-manager-admin-channel-name");
+        return prefix;
     }
 
     #endregion

--- a/Content.Server/Chat/Managers/IChatManager.cs
+++ b/Content.Server/Chat/Managers/IChatManager.cs
@@ -49,5 +49,7 @@ namespace Content.Server.Chat.Managers
         /// <param name="player">The player sending a chat message.</param>
         /// <returns>False if the player has violated rate limits and should be blocked from sending further messages.</returns>
         RateLimitStatus HandleRateLimit(ICommonSession player);
+
+        public string GetAdminTitle(ICommonSession player); // Far Horizons
     }
 }

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -40,6 +40,7 @@ using Content.Shared.Speech; // Starlight
 using Content.Server._Starlight.Language; // Starlight
 using Content.Shared._Starlight.Language; // Starlight
 using Content.Shared.Popups; // Starlight
+using Content.Server._NullLink.PlayerData;  // Far Horizons
 
 namespace Content.Server.Chat.Systems;
 
@@ -848,8 +849,9 @@ public sealed partial class ChatSystem : SharedChatSystem
         string wrappedMessage;
         if (_adminManager.IsAdmin(player))
         {
+            var prefix = _chatManager.GetAdminTitle(player);// Far Horizons
             wrappedMessage = Loc.GetString("chat-manager-send-admin-dead-chat-wrap-message",
-                ("adminChannelName", Loc.GetString("chat-manager-admin-channel-name")),
+                ("adminChannelName", prefix),  // Far Horizons
                 ("userName", player.Channel.UserName),
                 ("message", FormattedMessage.EscapeText(message)));
             _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Admin dead chat from {player:Player}: {message}");

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -50,7 +50,8 @@ chat-manager-send-hook-admin-wrap-message = ADMIN: [bold](D){$senderName}:[/bold
 
 chat-manager-dead-channel-name = DEAD
 #Far Horizons-Start Editing
-chat-manager-admin-channel-name = Staff
+chat-manager-admin-channel-name = Admin
+chat-manager-staff-channel-name = Staff
 #Far Horizons-End Editing
 
 chat-manager-rate-limited = You are sending messages too quickly!


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Admins are admins, and staff is staff now. But it will require using `addplayerrole username 1407078784611385534` on admins

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
I want to know who are admins in chat

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes, you must provide screenshots/videos of the changes.
-->
<img width="487" height="456" alt="image" src="https://github.com/user-attachments/assets/09483b90-db4c-4741-b607-ada0c816d44e" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: FAR HORIZONS TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: FAR HORIZONS TEAM
- tweak: Admins are admins and staff are staff in admin/dead chats.
