### PR TITLE
Nukie PDA fix, Bloodred magboots buff, Mining vendor addition and other stuff

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/syndiedrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/syndiedrobe.yml
@@ -15,6 +15,8 @@
     ClothingNeckScarfStripedSyndieGreen: 2
     ClothingNeckScarfStripedSyndieRed: 2
     ClothingShoesBootsWinterSyndicate: 2
+    ClothingBackpackSyndicate: 4 #FH edit
+    ClothingBackpackDuffelSyndicate: 4 #FH edit
   contrabandInventory:
     ToyFigurineFootsoldier: 1
     ToyFigurineNukieElite: 1

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -91,7 +91,7 @@
   parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseSyndicateContraband, ClothingShoesMilitaryBase] #FH edit
   id: ClothingShoesBootsMagSyndie
   name: blood-red magboots
-  description: Reverse-engineered magnetic boots that have a heavy magnetic pull and integrated thrusters. It can hold 0.75 L of gas.
+  description: Reverse-engineered magnetic boots that have a heavy magnetic pull and integrated thrusters. It can hold 0.75 L of gas. Has also been equipped with knife/small arms storage for Operatives on the go. #Far Horizons
   components:
   - type: Sprite
     sprite: Clothing/Shoes/Boots/magboots-syndicate.rsi

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -88,7 +88,7 @@
     price: 3000
 
 - type: entity
-  parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseSyndicateContraband]
+  parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseSyndicateContraband, ClothingShoesMilitaryBase] #FH edit
   id: ClothingShoesBootsMagSyndie
   name: blood-red magboots
   description: Reverse-engineered magnetic boots that have a heavy magnetic pull and integrated thrusters. It can hold 0.75 L of gas.
@@ -98,6 +98,8 @@
     state: icon
   - type: Clothing
     sprite: Clothing/Shoes/Boots/magboots-syndicate.rsi
+  - type: ClothingSlowOnDamageModifier #FH edit
+    modifier: 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -1131,7 +1131,7 @@
     - DoorBumpOpener
 
 - type: entity
-  parent: [ BasePDA, BaseSyndicateContraband ]
+  parent: [ BaseSyndiOperativePDA, BaseSyndicateContraband ] #FH edit
   id: SyndiPDA
   name: syndicate PDA
   description: Ok, time to be a productive member of- oh cool I'm a bad guy time to kill people!

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -1131,7 +1131,7 @@
     - DoorBumpOpener
 
 - type: entity
-  parent: [ BaseSyndiOperativePDA, BaseSyndicateContraband ] #FH edit
+  parent: [ BaseNukeOpsPDA, BaseSyndicateContraband ] #FH edit
   id: SyndiPDA
   name: syndicate PDA
   description: Ok, time to be a productive member of- oh cool I'm a bad guy time to kill people!

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -348,7 +348,7 @@
       params:
         variation: 0.12
   - type: RechargeBasicEntityAmmo
-    rechargeCooldown: 2
+    rechargeCooldown: 1 #FH edit
     rechargeSound:
       path: /Audio/Weapons/Guns/Bolt/lmg_bolt_closed.ogg
       params:

--- a/Resources/Prototypes/_FarHorizons/Catalog/VendingMachines/Inventories/mining.yml
+++ b/Resources/Prototypes/_FarHorizons/Catalog/VendingMachines/Inventories/mining.yml
@@ -11,3 +11,15 @@
   - !type:ListingLimitedStockCondition
     stock: 5
   - !type:BuyerAccessCondition
+
+- type: listing
+  id: VendorMiningPTK
+  productEntity: PTKFlatpack
+  cost:
+    SalvageTicket: 200
+  categories:
+  - MiningEquipment
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 4
+  - !type:BuyerAccessCondition

--- a/Resources/Prototypes/_FarHorizons/Catalog/VendingMachines/Inventories/mining.yml
+++ b/Resources/Prototypes/_FarHorizons/Catalog/VendingMachines/Inventories/mining.yml
@@ -16,7 +16,7 @@
   id: VendorMiningPTK
   productEntity: PTKFlatpack
   cost:
-    SalvageTicket: 200
+    SalvageTicket: 400
   categories:
   - MiningEquipment
   conditions:

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/flatpack.yml
@@ -23,3 +23,15 @@
     - state: large
   - type: Flatpack
     entity: Turbine
+
+- type: entity
+  parent: BaseFlatpack
+  id: PTKFlatpack
+  name: PTK-800 flatpack
+  description: A flatpack used for constructing a PTK-800 "Matter Dematerializer".
+  components:
+  - type: Flatpack
+    entity: ShuttleGunKinetic
+  - type: Sprite
+    layers:
+    - state: emitter

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/flatpack.yml
@@ -27,7 +27,7 @@
 - type: entity
   parent: BaseFlatpack
   id: PTKFlatpack
-  name: PTK-800 flatpack
+  name: PTK-800 Flatpack
   description: A flatpack used for constructing a PTK-800 "Matter Dematerializer".
   components:
   - type: Flatpack

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/pda.yml
@@ -123,7 +123,7 @@
   parent: [ BaseItem, StorePresetUplink ] 
   id: BaseSyndiOperativePDA
   name: evil syndicate PDA (no coords...)
-  description: EVIL Personal Data Assistant... it doesnt give you cancer...
+  description: Personal Data Assistant used by Nuclear Operatives... it doesn't give you cancer...
   components:
   - type: Appearance
     appearanceDataInit:

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/pda.yml
@@ -115,3 +115,130 @@
       whitelist:
         tags:
         - Write
+
+#SYNDI OPERATIVE PDA - needed for nukie pdas so they dont have sensors that show crew where they are
+
+- type: entity
+  abstract: true
+  parent: [ BaseItem, StorePresetUplink ] 
+  id: BaseSyndiOperativePDA
+  name: evil syndicate PDA (no coords...)
+  description: EVIL Personal Data Assistant... it doesnt give you cancer...
+  components:
+  - type: Appearance
+    appearanceDataInit:
+     enum.PdaVisuals.PdaType:
+       !type:String
+       pda
+  - type: Sprite
+    sprite: Objects/Devices/pda.rsi
+    layers:
+    - map: [ "enum.PdaVisualLayers.Base" ]
+      state: "pda"
+    - state: "light_overlay"
+      map: [ "enum.PdaVisualLayers.Flashlight" ]
+      shader: "unshaded"
+      visible: false
+    - state: "id_overlay"
+      map: [ "enum.PdaVisualLayers.IdLight" ]
+      shader: "unshaded"
+      visible: false
+  - type: Icon
+    sprite: Objects/Devices/pda.rsi
+    state: pda
+  - type: Pda
+    paiSlot:
+      priority: -2
+      whitelist:
+        components:
+        - PAI
+    penSlot:
+      startingItem: Pen
+      priority: -1
+      whitelist:
+        tags:
+        - Write
+    idSlot:
+      name: access-id-card-component-default
+      ejectSound: /Audio/Machines/id_swipe.ogg
+      insertSound: /Audio/Machines/id_insert.ogg
+      whitelist:
+        components:
+        - IdCard
+  - type: PdaVisuals
+  - type: Item
+    size: Small
+  - type: ContainerContainer
+    containers:
+      PDA-id: !type:ContainerSlot {}
+      PDA-pen: !type:ContainerSlot {}
+      PDA-pai: !type:ContainerSlot {}
+      Cartridge-Slot: !type:ContainerSlot {}
+      program-container: !type:Container
+  - type: ItemSlots
+  - type: Clothing
+    quickEquip: false
+    slots:
+    - idcard
+    - Belt
+  - type: UnpoweredFlashlight
+  - type: PointLight
+    enabled: false
+    radius: 1.7
+    falloff: 3
+    softness: 5
+    autoRot: true
+  - type: Ringer
+  - type: RingerUplink
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    prefix: device-address-prefix-console
+    savableAddress: false
+  - type: WirelessNetworkConnection
+    range: 1200 
+  - type: CartridgeLoader
+    uiKey: enum.PdaUiKey.Key
+    preinstalled:
+      - CrewManifestCartridge
+      - NotekeeperCartridge
+      - NanoTaskCartridge
+      - NewsReaderCartridge
+    cartridgeSlot:
+      priority: -1
+      name: device-pda-slot-component-slot-name-cartridge
+      ejectSound: /Audio/Machines/id_swipe.ogg
+      insertSound: /Audio/Machines/id_insert.ogg
+      whitelist:
+        components:
+          - Cartridge
+  - type: ActivatableUI
+    key: enum.PdaUiKey.Key
+    singleUser: true
+  - type: UserInterface
+    interfaces:
+      enum.PdaUiKey.Key:
+        type: PdaBoundUserInterface
+      enum.StoreUiKey.Key:
+        type: StoreBoundUserInterface
+      enum.RingerUiKey.Key:
+        type: RingerBoundUserInterface
+      enum.InstrumentUiKey.Key:
+        type: InstrumentBoundUserInterface
+      enum.HealthAnalyzerUiKey.Key:
+        type: HealthAnalyzerBoundUserInterface
+  - type: Tag
+    tags:
+    - DoorBumpOpener
+    - WhitelistChameleon
+    - WhitelistChameleonPDA
+  - type: Input
+    context: "human"
+  - type: SentienceTarget # sentient PDA = pAI lite
+    flavorKind: station-event-random-sentience-flavor-mechanical
+    weight: 0.001 # 1,000 PDAs = as likely to be picked as 1 regular animal
+  - type: BlockMovement
+    blockInteraction: false # lets the PDA toggle its own flashlight
+  - type: TypingIndicator
+    proto: robot
+  - type: Speech
+    speechVerb: Robotic

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/pda.yml
@@ -116,7 +116,7 @@
         tags:
         - Write
 
-#SYNDI OPERATIVE PDA - needed for nukie pdas so they dont have sensors that show crew where they are
+#Nuclear Operatives PDA - Needed for nukie pdas so they dont have sensors that show crew where they are
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/pda.yml
@@ -122,7 +122,8 @@
   abstract: true
   parent: [ BaseItem, StorePresetUplink ] 
   id: BaseSyndiOperativePDA
-  name: evil syndicate PDA (no coords...)
+  name: Nuclear Operative PDA
+  suffix: No Coordinates
   description: Personal Data Assistant used by Nuclear Operatives... it doesn't give you cancer...
   components:
   - type: Appearance

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/pda.yml
@@ -121,7 +121,7 @@
 - type: entity
   abstract: true
   parent: [ BaseItem, StorePresetUplink ] 
-  id: BaseSyndiOperativePDA
+  id: BaseNukeOpsPDA
   name: Nuclear Operative PDA
   suffix: No Coordinates
   description: Personal Data Assistant used by Nuclear Operatives... it doesn't give you cancer...


### PR DESCRIPTION
Fixed Nukie PDAs, Gave Bloodred Magboots the same slowdown reduction as jackboots/combat boots, can also store pistols and knives in them now too, added syndicate backpacks and duffelbags to syndiedrobe so nukies can use them, added PTK flatpack to mining ticket vendor because their shuttle starts with some anyway (and i was asked to while fixing the pdas)


## Short description
FIxed Nukie PDAs so they dont have coords, buffed bloodred magboots, they function as jackboots (less slow on low health and can hold pistols), added syndicate backpacks and duffelbags to syndiedrobe, 4 of each, added the PTK flatpack to mining ticket vendor for 400 credits (max of 4), made the PTK shoot faster too

## Why we need to add this
Nukie PDA bug fix, they were appearing as crew on the crew monitor and it fucked them over in at least 2 rounds, fixed now so their PDAs have no coords at all.

Buffed bloodred magboots so theyre more of an option over Noslips, giving them jackboot slow reduction also just kinda makes sense, theyre THE combat magboots, also having your viper in there is very nice.

Added syndicate backpacks to Syndiedrobe (duffels too but eh) so nukies can choose the option of less storage for no slowdown on their bag, same explosive resist as the duffel, syndiedrobe is north of starting room on the asteroid, in the dorms, in case you were unaware.

Added the PTK flatpack to mining ticket vendor because i was asked to and i see the logic, their shuttle starts with 2 already so this lets them upgrade their shuttle into a proper asteroid cracker. (made the PTK shoot faster so its more effective too)

## Media (Video/Screenshots)
<img width="512" height="334" alt="Screenshot 2025-12-13 174925" src="https://github.com/user-attachments/assets/a8e43f2b-550c-49d5-af23-26ce46065877" />
<img width="827" height="174" alt="Screenshot 2025-12-13 175010" src="https://github.com/user-attachments/assets/8bfafefb-b53f-4b81-ade6-4ebcec2472b6" />
<img width="497" height="761" alt="Screenshot 2025-12-13 175142" src="https://github.com/user-attachments/assets/7d80976c-bb64-4600-ab7d-ccd45332a66d" />
<img width="433" height="149" alt="Screenshot 2025-12-13 175020" src="https://github.com/user-attachments/assets/77ea85b6-b389-4acb-a978-80d135753a7d" />

## Checks


- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Roro
- add: Added PTK flatpacks to Mining ticket vendor so you can have more cannons for the shuttle (max of 4)
- tweak: Bloodred Magboots now have the added function of working like jackboots, less slowdown on low health and you can store pistols and knives in them
- tweak: Nukies can now get Syndicate backpacks in their Syndiedrobe, it offers less storage but no slowdown at all
- tweak: Made the PTK shuttle cannon shoot a lil faster
- fix: Nukies are no longer crew and dont show up on the crew monitor anymore
