### PR TITLE
remove shipwreck dungeon from desert biome

### DIFF
--- a/Resources/Prototypes/_StarLight/Procedural/salvage_mods.yml
+++ b/Resources/Prototypes/_StarLight/Procedural/salvage_mods.yml
@@ -31,7 +31,7 @@
   desc: salvage-dungeon-mod-soviet-stronghold
   proto: ShipWreckDungeon
   biomes:
-    - LowDesert # Far Horizons
+    #- LowDesert # Far Horizons
     - Grasslands
   difficulties: 
     - Challenging


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Hotfix removing this
<img width="1256" height="629" alt="image" src="https://github.com/user-attachments/assets/a388c5a1-c225-4cad-b3dd-7d9509ee3fb4" />

## Why we need to add this
looks kinda weird that oasises only appear in squares around shipwrecks

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: princess_gurchi
- tweak: removed shipwreck dungeon from desert biome because of grass floors