### PR TITLE
fix removing research from queue

### DIFF
--- a/Content.Client/_FarHorizons/Research/UI/FHResearchConsoleBUI.cs
+++ b/Content.Client/_FarHorizons/Research/UI/FHResearchConsoleBUI.cs
@@ -17,6 +17,7 @@ public sealed class FHResearchConsoleBoundUserInterface(EntityUid owner, Enum ui
     private HashSet<ProtoId<ResearchTreeNodePrototype>> _unlockedNodes = [];
     private HashSet<ProtoId<ResearchTreeNodePrototype>> _researchedNodes = [];
     private HashSet<ProtoId<ResearchTreeTierPrototype>> _unlockedTiers = [];
+    private List<ProtoId<ResearchTreeNodePrototype>> _queuedNodes = [];
     private bool _readonly = false;
 
     [ViewVariables]
@@ -36,6 +37,7 @@ public sealed class FHResearchConsoleBoundUserInterface(EntityUid owner, Enum ui
         {
             _window.OnResearchButtonPressed += SendReseachRequest;
             _window.OnRemoveQueueButtonPressed += SendRemoveFromQueueRequest;
+            _window.OnQuickResearch += QuickResearchRequest;
         }
     }
 
@@ -49,23 +51,34 @@ public sealed class FHResearchConsoleBoundUserInterface(EntityUid owner, Enum ui
             _researchedNodes = fullState.ResearchedNodes;
             _unlockedTiers = fullState.UnlockedTiers;
             _unlockedNodes = fullState.UnlockedNodes;
+            _queuedNodes = fullState.QueuedNodes;
             _readonly = fullState.Readonly;
 
             if (_readonly && _window != null)
             {
                 _window.OnResearchButtonPressed -= SendReseachRequest;
                 _window.OnRemoveQueueButtonPressed -= SendRemoveFromQueueRequest;
+                _window.OnQuickResearch -= QuickResearchRequest;
             }
             
-            _window?.SetupUI(_nodeProtos, _unlockedTiers, _unlockedNodes, _researchedNodes, fullState.QueuedNodes, fullState.ResearchProgress, fullState.BankedPoints, fullState.Readonly);
+            _window?.SetupUI(_nodeProtos, _unlockedTiers, _unlockedNodes, _researchedNodes, _queuedNodes, fullState.ResearchProgress, fullState.BankedPoints, fullState.Readonly);
         } else if (state is FHResearchConsoleBUIPartialState partialState)
         {
             _researchedNodes = partialState.ResearchedNodes;
             _unlockedTiers = partialState.UnlockedTiers;
             _unlockedNodes = partialState.UnlockedNodes;
+            _queuedNodes = partialState.QueuedNodes;
             
-            _window?.RefreshUI(_unlockedTiers, _unlockedNodes, _researchedNodes, partialState.QueuedNodes, partialState.ResearchProgress, partialState.BankedPoints);
+            _window?.RefreshUI(_unlockedTiers, _unlockedNodes, _researchedNodes, _queuedNodes, partialState.ResearchProgress, partialState.BankedPoints);
         }
+    }
+
+    private void QuickResearchRequest(ProtoId<ResearchTreeNodePrototype> node)
+    {
+        if (_queuedNodes.Contains(node))
+            SendRemoveFromQueueRequest(node);
+        else if (_unlockedNodes.Contains(node))
+            SendReseachRequest(node);
     }
 
     private void SendReseachRequest(ProtoId<ResearchTreeNodePrototype> node)

--- a/Content.Client/_FarHorizons/Research/UI/FHResearchConsoleWindow.xaml.cs
+++ b/Content.Client/_FarHorizons/Research/UI/FHResearchConsoleWindow.xaml.cs
@@ -27,6 +27,7 @@ public sealed partial class FHResearchConsoleWindow : FancyWindow
     public Action? OnServerButtonPressed;
     public Action<ProtoId<ResearchTreeNodePrototype>>? OnResearchButtonPressed;
     public Action<ProtoId<ResearchTreeNodePrototype>>? OnRemoveQueueButtonPressed;
+    public Action<ProtoId<ResearchTreeNodePrototype>>? OnQuickResearch;
 
     public FHResearchConsoleWindow()
     {
@@ -35,6 +36,7 @@ public sealed partial class FHResearchConsoleWindow : FancyWindow
 
         ServerButton.OnPressed += _ => OnServerButtonPressed?.Invoke();
         TreeDisplay.OnSelectionChanged += Selected;
+        TreeDisplay.OnQuickResearch += QuickResearch;
     }
 
     public void SetupUI(
@@ -137,6 +139,9 @@ public sealed partial class FHResearchConsoleWindow : FancyWindow
         UpdateRequirements();
         UpdateUnlocks();
     }
+
+    private void QuickResearch(ProtoId<ResearchTreeNodePrototype> node) =>
+        OnQuickResearch?.Invoke(node);
 
     private void ResearchNode(BaseButton.ButtonEventArgs args)
     {

--- a/Content.Client/_FarHorizons/Research/UI/FHResearchTree.xaml.cs
+++ b/Content.Client/_FarHorizons/Research/UI/FHResearchTree.xaml.cs
@@ -184,8 +184,16 @@ public sealed partial class FHResearchTree : BoxContainer
     {
         base.KeyBindUp(args);
 
-        if (args.Handled || 
-            !(args.Function == EngineKeyFunctions.UIClick || args.Function == ContentKeyFunctions.AltActivateItemInWorld))
+        if (args.Handled)
+            return;
+        
+        if (args.Function == ContentKeyFunctions.AltActivateItemInWorld && _hovered != null)
+        {
+            OnQuickResearch?.Invoke(_hovered.Value);
+            return;
+        }
+
+        if (args.Function != EngineKeyFunctions.UIClick)
             return;
 
         if (_search.AnyMouseOver)
@@ -207,9 +215,6 @@ public sealed partial class FHResearchTree : BoxContainer
         _selected = _hovered != null && _hovered == _willSelect ? _hovered : null;
         if (lastSelection != _selected)
             OnSelectionChanged?.Invoke(_selected);
-        
-        if (args.Function == ContentKeyFunctions.AltActivateItemInWorld && _hovered != null)
-            OnQuickResearch?.Invoke(_hovered.Value);
     }
     
     protected override void MouseWheel(GUIMouseWheelEventArgs args)

--- a/Content.Client/_FarHorizons/Research/UI/FHResearchTree.xaml.cs
+++ b/Content.Client/_FarHorizons/Research/UI/FHResearchTree.xaml.cs
@@ -12,6 +12,7 @@ using Content.Client._FarHorizons.Research.UI.Helpers;
 using Content.Client._FarHorizons.Research.UI.Helpers.Search;
 using System.Linq;
 using Robust.Shared.Timing;
+using Content.Shared.Input;
 
 namespace Content.Client._FarHorizons.Research.UI;
 
@@ -22,6 +23,7 @@ public sealed partial class FHResearchTree : BoxContainer
     [Dependency] private readonly IGameTiming _timing = default!;
 
     public Action<ProtoId<ResearchTreeNodePrototype>?>? OnSelectionChanged;
+    public Action<ProtoId<ResearchTreeNodePrototype>>? OnQuickResearch;
 
     private bool _moving = false;
     private bool _viewportReady = false;
@@ -182,7 +184,8 @@ public sealed partial class FHResearchTree : BoxContainer
     {
         base.KeyBindUp(args);
 
-        if (args.Handled || args.Function != EngineKeyFunctions.UIClick)
+        if (args.Handled || 
+            !(args.Function == EngineKeyFunctions.UIClick || args.Function == ContentKeyFunctions.AltActivateItemInWorld))
             return;
 
         if (_search.AnyMouseOver)
@@ -204,6 +207,9 @@ public sealed partial class FHResearchTree : BoxContainer
         _selected = _hovered != null && _hovered == _willSelect ? _hovered : null;
         if (lastSelection != _selected)
             OnSelectionChanged?.Invoke(_selected);
+        
+        if (args.Function == ContentKeyFunctions.AltActivateItemInWorld && _hovered != null)
+            OnQuickResearch?.Invoke(_hovered.Value);
     }
     
     protected override void MouseWheel(GUIMouseWheelEventArgs args)

--- a/Content.Server/_FarHorizons/Research/ResearchSystem.Tree.cs
+++ b/Content.Server/_FarHorizons/Research/ResearchSystem.Tree.cs
@@ -192,7 +192,15 @@ public sealed partial class FHResearchSystem
 
         if (!ent.Comp.Queue.Remove(node))
             return false;
-        ent.Comp.Queue = [.. ent.Comp.Queue.Intersect([.. GetUnlockedNodes((ent, ent.Comp))])];
+        
+        List<ProtoId<ResearchTreeNodePrototype>> toRemove = [];
+        foreach (var queuedNode in ent.Comp.Queue)
+        {
+            var nodeProto = _protoMan.Index(queuedNode);
+            if (nodeProto.DependencyChain(_protoMan).Any(p => p.ID == node))
+                toRemove.Add(queuedNode);
+        }
+        ent.Comp.Queue.RemoveAll(toRemove.Contains);
 
         RefreshUIOnClients(ent);
         return true;

--- a/Content.Shared/_FarHorizons/Research/ResearchTreeNodePrototype.cs
+++ b/Content.Shared/_FarHorizons/Research/ResearchTreeNodePrototype.cs
@@ -54,4 +54,13 @@ public sealed partial class ResearchTreeNodePrototype : IPrototype
 
     public List<ResearchTreeNodePrototype> Children(IPrototypeManager protoMan) =>
         [.. protoMan.EnumeratePrototypes<ResearchTreeNodePrototype>().Where(p => p.Requires.Contains(ID))];
+
+    public List<ResearchTreeNodePrototype> DependencyChain(IPrototypeManager protoMan)
+    {
+        List<ResearchTreeNodePrototype> dependencies = [.. Requires.Select(p => protoMan.Index(p))];
+        List<ResearchTreeNodePrototype> extras = [];
+        foreach (var dep in dependencies)
+            extras.AddRange(dep.DependencyChain(protoMan));
+        return [.. dependencies.Union(extras).Distinct()];
+    }
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Removing research from queue will correctly remove every single other research that has removed node in its chain of dependencies

## Why we need to add this
Bugfix

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/e74811dc-c066-4ff4-8861-22250fa1c392


https://github.com/user-attachments/assets/2ce2244f-212d-4b5b-8fd1-280605c37aa0


https://github.com/user-attachments/assets/06907a99-d15d-4ef0-9a56-5a5378cf3bc2



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: princess_gurchi
- add: Alt-click on research nodes in tree to quickly add/remove from queue
- fix: Removing research from queue now correctly removes all other research down the chain of dependencies