### PR TITLE
add cooldown for HumanoidEMP

### DIFF
--- a/Content.Server/_FarHorizons/Silicons/HumanoidEMP/HumanoidEMPSystem.cs
+++ b/Content.Server/_FarHorizons/Silicons/HumanoidEMP/HumanoidEMPSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared._FarHorizons.Silicons.HumanoidEMP;
 using Content.Shared.Damage;
 using Content.Shared.Movement.Systems;
 using Content.Shared.StatusEffectNew;
+using Robust.Shared.Timing;
 
 namespace Content.Server._FarHorizons.Silicons.HumanoidEMP;
 
@@ -17,25 +18,29 @@ public sealed partial class HumanoidEMPSystem : EntitySystem
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly StatusEffectsSystem _status = default!;
     [Dependency] private readonly HandsSystem _hands = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<HumanoidEMPComponent, EmpPulseEvent>(OnHumanoidEMP);
-        SubscribeLocalEvent<HumanoidEMPCompositeComponent, EmpPulseEvent>(OnHumanoidEMPComposite);
     }
 
     private void OnHumanoidEMP(Entity<HumanoidEMPComponent> ent, ref EmpPulseEvent args)
     {
         if (args.Disabled)
             return;
+        
+        if (_timing.CurTime < ent.Comp.NextEffect)
+            return;
+        
+        ent.Comp.NextEffect = _timing.CurTime + ent.Comp.EffectCooldown;
 
-        ApplyEffect(ent, ent.Comp.Effect);
-    }
-    private void OnHumanoidEMPComposite(Entity<HumanoidEMPCompositeComponent> ent, ref EmpPulseEvent args)
-    {
-        if (!args.Disabled)
-            ApplyEffect(ent, CompositeEffect(ent));
+        var effect = ent.Comp.Effect;
+        if (TryComp(ent, out HumanoidEMPCompositeComponent? composite))
+            effect = CompositeEffect((ent, composite));
+
+        ApplyEffect(ent, effect);
     }
 
     public HumanoidEMPEffect CompositeEffect(Entity<HumanoidEMPCompositeComponent> ent)

--- a/Content.Shared/_FarHorizons/Silicons/HumanoidEMP/HumanoidEMPComponent.cs
+++ b/Content.Shared/_FarHorizons/Silicons/HumanoidEMP/HumanoidEMPComponent.cs
@@ -64,7 +64,12 @@ public sealed partial class HumanoidEMPComponent : Component
 {
     [DataField]
     [AutoNetworkedField]
-    public HumanoidEMPEffect Effect;
+    public HumanoidEMPEffect Effect = new();
+
+    [DataField]
+    public TimeSpan EffectCooldown = TimeSpan.FromSeconds(0);
+
+    public TimeSpan NextEffect = TimeSpan.FromSeconds(0);
 }
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -304,7 +304,9 @@
   - type: FireVisuals
     alternateState: Standing
   - type: StunVisuals
-  - type: HumanoidEMPComposite # Far Horizons - just like HumanoidEMP, except the effect is combined from HumanoidEMPCompositeElement components on all limbs and organs
+  - type: HumanoidEMP # Far Horizons - HumanoidEMP is needed to receive EMP effects, it may carry its own innate effects, but doesn't have to
+    effectCooldown: 2
+  - type: HumanoidEMPComposite # Far Horizons - HumanoidEMPComposite is used to gather EMP effects from HumanoidEMPCompositeElement components on all limbs and organs. These effects added in addition to effects in HumanoidEMP and won't work without it
 
 - type: entity
   save: false

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
@@ -234,8 +234,9 @@
     damage:
       groups:
         Brute: -30 # 10 for each type
-  - type: HumanoidEMPComposite # Composite effect will include HumanoidEMP values, but also collect values from all limbs/organs
-  - type: HumanoidEMP
+  - type: HumanoidEMPComposite # HumanoidEMPComposite is used to gather EMP effects from HumanoidEMPCompositeElement components on all limbs and organs. These effects added in addition to effects in HumanoidEMP and won't work without it
+  - type: HumanoidEMP # HumanoidEMP is needed to receive EMP effects, it may carry its own innate effects, but doesn't have to
+    effectCooldown: 2
     effect:
       stunAmount: 2.5
       slowdownAmount: 5.0

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
@@ -101,7 +101,8 @@
       enum.InstrumentUiKey.Key:
         type: InstrumentBoundUserInterface
         requireInputValidation: false
-  - type: HumanoidEMP
+  - type: HumanoidEMP # HumanoidEMP is needed to receive EMP effects, it may carry its own innate effects, but doesn't have to
+    effectCooldown: 2
     effect:
       stunAmount: 5.0
       knockdownAmount: 2.0
@@ -925,7 +926,8 @@
         enum.InstrumentUiKey.Key:
           type: InstrumentBoundUserInterface
           requireInputValidation: false
-    - type: HumanoidEMP
+    - type: HumanoidEMP # HumanoidEMP is needed to receive EMP effects, it may carry its own innate effects, but doesn't have to
+      effectCooldown: 2
       effect:
         stunAmount: 5.0
         knockdownAmount: 2.0


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adding a short cooldown for humanoid EMP effects. Assuming cooldown stays around the same time as disabling power of EMP, it will not reduce overall EMP effectiveness, but reduce frustration that players get when they go from full health to death within 10 server ticks.

## Why we need to add this
Balancing concerns

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/7338c3ae-5f6c-445f-9c07-9aaf9482082e



## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: princess_gurchi
- tweak: Added 2 second cooldown on EMP effects that humanoids receive. That includes IPC, Protogens and anyone with cybernetics.