### PR TITLE
Netrunner Interaction Disabling

### DIFF
--- a/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
+++ b/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.Starlight.Antags.Abductor;
+using Content.Shared._Starlight.Railroading; /// Far Horizons -  You try finding a component that can be paired with AIEye so Netrunners stop interacting with the station.
 using Content.Shared.Silicons.StationAi;
 using Content.Shared.Body.Events;
 using Content.Shared.Emoting;
@@ -86,7 +87,7 @@ namespace Content.Shared.ActionBlocker
             if (!CanConsciouslyPerformAction(user))
                 return false;
             
-            if (HasComp<StationAiOverlayComponent>(user) && HasComp<AbductorScientistComponent>(user) || HasComp<StationAiOverlayComponent>(user) && HasComp<AbductorAgentComponent>(user))
+            if (HasComp<StationAiOverlayComponent>(user) && HasComp<AbductorScientistComponent>(user) || HasComp<StationAiOverlayComponent>(user) && HasComp<AbductorAgentComponent>(user) || HasComp<StationAiOverlayComponent>(user) && HasComp<RailroadableComponent>(user)) /// Far Horizons - Added StationAIOverlay and Railroadable to stop people using the netrunner eye to mess up station.
                 return false;
 
             var ev = new InteractionAttemptEvent(user, target);

--- a/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
+++ b/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
@@ -1,5 +1,5 @@
 ﻿using Content.Shared.Starlight.Antags.Abductor;
-using Content.Shared._Starlight.Railroading; /// Far Horizons -  You try finding a component that can be paired with AIEye so Netrunners stop interacting with the station.
+using Content.Shared._Starlight.Railroading; /// Far Horizons -  You try finding a component that can be paired with AIEye so Netrunners stop interacting with the station that the AI doesn't also share.
 using Content.Shared.Silicons.StationAi;
 using Content.Shared.Body.Events;
 using Content.Shared.Emoting;


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Currently we don't have a good way of countering Netrunners being able to interact with the station through their remote eye. (Ideas in the making for later down the road to do such a thing).
So this is disabling their ability to interact with anything currently. They can still see through the camera/eye, just no touching anything.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Because people got a little too silly. It doesn't make for a fun experience when they can interact with anything and everything, including power sources that engineering then have to watch constantly.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
### Before

https://github.com/user-attachments/assets/12b70819-c16c-43b1-b418-938a86810526


### After

https://github.com/user-attachments/assets/96e5dd7e-8499-4c34-9bae-35afdef9bad2


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: CorruptOmega
- tweak: NanoTrasen has updated their network firewalls so that Netrunners can no longer interact with everything on station.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: FAR HORIZONS TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
