### PR TITLE
Fix Nuclear Reactor Dungeon's Prototypes

### DIFF
--- a/Resources/Maps/_FarHorizons/Dungeon/Reactor/reactor_main_rooms.yml
+++ b/Resources/Maps/_FarHorizons/Dungeon/Reactor/reactor_main_rooms.yml
@@ -10605,37 +10605,29 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 43.5,2.5
       parent: 1
-- proto: NuclearReactorRandom
+- proto: NuclearReactorRandomSalvage
   entities:
   - uid: 3
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-    missingComponents:
-    - AccessReader
   - uid: 211
     components:
     - type: Transform
       pos: 26.5,6.5
       parent: 1
-    missingComponents:
-    - AccessReader
   - uid: 384
     components:
     - type: Transform
       pos: 8.5,17.5
       parent: 1
-    missingComponents:
-    - AccessReader
   - uid: 594
     components:
     - type: Transform
       pos: 35.5,3.5
       parent: 1
-    missingComponents:
-    - AccessReader
-- proto: NuclearReactorSmallRandom
+- proto: NuclearReactorSmallRandomSalvage
   entities:
   - uid: 595
     components:
@@ -10655,18 +10647,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 18.5,19.5
       parent: 1
-    - type: AccessReader
-      accessListsOriginal:
-      - - Engineering
   - uid: 2316
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 28.5,19.5
       parent: 1
-    - type: AccessReader
-      accessListsOriginal:
-      - - Engineering
 - proto: PillCanisterPotassiumIodide
   entities:
   - uid: 949


### PR DESCRIPTION
## Short description
What it says on the tin

## Why we need to add this
Stops the five hundred ghost warp points from the dungeon, and allows salvage to actually interact with them

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: jhrushbe
- tweak: The nuclear reactors found in salvage expeditions are no longer locked.
- fix: Fixed the reactor dungeon creating a ton of ghost warp points.
