### PR TITLE
Add horrific necktie as an loadout option for det mains

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1395,6 +1395,7 @@
   minLimit: 0
   loadouts:
   - DetectiveTie
+  - DetectiveHorrificNecktie
 
 - type: loadoutGroup
   id: DetectiveJumpsuit

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1395,7 +1395,7 @@
   minLimit: 0
   loadouts:
   - DetectiveTie
-  - DetectiveHorrificNecktie
+  - DetectiveHorrificNecktie #Far Horizons
 
 - type: loadoutGroup
   id: DetectiveJumpsuit

--- a/Resources/Prototypes/_FarHorizons/Loadouts/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/_FarHorizons/Loadouts/Jobs/Security/detective.yml
@@ -30,3 +30,11 @@
     - SpeedLoaderMagnumSP
     - SpeedLoaderMagnumSP
     - SpeedLoaderMagnumRubber
+
+- type: loadout
+  id: DetectiveHorrificNecktie
+  equipment:
+    neck: ClothingNeckHorrific
+  effects:
+    - !type:GroupLoadoutEffect
+      proto: MasterDet


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Horrific necktie (disco elysium reference) is now available for det mains as a loadout option

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Community request, and it seems to enrich the RP

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1173" height="244" alt="image" src="https://github.com/user-attachments/assets/5f205d97-e543-4577-b62c-d0dd1b9c261b" />
<img width="245" height="139" alt="image" src="https://github.com/user-attachments/assets/f5b00b14-9975-4e24-84b6-ff9d7af24d97" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: FAR HORIZONS TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: FAR HORIZONS TEAM
- add: Added horrific necktie as a loadout option for master detective.
