### PR TITLE
Ports SL #2744 to FH Oasis

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Maps/oasis.yml
+++ b/Resources/Prototypes/_FarHorizons/Maps/oasis.yml
@@ -2,7 +2,8 @@
   id: FHOasis
   mapName: 'Oasis'
   mapPath: /Maps/_FarHorizons/Stations/Oasis.yml
-  minPlayers: 65
+  minPlayers: 50
+  maxPlayers: 150
   stations:
     StarlightOasis:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Ports https://github.com/ss14Starlight/space-station-14/pull/2744 to the FH oasis map.

## Why we need to add this
Required for the upstream merge. I refactored disposal behaviour on SL, which broke Oasis. So, I fixed it there. We're getting those same changes, so I fixed it here.

## Media (Video/Screenshots)
P A I N

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: R3v3l4t1on
- tweak: Changed Oasis' disposals to work with upstream.
- tweak: The 3 SMES banks are now connected to one another (meaning all engines can contribute to every SMES bank. TL;DR it's less janky)
- tweak: The toilets on Oasis can now have loot in them
- tweak: Lowered Oasis minpop to 50, maxpop to 150 (irrelevant for now but upstream parity)
- fix: Fixed the position of a camera in the main engine chamber that could obstruct an emitter if one decided to build Tesla
- fix: Oasis distro/waste pipes now use the same colours as the ones on the spray painter.
