### PR TITLE
fix anom replacing actions

### DIFF
--- a/Content.Server/Anomaly/Effects/InnerBodyAnomalySystem.FarHorizons.cs
+++ b/Content.Server/Anomaly/Effects/InnerBodyAnomalySystem.FarHorizons.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using Content.Shared.Actions;
+using Robust.Shared.Prototypes;
+using static Robust.Shared.Prototypes.EntityPrototype;
+
+namespace Content.Server.Anomaly.Effects;
+
+public sealed partial class InnerBodyAnomalySystem
+{
+    [Dependency] private readonly ActionGrantSystem _actionGrant = default!;
+
+    private void AddComponentsCarefully(EntityUid target, ComponentRegistry components)
+    {
+        foreach (var comp in components)
+        {
+            switch(comp.Key) 
+            {
+                case "ActionGrant":
+                    if (comp.Value.Component is ActionGrantComponent actionGrantComp)
+                        HandleActionGrantAdd(target, actionGrantComp);
+                    break;
+                default: 
+                    EntityManager.AddComponent(target, comp.Value);
+                    break;
+            }
+        }
+    }
+
+    private void RemoveComponentsCarefully(EntityUid target, ComponentRegistry components)
+    {
+        foreach (var comp in components)
+        {
+            switch(comp.Key) 
+            {
+                case "ActionGrant":
+                    if (comp.Value.Component is ActionGrantComponent actionGrantComp)
+                        HandleActionGrantRemove(target, actionGrantComp);
+                    break;
+                default: 
+                    EntityManager.RemoveComponent(target, comp.Value.Component);
+                    break;
+            }
+        }
+    }
+
+    private void HandleActionGrantAdd(EntityUid target, ActionGrantComponent component)
+    {
+        if (!TryComp<ActionGrantComponent>(target, out var comp))
+        {
+            EntityManager.AddComponent(target, component);
+            return;
+        }
+
+        _actionGrant.AddActions((target, comp), component.Actions);
+    }
+
+    private void HandleActionGrantRemove(EntityUid target, ActionGrantComponent component)
+    {
+        if (!TryComp<ActionGrantComponent>(target, out var comp))
+        {
+            EntityManager.AddComponent(target, component);
+            return;
+        }
+
+        _actionGrant.RemoveActions((target, comp), component.Actions);
+    }
+}

--- a/Content.Server/Anomaly/Effects/InnerBodyAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/InnerBodyAnomalySystem.cs
@@ -20,7 +20,8 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.Anomaly.Effects;
 
-public sealed class InnerBodyAnomalySystem : SharedInnerBodyAnomalySystem
+// Far Horizons - made partial
+public sealed partial class InnerBodyAnomalySystem : SharedInnerBodyAnomalySystem
 {
     [Dependency] private readonly IAdminLogManager _adminLog = default!;
     [Dependency] private readonly AnomalySystem _anomaly = default!;
@@ -94,7 +95,7 @@ public sealed class InnerBodyAnomalySystem : SharedInnerBodyAnomalySystem
 
         ent.Comp.Injected = true;
 
-        EntityManager.AddComponents(ent, injectedAnom.Components);
+        AddComponentsCarefully(ent, injectedAnom.Components); // Far Horizons
 
         _stun.TryUpdateParalyzeDuration(ent, TimeSpan.FromSeconds(ent.Comp.StunDuration));
         _jitter.DoJitter(ent, TimeSpan.FromSeconds(ent.Comp.StunDuration), true);
@@ -211,7 +212,7 @@ public sealed class InnerBodyAnomalySystem : SharedInnerBodyAnomalySystem
             return;
 
         if (_proto.Resolve(ent.Comp.InjectionProto, out var injectedAnom))
-            EntityManager.RemoveComponents(ent, injectedAnom.Components);
+            RemoveComponentsCarefully(ent, injectedAnom.Components); // Far Horizons
 
         _stun.TryUpdateParalyzeDuration(ent, TimeSpan.FromSeconds(ent.Comp.StunDuration));
 

--- a/Content.Shared/Actions/ActionGrantSystem.FarHorizons.cs
+++ b/Content.Shared/Actions/ActionGrantSystem.FarHorizons.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Actions;
+
+public sealed partial class ActionGrantSystem
+{
+
+    public void AddAction(Entity<ActionGrantComponent> ent, EntProtoId action)
+    {
+        List<EntProtoId> actions = [];
+        actions.Add(action);
+        AddActions(ent, actions);
+    }
+
+    public void AddActions(Entity<ActionGrantComponent> ent, List<EntProtoId> actions)
+    {
+        var newActions = ent.Comp.Actions.Union(actions).ToList();
+        if (newActions == ent.Comp.Actions)
+            return;
+        
+        ActionGrantComponent combinedComp = new()
+        {
+            Actions = newActions
+        };
+
+        EntityManager.RemoveComponent<ActionGrantComponent>(ent);
+        EntityManager.AddComponent(ent, combinedComp);
+    }
+
+    public void RemoveAction(Entity<ActionGrantComponent> ent, EntProtoId action)
+    {
+        List<EntProtoId> actions = [];
+        actions.Add(action);
+        RemoveActions(ent, actions);
+    }
+        
+    public void RemoveActions(Entity<ActionGrantComponent> ent, List<EntProtoId> actions)
+    {
+        var newActions = ent.Comp.Actions.Except(actions).ToList();
+        if (newActions == ent.Comp.Actions)
+            return;
+
+        ActionGrantComponent decomposedComp = new()
+        {
+            Actions = newActions
+        };
+
+        EntityManager.RemoveComponent<ActionGrantComponent>(ent);
+        EntityManager.AddComponent(ent, decomposedComp);
+    }
+}

--- a/Content.Shared/Actions/ActionGrantSystem.cs
+++ b/Content.Shared/Actions/ActionGrantSystem.cs
@@ -5,7 +5,8 @@ namespace Content.Shared.Actions;
 /// <summary>
 /// <see cref="ActionGrantComponent"/>
 /// </summary>
-public sealed class ActionGrantSystem : EntitySystem
+/// Far Horizons - made partial
+public sealed partial class ActionGrantSystem : EntitySystem
 {
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly ActionContainerSystem _actionContainer = default!;


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Every time a mob gets infected with anom, it would replace all of the action that `ActionGrandComponent` might have been giving to it. Such as IPC/Protogen music player or borgi's laws.

## Why we need to add this
bugfix

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/92b1f74d-eb3e-4c48-b2b7-a254285238ce


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: princess_gurchi
- fix: Getting infected with an anomaly is no longer removing actions from your character (IPC and protogen music player, borgi action to view laws)