### PR TITLE
radio touchup

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioSystem.FarHorizons.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.FarHorizons.cs
@@ -1,0 +1,17 @@
+using Content.Shared.GameTicking;
+using Content.Shared.Radio;
+
+namespace Content.Server.Radio.EntitySystems;
+
+public sealed partial class RadioSystem
+{
+    [Dependency] private readonly SharedGameTicker _ticker = default!;
+
+    private string ObfuscateName(RadioChannelPrototype channel, EntityUid source)
+    {
+        int hash = HashCode.Combine(source, _ticker.RoundId); // Unique value per character per round
+        hash = Math.Abs(hash);
+        hash = hash % 900 + 100; // result is a number 100-999
+        return string.Format(channel.AnonymousAlias, hash);
+    }
+} 

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -293,6 +293,10 @@ public sealed partial class RadioSystem : EntitySystem
             languageColor = Color.InterpolateBetween(Color.White, colorOverride, colorOverride.A); // Changed first param to Color.White so it shows color correctly.
 
         var (iconId, jobName) = GetJobIcon(source);
+        // Far Horizons
+        if (channel.Anonymous)
+            (iconId, jobName) = (channel.AnonymousIcon, "");
+
 
         var namestring = $"[icon src=\"{iconId}\" tooltip=\"{jobName}\"] {name}";
         if (_language.GetLanguageIcon(language, obfuscated))

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -40,7 +40,8 @@ namespace Content.Server.Radio.EntitySystems;
 /// <summary>
 ///     This system handles intrinsic radios and the general process of converting radio messages into chat messages.
 /// </summary>
-public sealed class RadioSystem : EntitySystem
+/// Far Horizons - made partial
+public sealed partial class RadioSystem : EntitySystem
 {
     [Dependency] private readonly INetManager _netMan = default!;
     [Dependency] private readonly IReplayRecordingManager _replay = default!;
@@ -138,6 +139,11 @@ public sealed class RadioSystem : EntitySystem
         RaiseLocalEvent(messageSource, evt);
 
         var name = evt.VoiceName;
+
+        // Far Horizons
+        if (channel.Anonymous)
+            name = ObfuscateName(channel, messageSource);
+
         if (string.IsNullOrEmpty(name))
             name = entityName;
         if (name == null)

--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -1,3 +1,4 @@
+using Content.Shared.StatusIcon;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Radio;
@@ -42,5 +43,8 @@ public sealed partial class RadioChannelPrototype : IPrototype
 
     [DataField]
     public string AnonymousAlias = "Anonymous";
+
+    [DataField]
+    public ProtoId<JobIconPrototype> AnonymousIcon = "JobIconNoId";
     // Far Horizons end
 }

--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -35,4 +35,12 @@ public sealed partial class RadioChannelPrototype : IPrototype
     /// </summary>
     [DataField("longRange"), ViewVariables]
     public bool LongRange = false;
+
+    // Far Horizons start
+    [DataField]
+    public bool Anonymous = false;
+
+    [DataField]
+    public string AnonymousAlias = "Anonymous";
+    // Far Horizons end
 }

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -19,7 +19,7 @@
     - id: SalvageShuttleConsoleCircuitboard #starlight
     - id: ShipLabeler # Far Horizons
     - id: MiningShuttleConsoleCircuitboard #starlight
-    - id: EncryptionKeySalvage #starlight
+    # - id: EncryptionKeySalvage # Far Horizons - removed
     - id: PrintedDocumentGreenshiftAlert #SL
       conditions: #SL
       - !type:GamemodeCondition #SL
@@ -90,7 +90,7 @@
     - id: SpaceCash1000
     - id: ClothingEyesGlassesCommand
     - id: ClothingEyesHudCommand
-    - id: EncryptionKeyExpedition #starlight
+    # - id: EncryptionKeyExpedition # Far Horizons - removed
     - id: HeadSkeleton # A skull to accompany your skeleton crew
       conditions:
       - !type:PlayerCountCondition

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -71,7 +71,7 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyExpedition # Starlight
+      # - EncryptionKeyExpedition # Far Horizons - removed
       - EncryptionKeyCargo
       - EncryptionKeyCommand
       - EncryptionKeyCommon

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -18,7 +18,7 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyExpedition # Starlight
+      # - EncryptionKeyExpedition # Far Horizons - removed
       - EncryptionKeyCargo
       - EncryptionKeyCommand
       - EncryptionKeyCommon

--- a/Resources/Prototypes/_FarHorizons/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_FarHorizons/Catalog/Fills/Lockers/heads.yml
@@ -99,7 +99,7 @@
     - id: SpaceCash1000
     - id: ClothingEyesGlassesCommandSyndi
     - id: ClothingEyesHudCommandSyndi
-    - id: EncryptionKeyExpedition
+    - id: EncryptionKeyCargo # Far Horizons - replaced with cargo key
     - id: HeadSkeleton
       conditions:
       - !type:PlayerCountCondition

--- a/Resources/Prototypes/_StarLight/Admeme/neomoth/skubmoth.yml
+++ b/Resources/Prototypes/_StarLight/Admeme/neomoth/skubmoth.yml
@@ -21,9 +21,9 @@
       voice: alvinjr
     - type: IntrinsicRadioReceiver
     - type: IntrinsicRadioTransmitter
-      channels: [Common, CentCom, Command, Engineering, Medical, Science, Security, Service, Supply, Law, Binary, Expedition, Freelance, Xenoborg, Soviet, Mothership, Syndicate]
+      channels: [Common, CentCom, Command, Engineering, Medical, Science, Security, Service, Supply, Law, Binary, Freelance, Xenoborg, Soviet, Mothership, Syndicate] # Far Horizons - removed expedition
     - type: ActiveRadio
-      channels: [Common, CentCom, Command, Engineering, Medical, Science, Security, Service, Supply, Law, Binary, Expedition, Freelance, Xenoborg, Soviet, Mothership, Syndicate]
+      channels: [Common, CentCom, Command, Engineering, Medical, Science, Security, Service, Supply, Law, Binary, Freelance, Xenoborg, Soviet, Mothership, Syndicate] # Far Horizons - removed expedition
     
 - type: entity
   parent: ClothingBackpack

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Boxes/general.yml
@@ -16,27 +16,29 @@
           amount: 2
 # Fashion-O-Mat-End
 
+# Far Horizons - removed
 # Expedition Encryption Keys
-- type: entity
-  name: expedition encryption key box
-  parent: BoxEncryptionKeyAssistant
-  id: BoxEncryptionKeyExpedition
-  components:
-    - type: EntityTableContainerFill
-      containers:
-        storagebase: !type:AllSelector
-          children:
-          - id: EncryptionKeyExpedition
-            amount: 4
+# - type: entity
+#   name: expedition encryption key box
+#   parent: BoxEncryptionKeyAssistant
+#   id: BoxEncryptionKeyExpedition
+#   components:
+#     - type: EntityTableContainerFill
+#       containers:
+#         storagebase: !type:AllSelector
+#           children:
+#           - id: EncryptionKeyExpedition
+#             amount: 4
 
-- type: entity
-  name: salvage encryption key box
-  parent: BoxEncryptionKeyAssistant
-  id: BoxEncryptionKeySalvage
-  components:
-    - type: EntityTableContainerFill
-      containers:
-        storagebase: !type:AllSelector
-          children:
-          - id: EncryptionKeySalvage
-            amount: 4
+# Far Horizons - removed
+# - type: entity
+#   name: salvage encryption key box
+#   parent: BoxEncryptionKeyAssistant
+#   id: BoxEncryptionKeySalvage
+#   components:
+#     - type: EntityTableContainerFill
+#       containers:
+#         storagebase: !type:AllSelector
+#           children:
+#           - id: EncryptionKeySalvage
+#             amount: 4

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Ears/headsets.yml
@@ -87,7 +87,7 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyExpedition
+      # - EncryptionKeyExpedition # Far Horizons - removed
       - EncryptionKeyCargo
       - EncryptionKeyCommon
   - type: Sprite

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Devices/encryption_keys.yml
@@ -30,38 +30,40 @@
     - sprite: _Starlight/Objects/Devices/encryption_keys.rsi
       state: soviet_label
 
-- type: entity
-  parent: [ EncryptionKey, BaseCargoContraband ]
-  id: EncryptionKeyExpedition
-  name: expedition encryption key
-  description: An encryption key used by daring explorers.
-  components:
-  - type: EncryptionKey
-    channels:
-    - Expedition
-    defaultChannel: Expedition
-  - type: Sprite
-    layers:
-    - state: crypt_gray
-    - sprite: _Starlight/Objects/Devices/encryption_keys.rsi
-      state: expedition_label
+# Far Horizons - removed
+# - type: entity
+#   parent: [ EncryptionKey, BaseCargoContraband ]
+#   id: EncryptionKeyExpedition
+#   name: expedition encryption key
+#   description: An encryption key used by daring explorers.
+#   components:
+#   - type: EncryptionKey
+#     channels:
+#     - Expedition
+#     defaultChannel: Expedition
+#   - type: Sprite
+#     layers:
+#     - state: crypt_gray
+#     - sprite: _Starlight/Objects/Devices/encryption_keys.rsi
+#       state: expedition_label
 
-- type: entity
-  parent: [ EncryptionKey, BaseSalvageMiningContraband ]
-  id: EncryptionKeySalvage
-  name: salvage encryption key
-  description: A dual encryption key used by box-loving explorers.
-  components:
-    - type: EncryptionKey
-      channels:
-        - Expedition
-        - Supply
-      defaultChannel: Supply
-    - type: Sprite
-      layers:
-        - state: crypt_gray
-        - sprite: _Starlight/Objects/Devices/encryption_keys.rsi
-          state: salvage_label
-    - type: Tag
-      tags:
-        - EncryptionCargo
+# Far Horizons - removed
+# - type: entity
+#   parent: [ EncryptionKey, BaseSalvageMiningContraband ]
+#   id: EncryptionKeySalvage
+#   name: salvage encryption key
+#   description: A dual encryption key used by box-loving explorers.
+#   components:
+#     - type: EncryptionKey
+#       channels:
+#         - Expedition
+#         - Supply
+#       defaultChannel: Supply
+#     - type: Sprite
+#       layers:
+#         - state: crypt_gray
+#         - sprite: _Starlight/Objects/Devices/encryption_keys.rsi
+#           state: salvage_label
+#     - type: Tag
+#       tags:
+#         - EncryptionCargo

--- a/Resources/Prototypes/_StarLight/radio_channels.yml
+++ b/Resources/Prototypes/_StarLight/radio_channels.yml
@@ -13,11 +13,12 @@
   color: "#ed7300"
   longRange: true
 
-- type: radioChannel
-  id: Expedition
-  name: chat-radio-expedition
-  keycode: 'o'
-  frequency: 1550
-  color: "#963dca"
-  # long range since otherwise it'd defeat the point of a handheld radio independent of telecomms
-  longRange: true
+# Far Horizons removed
+# - type: radioChannel
+#   id: Expedition
+#   name: chat-radio-expedition
+#   keycode: 'o'
+#   frequency: 1550
+#   color: "#963dca"
+#   # long range since otherwise it'd defeat the point of a handheld radio independent of telecomms
+#   longRange: true

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -71,6 +71,7 @@
   longRange: true
   anonymous: true # Far Horuzons
   anonymousAlias: "Agent {0}" # Far Horizons
+  anonymousIcon: JobIconSyndicate
 
 # Far Horizons - removed
 # - type: radioChannel

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -69,14 +69,17 @@
   frequency: 1213
   color: "#b52424"
   longRange: true
+  anonymous: true # Far Horuzons
+  anonymousAlias: "Agent {0}" # Far Horizons
 
-- type: radioChannel
-  id: Handheld
-  name: chat-radio-handheld
-  frequency: 1330
-  color: "#967101"
-  # long range since otherwise it'd defeat the point of a handheld radio independent of telecomms
-  longRange: true
+# Far Horizons - removed
+# - type: radioChannel
+#   id: Handheld
+#   name: chat-radio-handheld
+#   frequency: 1330
+#   color: "#967101"
+#   # long range since otherwise it'd defeat the point of a handheld radio independent of telecomms
+#   longRange: true
 
 - type: radioChannel
   id: Binary


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Anonymous radio for syndie (traitors) + removal of handheld and expedition channels which aren't compatible with handhelds we use

## Why we need to add this
slight buff for traitor communication, removing the risk of being discovered

## Media (Video/Screenshots)
<img width="390" height="186" alt="image" src="https://github.com/user-attachments/assets/9aec59ce-2c38-4cab-b12f-495845842438" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: princess_gurchi
- add: Added support for anonymous radio channels. Anonymous channels will function similarly to hiveminds, obfuscating speaker name, while keeping individuals recognizable 
- tweak: Syndicate (traitor) radio is now anonymous
- remove: Removed handheld and expedition channels and their respective keys, as they are not compatible with handhelds we use.