### PR TITLE
ID rename fix

### DIFF
--- a/Content.Server/_FarHorizons/Silicons/IPC/IPCSystem.Ui.cs
+++ b/Content.Server/_FarHorizons/Silicons/IPC/IPCSystem.Ui.cs
@@ -67,7 +67,7 @@ public sealed partial class IPCSystem
             return;
 
         _adminLog.Add(LogType.Action, LogImpact.High, $"{ToPrettyString(args.Actor):player} set IPC \"{ToPrettyString(ent)}\"'s name to: {name}");
-        _metaData.SetEntityName(ent, name, metaData);
+        _metaData.SetEntityName(ent, name, metaData, false);
     }
 
     public void UpdateUI(EntityUid uid)

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.Ui.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.Ui.cs
@@ -58,7 +58,7 @@ public abstract partial class SharedBorgSystem
             return;
 
         _adminLog.Add(LogType.Action, LogImpact.High, $"{args.Actor} set borg \"{chassis.Owner}\"'s name to: {name}");
-        _metaData.SetEntityName(chassis, name, metaData);
+        _metaData.SetEntityName(chassis, name, metaData, false); // Far Horizons - changed raiseEvents to false so borgis don't get free ID rename
     }
 
     private void OnRemoveModuleBuiMessage(Entity<BorgChassisComponent> chassis, ref BorgRemoveModuleBuiMessage args)


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
an exploit that allowed IPCs and borgis to change the name on their ID for free

## Why we need to add this
fix unintended interactions

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: FAR HORIZONS TEAM
- fix: Fixed IPCs and borgis being able to rename their ID for free