### PR TITLE
Hotfixes L6C

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1383,6 +1383,22 @@
     - type: ItemBorgModule
       hands:
       - item: WeaponLightMachineGunL6C
+      # region starlight - L6C uses ammo
+      - item: MagazineLightRifleBoxSP
+        hand:
+          emptyRepresentative: MagazineLightRifleBoxSP
+          emptyLabel: borg-slot-light-box-empty
+          whitelist:
+            tags:
+            - MagazineLightRifleBox
+      - item: MagazineLightRifleBoxSP
+        hand:
+          emptyRepresentative: MagazineLightRifleBoxSP
+          emptyLabel: borg-slot-light-box-empty
+          whitelist:
+            tags:
+            - MagazineLightRifleBox
+      # end region starlight
       - item: PinpointerSyndicateNuclear
     - type: BorgModuleIcon
       icon: { sprite: Interface/Actions/actions_borg.rsi, state: syndicate-l6c-module }


### PR DESCRIPTION
L6C kinda needs the extra boxes again.

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Returns the ammo boxes to the L6C module

## Why we need to add this
During the latest upstream merge, we rejected the changes from SL that gave ammo to the borg... though this wasn't accounting for the fact that I had done another balancing pass over on SL. The unintended side-effect of this was that we got an L6 module with 100 shots and no regeneration. This PR brings us into parity with SL by returning the ammo boxes.

## Media (Video/Screenshots)
Unneeded.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: R3v3l4t1on
- fix: The L6C module has the ability to carry extra ammo again.
