### PR TITLE
Reactor Content 7 Hotfix 1

### DIFF
--- a/Content.Client/_FarHorizons/Power/Generation/FissionGenerator/TurbineSystem.cs
+++ b/Content.Client/_FarHorizons/Power/Generation/FissionGenerator/TurbineSystem.cs
@@ -35,10 +35,12 @@ public sealed class TurbineSystem : SharedTurbineSystem
         SubscribeLocalEvent<TurbineComponent, ItemSlotEjectAttemptEvent>(OnEjectAttempt);
     }
 
-    protected override void OnRepairTurbineFinished(EntityUid uid, TurbineComponent comp, ref RepairedEvent args)
+    protected override void OnRepairTurbineFinished(EntityUid uid, TurbineComponent comp, ref RepairDoAfterEvent args)
     {
-        // Sorry I broke something here. Different event now has no tool in it.
-        _popupSystem.PopupClient(Loc.GetString("turbine-repair", ("target", uid), ("tool", "")), uid, args.User);
+        if (args.Cancelled)
+            return;
+
+        _popupSystem.PopupClient(Loc.GetString("turbine-repair", ("target", uid), ("tool", args.Used!)), uid, args.User);
     }
 
     private void TurbineExamined(EntityUid uid, TurbineComponent comp, ClientExaminedEvent args) => Spawn(comp.ArrowPrototype, new EntityCoordinates(uid, 0, 0));

--- a/Content.Client/_FarHorizons/Power/UI/NuclearReactorWindow.xaml.cs
+++ b/Content.Client/_FarHorizons/Power/UI/NuclearReactorWindow.xaml.cs
@@ -64,6 +64,9 @@ public sealed partial class NuclearReactorWindow : FancyWindow
     private bool _isMonitor = false;
     private EntityUid _monitor;
 
+    private readonly float _repeatDelay = 0.5f;
+    private readonly Dictionary<Button, float> _repeatQueue = [];
+
     public NuclearReactorWindow()
     {
         RobustXamlLoader.Load(this);
@@ -84,9 +87,20 @@ public sealed partial class NuclearReactorWindow : FancyWindow
         EjectItem.OnPressed += _ => EjectButtonPressed?.Invoke();
 
         ControlRodsInsertLarge.OnPressed += _ => AdjustControlRods(0.1f);
+        ControlRodsInsertLarge.OnButtonDown += _ => _repeatQueue.Add(ControlRodsInsertLarge, _repeatDelay);
+        ControlRodsInsertLarge.OnButtonUp += _ => _repeatQueue.Remove(ControlRodsInsertLarge);
+
         ControlRodsInsert.OnPressed += _ => AdjustControlRods(0.01f);
+        ControlRodsInsert.OnButtonDown += _ => _repeatQueue.Add(ControlRodsInsert, _repeatDelay);
+        ControlRodsInsert.OnButtonUp += _ => _repeatQueue.Remove(ControlRodsInsert);
+
         ControlRodsRemove.OnPressed += _ => AdjustControlRods(-0.01f);
+        ControlRodsRemove.OnButtonDown += _ => _repeatQueue.Add(ControlRodsRemove, _repeatDelay);
+        ControlRodsRemove.OnButtonUp += _ => _repeatQueue.Remove(ControlRodsRemove);
+
         ControlRodsRemoveLarge.OnPressed += _ => AdjustControlRods(-0.1f);
+        ControlRodsRemoveLarge.OnButtonDown += _ => _repeatQueue.Add(ControlRodsRemoveLarge, _repeatDelay);
+        ControlRodsRemoveLarge.OnButtonUp += _ => _repeatQueue.Remove(ControlRodsRemoveLarge);
 
         TargetTemperature.OnPressed += _ => ChangeTemp();
     }
@@ -235,6 +249,32 @@ public sealed partial class NuclearReactorWindow : FancyWindow
 
         UpdateTargetInfo();
         UpdateItemAction();
+
+        // Handle repeat buttons
+        foreach ( var kvp in _repeatQueue)
+        {
+            if(kvp.Value > 0)
+            {
+                _repeatQueue[kvp.Key] -= args.DeltaSeconds;
+                continue;
+            }
+
+            switch (kvp.Key)
+            {
+                case var _ when kvp.Key == ControlRodsInsertLarge:
+                    AdjustControlRods(0.1f);
+                    break;
+                case var _ when kvp.Key == ControlRodsInsert:
+                    AdjustControlRods(0.01f);
+                    break;
+                case var _ when kvp.Key == ControlRodsRemove:
+                    AdjustControlRods(-0.01f);
+                    break;
+                case var _ when kvp.Key == ControlRodsRemoveLarge:
+                    AdjustControlRods(-0.1f);
+                    break;
+            }
+        }
     }
 
     private static Color GetColor(double pointA, double pointB, double value)

--- a/Content.Client/_FarHorizons/Power/UI/TurbineWindow.xaml.cs
+++ b/Content.Client/_FarHorizons/Power/UI/TurbineWindow.xaml.cs
@@ -117,14 +117,14 @@ public sealed partial class TurbineWindow : FancyWindow
 
         void FlowTextChanged(bool suppress = false)
         {
-            if (float.TryParse(TurbineFlowRateLabel.Text, out var num))
+            if (float.TryParse(TurbineFlowRateLabel.Text, out var num) && !float.IsNaN(num))
                 TurbineFlowRateChanged?.Invoke(num);
             _suppressFlowUpdate = suppress;
         }
 
         void StatorTextChanged(bool suppress = false)
         {
-            if (float.TryParse(TurbineStatorLoadLabel.Text, out var num))
+            if (float.TryParse(TurbineStatorLoadLabel.Text, out var num) && !float.IsNaN(num))
                 TurbineStatorLoadChanged?.Invoke(num);
             _suppressStatorUpdate = suppress;
         }

--- a/Content.Client/_FarHorizons/Power/UI/TurbineWindow.xaml.cs
+++ b/Content.Client/_FarHorizons/Power/UI/TurbineWindow.xaml.cs
@@ -71,6 +71,9 @@ public sealed partial class TurbineWindow : FancyWindow
     private bool _suppressSliderEvents;
     private bool _suppressStatorUpdate;
     private bool _suppressFlowUpdate;
+
+    private readonly float _repeatDelay = 0.5f;
+    private readonly Dictionary<Button, float> _repeatQueue = [];
     #endregion
 
     #region Events
@@ -98,7 +101,12 @@ public sealed partial class TurbineWindow : FancyWindow
                 TurbineFlowRateChanged?.Invoke(TurbineFlowRateSlider.Value);
         };
         FlowRateDecrease.OnPressed += _ => TurbineFlowRateChanged?.Invoke(_flowRate - 100);
+        FlowRateDecrease.OnButtonDown += _ => _repeatQueue.Add(FlowRateDecrease, _repeatDelay);
+        FlowRateDecrease.OnButtonUp += _ => _repeatQueue.Remove(FlowRateDecrease);
+
         FlowRateIncrease.OnPressed += _ => TurbineFlowRateChanged?.Invoke(_flowRate + 100);
+        FlowRateIncrease.OnButtonDown += _ => _repeatQueue.Add(FlowRateIncrease, _repeatDelay);
+        FlowRateIncrease.OnButtonUp += _ => _repeatQueue.Remove(FlowRateIncrease);
 
         // Handle stator load
         TurbineStatorLoadLabel.OnFocusEnter += _ => _suppressStatorUpdate = true;
@@ -106,9 +114,20 @@ public sealed partial class TurbineWindow : FancyWindow
         TurbineStatorLoadLabel.OnTextEntered += _ => StatorTextChanged(true);
 
         StatorLoadDecreaseLarge.OnPressed += _ => TurbineStatorLoadChanged?.Invoke(_statorLevel - 1000);
+        StatorLoadDecreaseLarge.OnButtonDown += _ => _repeatQueue.Add(StatorLoadDecreaseLarge, _repeatDelay);
+        StatorLoadDecreaseLarge.OnButtonUp += _ => _repeatQueue.Remove(StatorLoadDecreaseLarge);
+
         StatorLoadDecrease.OnPressed += _ => TurbineStatorLoadChanged?.Invoke(_statorLevel - 100);
+        StatorLoadDecrease.OnButtonDown += _ => _repeatQueue.Add(StatorLoadDecrease, _repeatDelay);
+        StatorLoadDecrease.OnButtonUp += _ => _repeatQueue.Remove(StatorLoadDecrease);
+
         StatorLoadIncrease.OnPressed += _ => TurbineStatorLoadChanged?.Invoke(_statorLevel + 100);
+        StatorLoadIncrease.OnButtonDown += _ => _repeatQueue.Add(StatorLoadIncrease, _repeatDelay);
+        StatorLoadIncrease.OnButtonUp += _ => _repeatQueue.Remove(StatorLoadIncrease);
+
         StatorLoadIncreaseLarge.OnPressed += _ => TurbineStatorLoadChanged?.Invoke(_statorLevel + 1000);
+        StatorLoadIncreaseLarge.OnButtonDown += _ => _repeatQueue.Add(StatorLoadIncreaseLarge, _repeatDelay);
+        StatorLoadIncreaseLarge.OnButtonUp += _ => _repeatQueue.Remove(StatorLoadIncreaseLarge);
 
         CTabContainer.SetTabTitle(0, Loc.GetString("comp-turbine-ui-tab-main"));
         CTabContainer.SetTabTitle(1, Loc.GetString("comp-turbine-ui-tab-parts"));
@@ -241,14 +260,37 @@ public sealed partial class TurbineWindow : FancyWindow
         for (var i = 0; i < _speedMeter.Length; i++)
         {
             var box = _speedMeter[i];
-            if (_speedLevel > i)
+            box.BackgroundColor = _speedLevel > i ? _speedColors[i] : _speedColorsDim[i];
+        }
+
+        foreach (var kvp in _repeatQueue)
+        {
+            if(kvp.Value > 0)
             {
-                // On
-                box.BackgroundColor = _speedColors[i];
+                _repeatQueue[kvp.Key] -= args.DeltaSeconds;
+                continue;
             }
-            else
+
+            switch (kvp.Key)
             {
-                box.BackgroundColor = _speedColorsDim[i];
+                case var _ when kvp.Key == FlowRateDecrease:
+                    TurbineFlowRateChanged?.Invoke(_flowRate - 100);
+                    break;
+                case var _ when kvp.Key == FlowRateIncrease:
+                    TurbineFlowRateChanged?.Invoke(_flowRate + 100);
+                    break;
+                case var _ when kvp.Key == StatorLoadDecreaseLarge:
+                    TurbineStatorLoadChanged?.Invoke(_statorLevel - 1000);
+                    break;
+                case var _ when kvp.Key == StatorLoadDecrease:
+                    TurbineStatorLoadChanged?.Invoke(_statorLevel - 100);
+                    break;
+                case var _ when kvp.Key == StatorLoadIncrease:
+                    TurbineStatorLoadChanged?.Invoke(_statorLevel + 100);
+                    break;
+                case var _ when kvp.Key == StatorLoadIncreaseLarge:
+                    TurbineStatorLoadChanged?.Invoke(_statorLevel + 1000);
+                    break;
             }
         }
     }

--- a/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/GasTurbineMonitorSystem.cs
+++ b/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/GasTurbineMonitorSystem.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.DeviceLinking.Systems;
 using Content.Shared._FarHorizons.Power.Generation.FissionGenerator;
@@ -102,28 +103,31 @@ public sealed partial class GasTurbineMonitorSystem : EntitySystem
         if (_accumulator > _threshold)
         {
             AccUpdate();
+            UpdateLogs();
             _accumulator = 0;
         }
-        
-        var toRemove = new List<KeyValuePair<EntityUid, EntityUid>>();
-        foreach (var log in _logQueue)
+
+        return;
+
+        void UpdateLogs()
         {
-            if ((_gameTiming.RealTime - log.Value.CreationTime).TotalSeconds < 2)
-                continue;
+            var toRemove = new List<KeyValuePair<EntityUid, EntityUid>>();
+            foreach (var log in _logQueue.Where(log => !((_gameTiming.RealTime - log.Value.CreationTime).TotalSeconds < 2)))
+            {
+                toRemove.Add(log.Key);
 
-            toRemove.Add(log.Key);
+                if (log.Value.SetFlowRate != null)
+                    _adminLogger.Add(LogType.AtmosVolumeChanged, LogImpact.Medium,
+                        $"{ToPrettyString(log.Key.Key):player} set the flow rate on {ToPrettyString(log.Value.Turbine):device} to {log.Value.SetFlowRate} through {ToPrettyString(log.Key.Value):monitor}");
 
-            if (log.Value.SetFlowRate != null)
-                _adminLogger.Add(LogType.AtmosVolumeChanged, LogImpact.Medium,
-                    $"{ToPrettyString(log.Key.Key):player} set the flow rate on {ToPrettyString(log.Value.Turbine):device} to {log.Value.SetFlowRate} through {ToPrettyString(log.Key.Value):monitor}");
+                if (log.Value.SetStatorLoad != null)
+                    _adminLogger.Add(LogType.AtmosDeviceSetting, LogImpact.Medium,
+                        $"{ToPrettyString(log.Key.Key):player} set the stator load on {ToPrettyString(log.Value.Turbine):device} to {log.Value.SetStatorLoad} through {ToPrettyString(log.Key.Value):monitor}");
+            }
 
-            if (log.Value.SetStatorLoad != null)
-                _adminLogger.Add(LogType.AtmosDeviceSetting, LogImpact.Medium,
-                    $"{ToPrettyString(log.Key.Key):player} set the stator load on {ToPrettyString(log.Value.Turbine):device} to {log.Value.SetStatorLoad} through {ToPrettyString(log.Key.Value):monitor}");
+            foreach (var kvp in toRemove)
+                _logQueue.Remove(kvp);
         }
-
-        foreach (var uid in toRemove)
-            _logQueue.Remove(uid);
     }
 
     private void AccUpdate()

--- a/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/GasTurbineMonitorSystem.cs
+++ b/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/GasTurbineMonitorSystem.cs
@@ -6,20 +6,32 @@ using Content.Shared.Database;
 using Content.Shared.DeviceLinking;
 using Content.Shared.DeviceLinking.Events;
 using Robust.Server.GameObjects;
+using Robust.Shared.Timing;
 
 namespace Content.Server._FarHorizons.Power.Generation.FissionGenerator;
 
 public sealed partial class GasTurbineMonitorSystem : EntitySystem
 {
     [Dependency] private readonly EntityManager _entityManager = default!;
-    [Dependency] private readonly IAdminLogManager _adminLog = default!;
+    [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly TurbineSystem _turbineSystem = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
     [Dependency] private readonly DeviceLinkSystem _signal = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = null!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
 
     private readonly float _threshold = 0.5f;
     private float _accumulator = 0f;
+
+    private sealed class LogData
+    {
+        public TimeSpan CreationTime;
+        public NetEntity Turbine;
+        public float? SetFlowRate;
+        public float? SetStatorLoad;
+    }
+
+    private readonly Dictionary<KeyValuePair<EntityUid, EntityUid>, LogData> _logQueue = [];
 
     public override void Initialize()
     {
@@ -92,6 +104,26 @@ public sealed partial class GasTurbineMonitorSystem : EntitySystem
             AccUpdate();
             _accumulator = 0;
         }
+        
+        var toRemove = new List<KeyValuePair<EntityUid, EntityUid>>();
+        foreach (var log in _logQueue)
+        {
+            if ((_gameTiming.RealTime - log.Value.CreationTime).TotalSeconds < 2)
+                continue;
+
+            toRemove.Add(log.Key);
+
+            if (log.Value.SetFlowRate != null)
+                _adminLogger.Add(LogType.AtmosVolumeChanged, LogImpact.Medium,
+                    $"{ToPrettyString(log.Key.Key):player} set the flow rate on {ToPrettyString(log.Value.Turbine):device} to {log.Value.SetFlowRate} through {ToPrettyString(log.Key.Value):monitor}");
+
+            if (log.Value.SetStatorLoad != null)
+                _adminLogger.Add(LogType.AtmosDeviceSetting, LogImpact.Medium,
+                    $"{ToPrettyString(log.Key.Key):player} set the stator load on {ToPrettyString(log.Value.Turbine):device} to {log.Value.SetStatorLoad} through {ToPrettyString(log.Key.Value):monitor}");
+        }
+
+        foreach (var uid in toRemove)
+            _logQueue.Remove(uid);
     }
 
     private void AccUpdate()
@@ -110,26 +142,74 @@ public sealed partial class GasTurbineMonitorSystem : EntitySystem
 
     private void OnTurbineFlowRateChanged(EntityUid uid, GasTurbineMonitorComponent comp, TurbineChangeFlowRateMessage args)
     {
-        if (!TryGetTurbineComp(comp, out var turbine) || !_entityManager.TryGetEntity(comp.turbine, out var turbineUid))
+        if (!TryGetTurbineComp(comp, out var turbine))
             return;
 
-        turbine.FlowRate = Math.Clamp(args.FlowRate, 0f, turbine.FlowRateMax);
-        Dirty(turbineUid.Value, turbine);
+        if(TrySetFlowRate())
+        {
+            // Data is sent to a log queue to avoid spamming the admin log when adjusting values rapidly
+            var key = new KeyValuePair<EntityUid, EntityUid>(args.Actor, uid);
+            if(!_logQueue.TryGetValue(key, out var value))
+                _logQueue.Add(key, new LogData
+                {
+                    CreationTime = _gameTiming.RealTime,
+                    Turbine = comp.turbine!.Value,
+                    SetFlowRate = turbine.FlowRate
+                });
+            else
+                value.SetFlowRate = turbine.FlowRate;
+        }
+            
         _turbineSystem.UpdateUI(uid, turbine);
-        _adminLog.Add(LogType.AtmosVolumeChanged, LogImpact.Medium,
-            $"{ToPrettyString(args.Actor):player} set the flow rate on {ToPrettyString(uid):device} to {args.FlowRate} through {ToPrettyString(uid):monitor}");
+
+        return;
+
+        bool TrySetFlowRate()
+        {
+            var newSet = Math.Clamp(args.FlowRate, 0f, turbine.FlowRateMax);
+            if (turbine.FlowRate != newSet)
+            {
+                turbine.FlowRate = newSet;
+                return true;
+            }
+            return false; 
+        }
     }
 
     private void OnTurbineStatorLoadChanged(EntityUid uid, GasTurbineMonitorComponent comp, TurbineChangeStatorLoadMessage args)
     {
-        if (!TryGetTurbineComp(comp, out var turbine) || !_entityManager.TryGetEntity(comp.turbine, out var turbineUid))
+        if (!TryGetTurbineComp(comp, out var turbine))
             return;
+        
+        if (TrySetStatorLoad())
+        {
+            // Data is sent to a log queue to avoid spamming the admin log when adjusting values rapidly
+            var key = new KeyValuePair<EntityUid, EntityUid>(args.Actor, uid);
+            if (!_logQueue.TryGetValue(key, out var value))
+                _logQueue.Add(key, new LogData
+                {
+                    CreationTime = _gameTiming.RealTime,
+                    Turbine = comp.turbine!.Value,
+                    SetStatorLoad = turbine.StatorLoad
+                });
+            else
+                value.SetStatorLoad = turbine.StatorLoad;
+        }
 
-        turbine.StatorLoad = Math.Max(args.StatorLoad, 1000f);
-        Dirty(turbineUid.Value, turbine);
         _turbineSystem.UpdateUI(uid, turbine);
-        _adminLog.Add(LogType.AtmosDeviceSetting, LogImpact.Medium,
-            $"{ToPrettyString(args.Actor):player} set the stator load on {ToPrettyString(uid):device} to {args.StatorLoad} through {ToPrettyString(uid):monitor}");
+
+        return;
+
+        bool TrySetStatorLoad()
+        {
+            var newSet = Math.Max(args.StatorLoad, 1000f);
+            if (turbine.StatorLoad != newSet)
+            {
+                turbine.StatorLoad = newSet;
+                return true;
+            }
+            return false; 
+        }
     }
     #endregion
 

--- a/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/NuclearReactorMonitorSystem.cs
+++ b/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/NuclearReactorMonitorSystem.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.DeviceLinking.Systems;
 using Content.Shared._FarHorizons.Power.Generation.FissionGenerator;
@@ -100,24 +101,28 @@ public sealed partial class NuclearReactorMonitorSystem : EntitySystem
         if (_accumulator > _threshold)
         {
             AccUpdate();
+            UpdateLogs();
             _accumulator = 0;
         }
 
-        var toRemove = new List<KeyValuePair<EntityUid, EntityUid>>();
-        foreach (var log in _logQueue)
+        return;
+
+        void UpdateLogs()
         {
-            if ((_gameTiming.RealTime - log.Value.CreationTime).TotalSeconds < 2)
-                continue;
+            var toRemove = new List<KeyValuePair<EntityUid, EntityUid>>();
+            foreach (var log in _logQueue.Where(log => !((_gameTiming.RealTime - log.Value.CreationTime).TotalSeconds < 2)))
+            {
+                toRemove.Add(log.Key);
 
-            toRemove.Add(log.Key);
+                if (log.Value.SetControlRodInsertion != null)
+                    _adminLog.Add(LogType.Action, $"{ToPrettyString(log.Key.Key):actor} set control rod insertion of {ToPrettyString(log.Value.Reactor):target} to {log.Value.SetControlRodInsertion} through {ToPrettyString(log.Key.Value):monitor}");
+            }
 
-            if (log.Value.SetControlRodInsertion != null)
-                _adminLog.Add(LogType.Action, $"{ToPrettyString(log.Key.Key):actor} set control rod insertion of {ToPrettyString(log.Value.Reactor):target} to {log.Value.SetControlRodInsertion} through {ToPrettyString(log.Key.Value):monitor}");
+            foreach (var kvp in toRemove)
+                _logQueue.Remove(kvp);
         }
-
-        foreach (var uid in toRemove)
-            _logQueue.Remove(uid);
     }
+
     private void AccUpdate()
     {
         var query = EntityQueryEnumerator<NuclearReactorMonitorComponent>();

--- a/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/NuclearReactorMonitorSystem.cs
+++ b/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/NuclearReactorMonitorSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Database;
 using Content.Shared.DeviceLinking;
 using Content.Shared.DeviceLinking.Events;
 using Robust.Server.GameObjects;
+using Robust.Shared.Timing;
 
 namespace Content.Server._FarHorizons.Power.Generation.FissionGenerator;
 
@@ -17,9 +18,19 @@ public sealed partial class NuclearReactorMonitorSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
     [Dependency] private readonly DeviceLinkSystem _signal = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = null!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
 
     private readonly float _threshold = 0.5f;
     private float _accumulator = 0f;
+
+    private sealed class LogData
+    {
+        public TimeSpan CreationTime;
+        public NetEntity Reactor;
+        public float? SetControlRodInsertion;
+    }
+
+    private readonly Dictionary<KeyValuePair<EntityUid, EntityUid>, LogData> _logQueue = [];
 
     public override void Initialize()
     {
@@ -91,6 +102,21 @@ public sealed partial class NuclearReactorMonitorSystem : EntitySystem
             AccUpdate();
             _accumulator = 0;
         }
+
+        var toRemove = new List<KeyValuePair<EntityUid, EntityUid>>();
+        foreach (var log in _logQueue)
+        {
+            if ((_gameTiming.RealTime - log.Value.CreationTime).TotalSeconds < 2)
+                continue;
+
+            toRemove.Add(log.Key);
+
+            if (log.Value.SetControlRodInsertion != null)
+                _adminLog.Add(LogType.Action, $"{ToPrettyString(log.Key.Key):actor} set control rod insertion of {ToPrettyString(log.Value.Reactor):target} to {log.Value.SetControlRodInsertion} through {ToPrettyString(log.Key.Value):monitor}");
+        }
+
+        foreach (var uid in toRemove)
+            _logQueue.Remove(uid);
     }
     private void AccUpdate()
     {
@@ -111,8 +137,20 @@ public sealed partial class NuclearReactorMonitorSystem : EntitySystem
         if (!TryGetReactorComp(comp, out var reactor))
             return;
 
-        if (SharedNuclearReactorSystem.AdjustControlRods(reactor, args.Change))
-            _adminLog.Add(LogType.Action, $"{ToPrettyString(args.Actor):actor} set control rod insertion of {ToPrettyString(comp.reactor):target} to {reactor.ControlRodInsertion} through {ToPrettyString(uid):monitor}");
+        if(SharedNuclearReactorSystem.AdjustControlRods(reactor, args.Change))
+        {
+            // Data is sent to a log queue to avoid spamming the admin log when adjusting values rapidly
+            var key = new KeyValuePair<EntityUid, EntityUid>(args.Actor, uid);
+            if(!_logQueue.TryGetValue(key, out var value))
+                _logQueue.Add(key, new LogData {
+                    CreationTime = _gameTiming.RealTime, 
+                    Reactor = comp.reactor!.Value,
+                    SetControlRodInsertion = reactor.ControlRodInsertion
+                });
+            else
+                value.SetControlRodInsertion = reactor.ControlRodInsertion;
+        }
+
         _reactorSystem.UpdateUI(uid, reactor);
     }
     #endregion

--- a/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/NuclearReactorSystem.cs
+++ b/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/NuclearReactorSystem.cs
@@ -842,22 +842,34 @@ public sealed class NuclearReactorSystem : SharedNuclearReactorSystem
         UpdateUI(ent.Owner, ent.Comp);
     }
 
+    private float _accumulator = 0f;
+    private readonly float _threshold = 0.5f;
+
     public override void Update(float frameTime)
     {
-        var toRemove = new List<KeyValuePair<EntityUid, EntityUid>>();
-        foreach (var log in _logQueue)
+        _accumulator += frameTime;
+        if (_accumulator > _threshold)
         {
-            if ((_gameTiming.RealTime - log.Value.CreationTime).TotalSeconds < 2)
-                continue;
-
-            toRemove.Add(log.Key);
-
-            if (log.Value.SetControlRodInsertion != null)
-                _adminLog.Add(LogType.Action, $"{ToPrettyString(log.Key.Key):actor} set control rod insertion of {ToPrettyString(log.Key.Value):target} to {log.Value.SetControlRodInsertion}");
+            UpdateLogs();
+            _accumulator = 0;
         }
 
-        foreach (var uid in toRemove)
-            _logQueue.Remove(uid);
+        return;
+
+        void UpdateLogs()
+        {
+            var toRemove = new List<KeyValuePair<EntityUid, EntityUid>>();
+            foreach (var log in _logQueue.Where(log => !((_gameTiming.RealTime - log.Value.CreationTime).TotalSeconds < 2)))
+            {
+                toRemove.Add(log.Key);
+
+                if (log.Value.SetControlRodInsertion != null)
+                    _adminLog.Add(LogType.Action, $"{ToPrettyString(log.Key.Key):actor} set control rod insertion of {ToPrettyString(log.Key.Value):target} to {log.Value.SetControlRodInsertion}");
+            }
+
+            foreach (var kvp in toRemove)
+                _logQueue.Remove(kvp);
+        }
     }
     #endregion
 

--- a/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/NuclearReactorSystem.cs
+++ b/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/NuclearReactorSystem.cs
@@ -903,7 +903,7 @@ public sealed class NuclearReactorSystem : SharedNuclearReactorSystem
 
         if (!Transform(comp.InletEnt.Value).Anchored || !Transform(comp.OutletEnt.Value).Anchored)
         {
-            _popupSystem.PopupEntity(Loc.GetString("turbine-anchor-warning"), uid, PopupType.MediumCaution);
+            _popupSystem.PopupEntity(Loc.GetString("reactor-unanchor-warning"), uid, PopupType.MediumCaution);
             CleanUp(comp);
             _transform.Unanchor(uid);
             return false;

--- a/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/NuclearReactorSystem.cs
+++ b/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/NuclearReactorSystem.cs
@@ -35,6 +35,7 @@ using Content.Shared.Random.Helpers;
 using Content.Shared.Throwing;
 using Content.Shared.Damage.Systems;
 using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.Timing;
 
 namespace Content.Server._FarHorizons.Power.Generation.FissionGenerator;
 
@@ -68,6 +69,15 @@ public sealed class NuclearReactorSystem : SharedNuclearReactorSystem
     [Dependency] private readonly TransformSystem _transformSystem = default!;
     [Dependency] private readonly SharedPointLightSystem _lightSystem = default!;
     [Dependency] private readonly AmbientSoundSystem _ambientSoundSystem = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+
+    private sealed class LogData
+    {
+        public TimeSpan CreationTime;
+        public float? SetControlRodInsertion;
+    }
+
+    private readonly Dictionary<KeyValuePair<EntityUid, EntityUid>, LogData> _logQueue = [];
 
     public override void Initialize()
     {
@@ -820,8 +830,34 @@ public sealed class NuclearReactorSystem : SharedNuclearReactorSystem
     private void OnControlRodMessage(Entity<NuclearReactorComponent> ent, ref ReactorControlRodModifyMessage args)
     {
         if(AdjustControlRods(ent.Comp, args.Change))
-            _adminLog.Add(LogType.Action, $"{ToPrettyString(args.Actor):actor} set control rod insertion of {ToPrettyString(ent):target} to {ent.Comp.ControlRodInsertion}");
+            // Data is sent to a log queue to avoid spamming the admin log when adjusting values rapidly
+            if(!_logQueue.TryGetValue(new(args.Actor, ent.Owner), out var value))
+                _logQueue.Add(new(args.Actor, ent.Owner), new LogData {
+                    CreationTime = _gameTiming.RealTime, 
+                    SetControlRodInsertion = ent.Comp.ControlRodInsertion
+                });
+            else
+                value.SetControlRodInsertion = ent.Comp.ControlRodInsertion;
+
         UpdateUI(ent.Owner, ent.Comp);
+    }
+
+    public override void Update(float frameTime)
+    {
+        var toRemove = new List<KeyValuePair<EntityUid, EntityUid>>();
+        foreach (var log in _logQueue)
+        {
+            if ((_gameTiming.RealTime - log.Value.CreationTime).TotalSeconds < 2)
+                continue;
+
+            toRemove.Add(log.Key);
+
+            if (log.Value.SetControlRodInsertion != null)
+                _adminLog.Add(LogType.Action, $"{ToPrettyString(log.Key.Key):actor} set control rod insertion of {ToPrettyString(log.Key.Value):target} to {log.Value.SetControlRodInsertion}");
+        }
+
+        foreach (var uid in toRemove)
+            _logQueue.Remove(uid);
     }
     #endregion
 

--- a/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/TurbineSystem.cs
+++ b/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/TurbineSystem.cs
@@ -26,6 +26,7 @@ using Content.Shared.Damage.Systems;
 using Content.Server.Audio;
 using Content.Shared.Audio;
 using Robust.Shared.Timing;
+using System.Linq;
 
 namespace Content.Server._FarHorizons.Power.Generation.FissionGenerator;
 
@@ -455,27 +456,39 @@ public sealed class TurbineSystem : SharedTurbineSystem
         }
     }
 
+    private float _accumulator = 0f;
+    private readonly float _threshold = 0.5f;
+
     public override void Update(float frameTime)
     {
-        var toRemove = new List<KeyValuePair<EntityUid, EntityUid>>();
-        foreach (var log in _logQueue)
+        _accumulator += frameTime;
+        if (_accumulator > _threshold)
         {
-            if ((_gameTiming.RealTime - log.Value.CreationTime).TotalSeconds < 2)
-                continue;
-
-            toRemove.Add(log.Key);
-
-            if (log.Value.SetFlowRate != null)
-                _adminLogger.Add(LogType.AtmosVolumeChanged, LogImpact.Medium,
-                    $"{ToPrettyString(log.Key.Key):player} set the flow rate on {ToPrettyString(log.Key.Value):device} to {log.Value.SetFlowRate}");
-
-            if (log.Value.SetStatorLoad != null)
-                _adminLogger.Add(LogType.AtmosDeviceSetting, LogImpact.Medium,
-                    $"{ToPrettyString(log.Key.Key):player} set the stator load on {ToPrettyString(log.Key.Value):device} to {log.Value.SetStatorLoad}");
+            UpdateLogs();
+            _accumulator = 0;
         }
 
-        foreach (var uid in toRemove)
-            _logQueue.Remove(uid);
+        return;
+
+        void UpdateLogs()
+        {
+            var toRemove = new List<KeyValuePair<EntityUid, EntityUid>>();
+            foreach (var log in _logQueue.Where(log => !((_gameTiming.RealTime - log.Value.CreationTime).TotalSeconds < 2)))
+            {
+                toRemove.Add(log.Key);
+
+                if (log.Value.SetFlowRate != null)
+                    _adminLogger.Add(LogType.AtmosVolumeChanged, LogImpact.Medium,
+                        $"{ToPrettyString(log.Key.Key):player} set the flow rate on {ToPrettyString(log.Key.Value):device} to {log.Value.SetFlowRate}");
+
+                if (log.Value.SetStatorLoad != null)
+                    _adminLogger.Add(LogType.AtmosDeviceSetting, LogImpact.Medium,
+                        $"{ToPrettyString(log.Key.Key):player} set the stator load on {ToPrettyString(log.Key.Value):device} to {log.Value.SetStatorLoad}");
+            }
+
+            foreach (var kvp in toRemove)
+                _logQueue.Remove(kvp);
+        }
     }
     #endregion
 

--- a/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/TurbineSystem.cs
+++ b/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/TurbineSystem.cs
@@ -25,6 +25,7 @@ using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Damage.Systems;
 using Content.Server.Audio;
 using Content.Shared.Audio;
+using Robust.Shared.Timing;
 
 namespace Content.Server._FarHorizons.Power.Generation.FissionGenerator;
 
@@ -48,8 +49,7 @@ public sealed class TurbineSystem : SharedTurbineSystem
     [Dependency] private readonly EntityManager _entityManager = default!;
     [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
     [Dependency] private readonly AmbientSoundSystem _ambientSoundSystem = default!;
-
-    public event Action<string>? TurbineRepairMessage;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
 
     private readonly List<string> _damageSoundList = [
         "/Audio/_FarHorizons/Effects/engine_grump1.ogg",
@@ -58,6 +58,15 @@ public sealed class TurbineSystem : SharedTurbineSystem
         "/Audio/Effects/metal_slam5.ogg",
         "/Audio/Effects/metal_scrape2.ogg"
     ];
+
+    private sealed class LogData
+    {
+        public TimeSpan CreationTime;
+        public float? SetFlowRate;
+        public float? SetStatorLoad;
+    }
+
+    private readonly Dictionary<KeyValuePair<EntityUid, EntityUid>, LogData> _logQueue = [];
 
     public override void Initialize()
     {
@@ -384,20 +393,89 @@ public sealed class TurbineSystem : SharedTurbineSystem
 
     private void OnTurbineFlowRateChanged(EntityUid uid, TurbineComponent turbine, TurbineChangeFlowRateMessage args)
     {
-        turbine.FlowRate = Math.Clamp(args.FlowRate, 0f, turbine.FlowRateMax);
-        Dirty(uid, turbine);
+        if(TrySetFlowRate())
+        {
+            // Data is sent to a log queue to avoid spamming the admin log when adjusting values rapidly
+            var key = new KeyValuePair<EntityUid, EntityUid>(args.Actor, uid);
+            if(!_logQueue.TryGetValue(key, out var value))
+                _logQueue.Add(key, new LogData
+                {
+                    CreationTime = _gameTiming.RealTime,
+                    SetFlowRate = turbine.FlowRate
+                });
+            else
+                value.SetFlowRate = turbine.FlowRate;
+        }
+            
         UpdateUI(uid, turbine);
-        _adminLogger.Add(LogType.AtmosVolumeChanged, LogImpact.Medium,
-            $"{ToPrettyString(args.Actor):player} set the flow rate on {ToPrettyString(uid):device} to {args.FlowRate}");
+
+        return;
+
+        bool TrySetFlowRate()
+        {
+            var newSet = Math.Clamp(args.FlowRate, 0f, turbine.FlowRateMax);
+            if (turbine.FlowRate != newSet)
+            {
+                turbine.FlowRate = newSet;
+                return true;
+            }
+            return false; 
+        }
     }
 
     private void OnTurbineStatorLoadChanged(EntityUid uid, TurbineComponent turbine, TurbineChangeStatorLoadMessage args)
     {
-        turbine.StatorLoad = Math.Max(args.StatorLoad, 1000f);
-        Dirty(uid, turbine);
+        if (TrySetStatorLoad())
+        {
+            // Data is sent to a log queue to avoid spamming the admin log when adjusting values rapidly
+            var key = new KeyValuePair<EntityUid, EntityUid>(args.Actor, uid);
+            if (!_logQueue.TryGetValue(key, out var value))
+                _logQueue.Add(key, new LogData
+                {
+                    CreationTime = _gameTiming.RealTime,
+                    SetStatorLoad = turbine.StatorLoad
+                });
+            else
+                value.SetStatorLoad = turbine.StatorLoad;
+        }
+
         UpdateUI(uid, turbine);
-        _adminLogger.Add(LogType.AtmosDeviceSetting, LogImpact.Medium,
-            $"{ToPrettyString(args.Actor):player} set the stator load on {ToPrettyString(uid):device} to {args.StatorLoad}");
+
+        return;
+
+        bool TrySetStatorLoad()
+        {
+            var newSet = Math.Max(args.StatorLoad, 1000f);
+            if (turbine.StatorLoad != newSet)
+            {
+                turbine.StatorLoad = newSet;
+                return true;
+            }
+            return false; 
+        }
+    }
+
+    public override void Update(float frameTime)
+    {
+        var toRemove = new List<KeyValuePair<EntityUid, EntityUid>>();
+        foreach (var log in _logQueue)
+        {
+            if ((_gameTiming.RealTime - log.Value.CreationTime).TotalSeconds < 2)
+                continue;
+
+            toRemove.Add(log.Key);
+
+            if (log.Value.SetFlowRate != null)
+                _adminLogger.Add(LogType.AtmosVolumeChanged, LogImpact.Medium,
+                    $"{ToPrettyString(log.Key.Key):player} set the flow rate on {ToPrettyString(log.Key.Value):device} to {log.Value.SetFlowRate}");
+
+            if (log.Value.SetStatorLoad != null)
+                _adminLogger.Add(LogType.AtmosDeviceSetting, LogImpact.Medium,
+                    $"{ToPrettyString(log.Key.Key):player} set the stator load on {ToPrettyString(log.Key.Value):device} to {log.Value.SetStatorLoad}");
+        }
+
+        foreach (var uid in toRemove)
+            _logQueue.Remove(uid);
     }
     #endregion
 

--- a/Content.Shared/_FarHorizons/Power/Generation/FissionGenerator/SharedTurbineSystem.cs
+++ b/Content.Shared/_FarHorizons/Power/Generation/FissionGenerator/SharedTurbineSystem.cs
@@ -35,7 +35,7 @@ public abstract class SharedTurbineSystem : EntitySystem
         SubscribeLocalEvent<TurbineComponent, ExaminedEvent>(OnExamined);
 
         SubscribeLocalEvent<TurbineComponent, InteractUsingEvent>(RepairTurbine);
-        SubscribeLocalEvent<TurbineComponent, RepairedEvent>(OnRepairTurbineFinished);
+        SubscribeLocalEvent<TurbineComponent, RepairDoAfterEvent>(OnRepairTurbineFinished);
     }
 
     private void OnExamined(Entity<TurbineComponent> ent, ref ExaminedEvent args)
@@ -48,19 +48,11 @@ public abstract class SharedTurbineSystem : EntitySystem
         {
             if(comp.CurrentStator == null)
                 args.PushMarkup(Loc.GetString("gas-turbine-examine-stator-null"));
-            else
-            // Doesn't work right due to LOC
-            //args.PushMarkup(Loc.GetString("gas-turbine-examine-stator", ("material", _proto.Index(_entityManager.GetComponent<GasTurbineStatorComponent>(comp.CurrentStator.Value).Material).Name)));
-            args.PushMarkup(Loc.GetString("gas-turbine-examine-stator"));
 
             if (comp.CurrentBlade == null)
                 args.PushMarkup(Loc.GetString("gas-turbine-examine-blade-null"));
             else
             {
-                // Doesn't work right due to LOC
-                //args.PushMarkup(Loc.GetString("gas-turbine-examine-blade", ("material", _proto.Index(_entityManager.GetComponent<GasTurbineBladeComponent>(comp.CurrentBlade.Value).Material).Name)));
-                args.PushMarkup(Loc.GetString("gas-turbine-examine-blade"));
-
                 switch (comp.RPM)
                 {
                     case float n when n is >= 0 and <= 1:
@@ -173,7 +165,7 @@ public abstract class SharedTurbineSystem : EntitySystem
     }
 
     //Gotta love server/client desync
-    protected virtual void OnRepairTurbineFinished(EntityUid uid, TurbineComponent comp, ref RepairedEvent args)
+    protected virtual void OnRepairTurbineFinished(EntityUid uid, TurbineComponent comp, ref RepairDoAfterEvent args)
     {
         if (comp.Ruined)
         {


### PR DESCRIPTION
## Short description
Fixes some bugs and adds a little QOL as a treat.

## Why we need to add this
So engineering can play with the reactor again.

## Media (Video/Screenshots)
### Hold-down Buttons
https://github.com/user-attachments/assets/4990c49b-5350-4c93-a838-53ba9d72b936

### Gas Turbine Repairable
https://github.com/user-attachments/assets/316b1c71-06aa-47f4-a794-8b84a231379e

Devlog/Discussion thread: https://discord.com/channels/1407077238876147783/1428831494318850102

## Checks
- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**
:cl: jhrushbe
- add: Added a hold-down function to the +/- buttons in the nuclear reactor and gas turbine interfaces.
- tweak: Stopped showing excessive data when examining a gas turbine.
- fix: Fixed a bug where gas turbines could not be repaired.
- fix: Fixed a bug where the nuclear reactor would give the gas turbine's unanchor warning messages.
- fix: Fixed a bug where the gas turbine would shatter reality if given "NaN" as a stator load or flow rate value.
