### PR TITLE
Ports #2857 from SL: Avali 0g movement fix 

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
@@ -115,9 +115,9 @@
         Female: FemaleAvali
         Unsexed: MaleAvali
     - type: MovementSpeedModifier
-      weightlessAcceleration: 1.6 # Avalis are specifically built to fly in low-g environments
-      weightlessFriction: 1
-      weightlessModifier: 1
+      baseWeightlessAcceleration: 1.6 # Avalis are specifically built to fly in low-g environments
+      baseWeightlessFriction: 1
+      baseWeightlessModifier: 1
     - type: Damageable
       damageContainer: Biological
       damageModifierSet: Avali


### PR DESCRIPTION
## Short description
This PR ports a bugfix from SL in regards to Avali 0g movement (its plain out not working currently). All changes on SL done by Fasuh, I simply ported the fix.

Original PR https://github.com/ss14Starlight/space-station-14/pull/2857

## Why we need to add this
It fixes a bug in regards to a species and cleans up code. 

## Media (Video/Screenshots)

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: IrkallaEpsilon
- fix: Avali Zero G movement now works 