### PR TITLE
borg update

### DIFF
--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -43,7 +43,8 @@ namespace Content.IntegrationTests.Tests
                     .Where(p => !p.Components.ContainsKey("MapGrid")) // This will smash stuff otherwise.
                     .Where(p => !p.Components.ContainsKey("RoomFill")) // This comp can delete all entities, and spawn others
                     .Where(p => !p.Components.ContainsKey("TraitorCodePaperComponent") && // FH - Prevets codeword system from freaking out
-                                !p.Components.ContainsKey("ParadoxCloneRuleComponent")) // FH - No people to clone in tests
+                                !p.Components.ContainsKey("ParadoxCloneRuleComponent") && // FH - No people to clone in tests
+                                !p.Components.ContainsKey("RevSupplyRift")) // FH - no crates
                     .Select(p => p.ID)
                     .ToList();
 
@@ -108,7 +109,8 @@ namespace Content.IntegrationTests.Tests
                     .Where(p => !p.Components.ContainsKey("MapGrid")) // This will smash stuff otherwise.
                     .Where(p => !p.Components.ContainsKey("RoomFill")) // This comp can delete all entities, and spawn others
                     .Where(p => !p.Components.ContainsKey("TraitorCodePaperComponent") && // FH - Prevets codeword system from freaking out
-                                !p.Components.ContainsKey("ParadoxCloneRuleComponent")) // FH - No people to clone in tests
+                                !p.Components.ContainsKey("ParadoxCloneRuleComponent") && // FH - No people to clone in tests
+                                !p.Components.ContainsKey("RevSupplyRift")) // FH - no crates
                     .Select(p => p.ID)
                     .ToList();
                 foreach (var protoId in protoIds)
@@ -170,7 +172,8 @@ namespace Content.IntegrationTests.Tests
                 .Where(p => !pair.IsTestPrototype(p))
                 .Where(p => !p.Components.ContainsKey("MapGrid")) // This will smash stuff otherwise.
                 .Where(p => !p.Components.ContainsKey("TraitorCodePaperComponent") && // FH - Prevets codeword system from freaking out
-                            !p.Components.ContainsKey("ParadoxCloneRuleComponent")) // FH - No people to clone in tests
+                            !p.Components.ContainsKey("ParadoxCloneRuleComponent") && // FH - No people to clone in tests
+                            !p.Components.ContainsKey("RevSupplyRift")) // FH - no crates
                 .Select(p => p.ID)
                 .ToList();
 
@@ -253,6 +256,7 @@ namespace Content.IntegrationTests.Tests
 
                 "TraitorCodePaperComponent", // FH - Prevets codeword system from freaking out
                 "ParadoxCloneRuleComponent", // FH - No people to clone in tests
+                "RevSupplyRift", // FH - no crates
             };
 
             Assert.That(server.CfgMan.GetCVar(CVars.NetPVS), Is.False);

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -44,7 +44,7 @@ namespace Content.IntegrationTests.Tests
                     .Where(p => !p.Components.ContainsKey("RoomFill")) // This comp can delete all entities, and spawn others
                     .Where(p => !p.Components.ContainsKey("TraitorCodePaperComponent") && // FH - Prevets codeword system from freaking out
                                 !p.Components.ContainsKey("ParadoxCloneRuleComponent") && // FH - No people to clone in tests
-                                !p.Components.ContainsKey("RevSupplyRift")) // FH - no crates
+                                !p.Components.ContainsKey("RevSupplyRift")) // FH - I'm pretty sure revolutionary rift was breaking the game by spawning too many crates in tests, those crates weren't deleted properly and crashed tests
                     .Select(p => p.ID)
                     .ToList();
 
@@ -110,7 +110,7 @@ namespace Content.IntegrationTests.Tests
                     .Where(p => !p.Components.ContainsKey("RoomFill")) // This comp can delete all entities, and spawn others
                     .Where(p => !p.Components.ContainsKey("TraitorCodePaperComponent") && // FH - Prevets codeword system from freaking out
                                 !p.Components.ContainsKey("ParadoxCloneRuleComponent") && // FH - No people to clone in tests
-                                !p.Components.ContainsKey("RevSupplyRift")) // FH - no crates
+                                !p.Components.ContainsKey("RevSupplyRift")) // FH - I'm pretty sure revolutionary rift was breaking the game by spawning too many crates in tests, those crates weren't deleted properly and crashed tests
                     .Select(p => p.ID)
                     .ToList();
                 foreach (var protoId in protoIds)
@@ -173,7 +173,7 @@ namespace Content.IntegrationTests.Tests
                 .Where(p => !p.Components.ContainsKey("MapGrid")) // This will smash stuff otherwise.
                 .Where(p => !p.Components.ContainsKey("TraitorCodePaperComponent") && // FH - Prevets codeword system from freaking out
                             !p.Components.ContainsKey("ParadoxCloneRuleComponent") && // FH - No people to clone in tests
-                            !p.Components.ContainsKey("RevSupplyRift")) // FH - no crates
+                            !p.Components.ContainsKey("RevSupplyRift")) // FH - I'm pretty sure revolutionary rift was breaking the game by spawning too many crates in tests, those crates weren't deleted properly and crashed tests
                 .Select(p => p.ID)
                 .ToList();
 
@@ -256,7 +256,7 @@ namespace Content.IntegrationTests.Tests
 
                 "TraitorCodePaperComponent", // FH - Prevets codeword system from freaking out
                 "ParadoxCloneRuleComponent", // FH - No people to clone in tests
-                "RevSupplyRift", // FH - no crates
+                "RevSupplyRift", // FH - I'm pretty sure revolutionary rift was breaking the game by spawning too many crates in tests, those crates weren't deleted properly and crashed tests
             };
 
             Assert.That(server.CfgMan.GetCVar(CVars.NetPVS), Is.False);

--- a/Content.Shared/StepTrigger/Components/PreventableStepTriggerComponent.cs
+++ b/Content.Shared/StepTrigger/Components/PreventableStepTriggerComponent.cs
@@ -7,4 +7,8 @@ namespace Content.Shared.StepTrigger.Components;
 /// This is used for marking step trigger events that require the user to wear shoes or have protection of some sort, such as for glass shards.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class PreventableStepTriggerComponent : Component;
+public sealed partial class PreventableStepTriggerComponent : Component
+{
+    // Far Horizons - add ability for PreventableStepTriggerComponent to be used for anything other than barefoot and glass shards
+    [DataField] public string ProtectionKey = "default";
+}

--- a/Content.Shared/StepTrigger/Components/ProtectedFromStepTriggersComponent.cs
+++ b/Content.Shared/StepTrigger/Components/ProtectedFromStepTriggersComponent.cs
@@ -13,4 +13,7 @@ public sealed partial class ProtectedFromStepTriggersComponent : Component, IClo
 {
     [DataField]
     public SlotFlags Slots { get; set; } = SlotFlags.FEET;
+
+    // Far Horizons - add ability for PreventableStepTriggerComponent to be used for anything other than barefoot and glass shards
+    [DataField] public string ProtectionKey = "default";
 }

--- a/Content.Shared/StepTrigger/Systems/StepTriggerImmuneSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerImmuneSystem.cs
@@ -17,7 +17,9 @@ public sealed class StepTriggerImmuneSystem : EntitySystem
 
     private void OnStepTriggerClothingAttempt(Entity<PreventableStepTriggerComponent> ent, ref StepTriggerAttemptEvent args)
     {
-        if (HasComp<ProtectedFromStepTriggersComponent>(args.Tripper) || _inventory.TryGetInventoryEntity<ProtectedFromStepTriggersComponent>(args.Tripper, out _))
+        // Far Horizons adding ProtectionKey value so ProtectedFromStepTriggersComponent can be used for more things than just glass shards and boots
+        if ((TryComp<ProtectedFromStepTriggersComponent>(args.Tripper, out var protectionComp) && protectionComp.ProtectionKey == ent.Comp.ProtectionKey) || 
+            (_inventory.TryGetInventoryEntity<ProtectedFromStepTriggersComponent>(args.Tripper, out var invProtectionItem) && invProtectionItem.Comp!.ProtectionKey == ent.Comp.ProtectionKey))
         {
             args.Cancelled = true;
         }

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/NPCs/dungeon_borg.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/NPCs/dungeon_borg.yml
@@ -31,6 +31,8 @@
         15.0
       MaximumIdleTime: !type:Single
         30.0
+      MeleeMissChance: !type:Single
+        0.15 # Default was 0.3, lowering it to take into account lower attack speed these mobs have
       IdleRange: !type:Single
         5.5
   - type: Prying
@@ -42,6 +44,7 @@
   - type: NpcFactionMember
     factions:
     - DungeonSilicon
+  - type: NPCRetaliation
   - type: Hands
   - type: ComplexInteraction
   - type: Fixtures
@@ -115,6 +118,8 @@
   - type: Vocalizer
     minVocalizeInterval: 240
     maxVocalizeInterval: 360
+  - type: ProtectedFromStepTriggers
+    protectionKey: "dungeon_exploding_borg"
       
 
 # Base borg. Normal speed, attacks with a wrench. Unrobust
@@ -130,7 +135,8 @@
   - type: MeleeWeapon
     altDisarm: false
     attackRate: 0.75
-    angle: 90
+    angle: 60
+    autoAttack: true
     soundHit:
      collection: MetalThud
     animation: WeaponArcWrench
@@ -166,7 +172,8 @@
   - type: MeleeWeapon
     altDisarm: false
     attackRate: 0.75
-    angle: 90
+    angle: 60
+    autoAttack: true
     soundHit:
       path: /Audio/Weapons/Guns/Hits/energy_meat1.ogg
     animation: WeaponArcWelder
@@ -205,7 +212,8 @@
   - type: MeleeWeapon
     altDisarm: false
     attackRate: 4
-    angle: 15
+    angle: 30
+    autoAttack: true
     soundHit:
       path: /Audio/Items/drill_hit.ogg
     wideAnimationRotation: -90
@@ -245,7 +253,8 @@
   - type: MeleeWeapon
     altDisarm: false
     attackRate: 0.4
-    angle: 90
+    angle: 60
+    autoAttack: true
     soundHit:
       collection: MetalThud
     wideAnimationRotation: -90
@@ -286,7 +295,8 @@
   - type: MeleeWeapon
     altDisarm: false
     attackRate: 1.2
-    angle: 90
+    angle: 60
+    autoAttack: true
     soundHit:
       collection: AlienClaw
     animation: WeaponArcClaw
@@ -402,6 +412,8 @@
       requiredTriggeredSpeed: 0
       intersectRatio: 0.1
       ignoreWeightless: true
+    - type: PreventableStepTrigger
+      protectionKey: "dungeon_exploding_borg"
     - type: TriggerOnStepTrigger
     - type: Slippery
       slipData:

--- a/Resources/Prototypes/_FarHorizons/Procedural/salvage_factions.yml
+++ b/Resources/Prototypes/_FarHorizons/Procedural/salvage_factions.yml
@@ -8,19 +8,19 @@
       cost: 2
       prob: 0.7
     - proto: MobDungeonBorgMining
-      cost: 4
-      prob: 0.3
+      cost: 2
+      prob: 0.4
     - proto: MobDungeonBorgMedi
-      cost: 8
+      cost: 1
       prob: 0.25
     - proto: MobDungeonBorgMediExplosive
-      cost: 8
+      cost: 4
       prob: 0.25
     - proto: MobDungeonBorgJani
       cost: 6
       prob: 0.2
     - proto: MobDungeonBorgThing
-      cost: 9
+      cost: 8
       prob: 0.1
   difficulties: 
     - Challenging

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/soviet_armaments_crate.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/soviet_armaments_crate.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CrateSovietArmaments
-  parent: [CrateGenericSteel, BaseSovietContraband]
+  parent: [CrateGeneric, BaseSovietContraband]
   name: SKB armaments crate
   description: The red tide is here.
   components:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/soviet_armaments_crate.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/soviet_armaments_crate.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CrateSovietArmaments
-  parent: [CrateGeneric, BaseSovietContraband]
+  parent: [CrateGenericSteel, BaseSovietContraband]
   name: SKB armaments crate
   description: The red tide is here.
   components:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
fixes/updates for borg salvage enemy

Also pretty sure I fixed tests by blacklisting revolutionary portal which spawned bunch of crates

## Why we need to add this
yes

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- tweak: Explosive borgs in salvage expeditions will no longer go off by touching other NPC borgs
- tweak: Expedition borgs now have higher hit chance to account for their lower attack speed
- tweak: Rebalanced borg dungeon spawning rule to have more borg
- tweak: Expedition borgs will now properly defend themselves if a player borg, who NPC borgs welcomed as one of their own, attacks them