### PR TITLE
Test for lowering sec pop based on MATH

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Maps/oasis.yml
+++ b/Resources/Prototypes/_FarHorizons/Maps/oasis.yml
@@ -17,7 +17,7 @@
           emergencyShuttlePath: /Maps/Shuttles/emergency_accordia.yml
         - type: StationJobs
           availableJobs:
-            #service
+            #service - 20 people
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 2, 2 ]
@@ -29,12 +29,12 @@
             ServiceWorker: [ 3, 3 ]
             Zookeeper: [ 1, 1 ]
             Reporter: [ 1, 2 ]
-            #engineering
+            #engineering - 14 people
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 6, 6 ]
             TechnicalAssistant: [ 4, 4 ]
-            #medical
+            #medical - 13 people
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 2 ]
             MedicalDoctor: [ 6, 6 ]
@@ -42,20 +42,20 @@
             MedicalIntern: [ 4, 4 ]
             Psychologist: [ 1, 1 ]
             Surgeon: [ 2, 2 ]
-            #science
+            #science - 13 people
             ResearchDirector: [ 1, 1 ]
             Scientist: [ 6, 6 ]
             ResearchAssistant: [ 5, 5 ]
             Roboticist: [ 2, 2 ]
-            #security
+            #security - 16 Total / 14 Responders w/Cadets / 11 Avaliable w/o Cadets v 8 Antags
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 10, 10 ]
+            SecurityOfficer: [ 7, 7 ]
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 5, 5 ]
+            SecurityCadet: [ 3, 3 ]
             Brigmedic: [ 1, 1 ]
-            Corpsman: [1,1] #Far Horizons
-            SecBorg: [1,1] #Far Horizons
+            Corpsman: [ 1, 1 ]
+            SecBorg: [ 1, 1 ]
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageLead: [ 1, 1 ]
@@ -63,17 +63,17 @@
             MiningSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             MailTech: [ 1, 2 ]
-            #civilian
+            #civilian - 3 people
             Assistant: [ -1, -1 ]
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 2 ]
-            #silicon
+            #silicon - 5 people
             StationAi: [ 1, 1 ]
             Borg: [ 3, 4 ]
-            #law
+            #law - 3 people
             Magistrate: [ 1, 1 ]
             IAA: [ 2, 2 ]
-            #Representives
+            #Representives - 2 people
             BlueShield: [ 1, 1 ]
             NanoTrasenRepresentative: [ 1, 1 ]


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Changes Oasis sec pop to 16 instead of 21, vs 8 antags (80 pop)
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Lotta math, but, essentially wizden security manages a 14v8 situation just fine in the same conditions, given buffs have been given to both antags and sec on our side it should work well enough for us

I chose 80 pop because it's the middle ground between 60-100, which is the typical playercount FH gets. 
As for why it's not 16v8, it's because 2 security roles are never supposed to leave brig (ward/brigmedic), so it's a 14v8. 

If this test proves fruitful, I will remap and apply these standards to other medium-pop maps that we currently have.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Killer Tamashi
- tweak: Nerfed sec jobslot count on Oasis from 21 to 16.
