### PR TITLE
Moar bugfixes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -42,7 +42,7 @@
   parent: ClothingBackpackDuffelSyndicateBundle
   id: ClothingBackpackDuffelSyndicateFilledShotgun
   name: Bulldog bundle
-  description: "Lean and mean: Contains the popular Bulldog Shotgun, a 12g slug drum, and four 12g buckshot drums." #, and a pair of Thermal Imaging Goggles.
+  description: "Lean and mean: Contains the popular Bulldog Shotgun, three shotgun slug drums and a 12g buckshot drum." #, and a pair of Thermal Imaging Goggles.
   components:
   - type: EntityTableContainerFill
     containers:

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -49,9 +49,9 @@
       storagebase: !type:AllSelector
         children:
         - id: WeaponShotgunBulldog
-        - id: MagazineShotgun
-          amount: 3
+        - id: MagazineShotgun #FH
         - id: MagazineShotgunSlug
+          amount: 3 #FH
 #       - id: ThermalImagingGoggles
 
 - type: entity
@@ -161,7 +161,7 @@
         - id: MagazinePistolSubMachineGunSP  #FH
           amount: 5  #FH
         - id: MagazineShotgun  #FH
-          amount: 5  #FH
+          amount: 3  #FH
         - id: MagazineRifleSP  #FH
           amount: 4  #FH
         - id: MagazineMagnumRifleSP #FH
@@ -169,7 +169,7 @@
         - id: MagazineLightRifleBoxSP #FH
           amount: 4 #FH
         - id: MagazineShotgunSlug #FH
-          amount: 2 #FH
+          amount: 4 #FH
         - id: SpeedLoaderMagnumAP #FH
           amount: 2 #FH
         - id: SpeedLoaderMagnumSP #FH

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -97,7 +97,7 @@
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: MagazineShotgun
+        startingItem: MagazineShotgunSlug #FH
         priority: 2
         whitelist:
           tags:

--- a/Resources/Prototypes/_FarHorizons/Loadouts/Jobs/security.yml
+++ b/Resources/Prototypes/_FarHorizons/Loadouts/Jobs/security.yml
@@ -190,6 +190,15 @@
     - !type:GroupLoadoutEffect
       proto: MasterDet
 
+- type: loadout
+  id: SecurityRevolverInstigatorDet # Detective gets it as his starting firearm instead of the MK.
+  dummyEntity: WeaponRevolverInstigator
+  storage:
+    back:
+    - WeaponRevolverInstigator
+    - SpeedLoaderPistol40SP
+    - SpeedLoaderPistol40SP
+    - SpeedLoaderPistol40Rubber
 #region Sec Officer
 
 # Sidearm

--- a/Resources/Prototypes/_FarHorizons/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_FarHorizons/Loadouts/loadout_groups.yml
@@ -366,7 +366,7 @@
   loadouts:
   - SecurityRevolverInspectorM500
   - SecurityRevolverInspector
-  - SecurityRevolverInstigator
+  - SecurityRevolverInstigatorDet
 
 # Warden
 

--- a/Resources/Prototypes/_StarLight/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Jobs/Security/security_officer.yml
@@ -25,9 +25,10 @@
   dummyEntity: WeaponPistolMk58
   storage:
     back:
-      - WeaponPistolMk58Nonlethal #Far Horizons
+      - WeaponPistolMk58 #Far Horizons
+      - MagazinePistolSP #Far Horizons
       - MagazinePistolRubber #Far Horizons
-      - MagazinePistolSP
+      - MagazinePistolRubber #Far Horizons
 
 - type: loadout
   id: SecurityPistolDP


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes the issue of MK 78 sometimes not working, it was the fact that it was using a nonlethal MK 58 in loadout
As well as ammo changes to the bulldog so it's not hot garbage
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Killer Tamashi
- tweak: Changed bulldog ammo types, it now starts with slug by default and the bundle has 3 slug mags and 1 buckshot mag, instead of the reverse
- tweak: Changed shotgun magazine distribution in the ammo bundle from 2 slug mags to 4, and from 5 buckshot mags to 3
- fix: Fixed the MK 78 loadout variant not using the actual MK 78
- fix: Fixed detectives not spawning with a firearm due to little to no playtime requirements for sec jobs
