### PR TITLE
Partially reverts #41693 (Desoxyephedrine and Ephedrine) changes from wizden

### DIFF
--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -16,24 +16,23 @@
       - !type:HealthChange
         damage:
           types:
-            Poison: 0.55
-            Blunt: 0.5
+            Poison: 0.75 # FH pre wizden nerf
       # OD
       - !type:HealthChange
         conditions:
         - !type:ReagentCondition
           reagent: Desoxyephedrine
-          min: 16
+          min: 30 # FH pre wizden nerf threshold
         damage:
           types:
-            Poison: 3 # this is added to the base damage of the meth.
+            Poison: 2 # this is added to the base damage of the meth. # FH pre wizden nerf poison
             Asphyxiation: 2
     Narcotic:
       effects:
       # Main effects
       - !type:MovementSpeedModifier
-        walkSpeedModifier: 1.20
-        sprintSpeedModifier: 1.20
+        walkSpeedModifier: 1.35 #FH pre wizden nerf
+        sprintSpeedModifier: 1.35 #FH pre wizden nerf
       - !type:ModifyStatusEffect
         effectProto: StatusEffectDesoxyStamina # You are on meth. You keep going.
         time: 3
@@ -82,8 +81,8 @@
       effects:
       # Main effects
       - !type:MovementSpeedModifier
-        walkSpeedModifier: 1.15
-        sprintSpeedModifier: 1.15
+        walkSpeedModifier: 1.25 #FH pre wizden nerf
+        sprintSpeedModifier: 1.25 #FH pre wizden nerf
       - !type:ModifyStatusEffect
         effectProto: StatusEffectStunned
         time: 1
@@ -103,7 +102,7 @@
         conditions:
         - !type:ReagentCondition
           reagent: Ephedrine
-          min: 20
+          min: 30 #FH pre wizden nerf
         damage:
           types:
             Poison: 2


### PR DESCRIPTION
## Short description

Hyperzine got a considerable buff shipped with considerable nerfs to Ephedrine and M- Desoxyephedrine. The Hyperzine buffs make it actually a good purchase for traitor. 60 seconds of Doomguy mode on a large injector, 30 on a small. Pretty good. Ephedrine and Walter Whiteium however got nerfed alot overall and for Jesse we gotta cook one takes now brute damage ontop of poison damage if taken.

## Why we need to add this
To me this punishes crafty chemist both crewside and traitor needlessly by nerfing both Ephedrine and the white organic crystals that turn blue if impure IRL. The hyperzine buff Wizden implemented is, in my eyes, much needed though.

## Media (Video/Screenshots)
n/A, it returns (S)-N-Methyl-1-phenylpropan-2-amin and Ephedrine to its pre-nerfed states.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: IrkallaEpsilon
- tweak: Reverts Wizden nerfs to Pervitin (Desoxyephedrine) and Ephedrine
