### PR TITLE
Remove "Greenshift-like" modes from secret

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -359,10 +359,12 @@
     - DerelictGenericCyborgSpawn
     - BasicStationEventScheduler
     - MeteorSwarmMildScheduler
-    - SubGamemodesRule
+    - SubGamemodesRuleNoChangelings #Far Horizons
     - IonStorm
     - CockroachMigration
     - MouseMigration
     - BasicRoundstartVariation
     - BasicRoundstartVariation
     - BasicRoundstartVariation
+    - SLChangeling #Far Horizons
+    - Traitor #Far Horizons

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -15,17 +15,17 @@
     ShitStation: 0.10 #SL
     Xenoborgs: 0.15 #SL
 
-- type: weightedRandom
+- type: weightedRandom #FH - Adds to 100. God. Why was it in decimals..
   id: SecretLP
   weights:
-    Nukeops: 0.028818444
-    Traitor: 0.461095101
-    Zombie: 0.005763689
-    Changeling: 0.057636888 #SL
-    Zombieteors: 0.005763689
-    Survival: 0.057636888
-    KesslerSyndrome: 0.028818444
-    Revolutionary: 0.057636888
+    Nukeops: 0.02 #FH
+    Traitor: 0.6 #FH
+    Zombie: 0.03 #FH
+    Changeling: 0.2 #FH
+    Zombieteors: 0.01 #FH
+    Survival: 0.03 #FH
+    KesslerSyndrome: 0.01 #FH
+    Revolutionary: 0.05 #FH
     #Vampire: 0.115273775 #SL
-    Extended: 0.152737752
-    Wizard: 0.028818444
+#    Extended: 0 #FH
+    Wizard: 0.05 #FH


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Title.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
More accurately, changes ShitStation into an actual mode rather than "greenshift but the station is dirty" 
Also unfucks decimal counts on gamemode chances because holy god that's awful

As for why, sudden greenshift is not productive to playtesting nor should it be something that happens in secret by chance.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Killer Tamashi
- remove: Removed Extended from SecretLP (Low-Player) pool
- tweak: Changed ShitStation into being an actual gamemode with antags
