### PR TITLE
Adds the Mechwright Arm to trinkets for 20h of Engineering

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -104,6 +104,7 @@
   - MagicCrayon #SL
   - HappyHonk #SL
   - leftripperarm #SL
+  - rightmechwrightarm #FH
   - CigPackBub #SL
   - PillCanisterPsicodine #SL
   - ClothingDogTags # SL

--- a/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/trinkets.yml
@@ -476,6 +476,18 @@
   storage:
     back: 
       - LeftArmCyberRipper
+      
+- type: loadout #FH addition begin
+  id: rightmechwrightarm 
+  effects: 
+    - !type:JobRequirementLoadoutEffect
+      requirement:
+        !type:DepartmentTimeRequirement
+        department: DepartmentEngineering
+        time: 72000 #20 hours in engineering
+  storage:
+    back: 
+      - RightArmCyberMechwright #FH addition end      
 
 - type: loadout
   id: CigPackBub


### PR DESCRIPTION
## Short description
This PR adds the mechwright arm to trinkets for 20h of engineering. Engineering hours, not engineer hours. It still needs to be installed by a surgeon and thus doesn't come preinstalled. What it doesn't do is port SLs cyberlimb expansion.

## Why we need to add this
Ideally, some time later down the line by a more capable contributor/coder/dev there should be a cyberware rework so people can pick based on a point system or something. The mechwright arm in loadout is so far a neat addition for engineering mains similar to how the ripperdoc arm is a neat addition for those dedicating their time playing surgeon.

## Media (Video/Screenshots)
It adds an item to loadout.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: IrkallaEpsilon
- add: Adds mechwright arm to loadout

