### PR TITLE
Reverts #41716 from Wizden (Botany Nerfs to RandomMutation Chems)

### DIFF
--- a/Resources/Prototypes/Hydroponics/randomChemicals.yml
+++ b/Resources/Prototypes/Hydroponics/randomChemicals.yml
@@ -10,6 +10,10 @@
     - HeartbreakerToxin
     - Honk
     - BuzzochloricBees
+    - Nocturine #FH edit begin
+    - Lexorin
+    - Stimulants
+    - MuteToxin #FH edit end
   - quantity: 5
     weight: 1
     reagents:


### PR DESCRIPTION
## Short description
In the recent set of upstream pulls from Wizden a few botany nerfs  were shipped that disallow acquisition of Vestine chem family (i.e. Nocturine) by means of random plant mutation. This PR reverts the change from Wizden.

## Why we need to add this
Randomly rolling a rare chem is already quite rare and crafty botanists, both crew or antag alike should be rewarded for their efforts. This also breaks the meta of "Botanist has hyperzine plant, therefor must be a traitor due to having used Vestine to mutate". I know, wild to think botany is frequently played.

## Media (Video/Screenshots)
n/A, wizden change reverted


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: IrkallaEpsilon
- tweak: Reverts Wizden #41716; Plants can now be mutated to rarely grow Vestine derivatives.
