### PR TITLE
New Salvage Belt and update Salvage Webbing

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
@@ -121,6 +121,9 @@
   - type: Item
     sprite: Objects/Misc/fire_extinguisher_mini.rsi
     size: Small
+  - type: Tag #Far Horizons
+    tags:
+    - PocketFireExtinguish
   - type: SolutionContainerManager
     solutions:
       spray:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -379,6 +379,9 @@
             True: { state: base-unshaded }
             False: { state: base-unshaded-off }
     - type: PacifismAllowedGun
+    - type: Tag #Far Horizons
+      tags:
+      - GrappleGun
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -41,7 +41,8 @@
   equipment:
     id: QuartermasterPDA
     ears: ClothingHeadsetQM
-    belt: ClothingBeltSalvageWebbing #Far Horizons
+    rig: ClothingBeltSalvageWebbing #Far Horizons - They have this on top of a belt.
+    belt: ClothingBeltSalvage #Far Horizons - They also get a rig now
     pocket1: AppraisalTool
     gloves: ClothingHandsGlovesCargo #Far Horizons
   storage:

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -27,7 +27,8 @@
   equipment:
     #id: SalvagePDA #Far Horizons - Disabling because you spawn with one from loadout.
     ears: ClothingHeadsetCargo
-    belt: ClothingBeltSalvageWebbing #Far Horizons
+    rig: ClothingBeltSalvageWebbing #Far Horizons - They have this on top of a belt.
+    belt: ClothingBeltSalvage #Far Horizons - They also get a rig now
     gloves: ClothingHandsGlovesCargo #Far Horizons
   #storage:
     #back:

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Belt/belts.yml
@@ -93,6 +93,109 @@
           - Wrench
           - ImprovisedWrench
 
+- type: entity
+  parent: ClothingBeltStorageBase
+  id: ClothingBeltSalvage
+  name: Salvage Utility Belt
+  description: Can hold a various amount of lo- required gear used by the Salvage and Mining teams.
+  components:
+  - type: Sprite
+    sprite: _FarHorizons/Clothing/Belt/cargoutility.rsi
+  - type: Clothing
+    sprite: _FarHorizons/Clothing/Belt/cargoutility.rsi
+  - type: Storage
+    grid:
+    - 0,0,0,0 #left
+    - 0,1,0,1 #left vertical label
+    - 2,0,9,1
+    - 11,0,12,0 #right
+    - 11,1,11,1 #right - grapple
+    whitelist:
+      tags:
+        - Wirecutter
+        - Crowbar
+        - Screwdriver
+        - Flashlight
+        - Wrench
+        - GeigerCounter
+        - Flare
+        - CableCoil
+        - Powerdrill
+        - JawsOfLife
+        - CigPack
+        - Radio
+        - HolofanProjector
+        - Multitool
+        - AppraisalTool
+        - GPS
+        - WeldingMask
+        - RemoteSignaller
+        - ImprovisedCrowbar
+        - ImprovisedScrewdriver
+        - ImprovisedWirecutter
+        - ImprovisedWrench
+        - ImprovisedMultitool
+        - Knife
+        - GrappleGun
+        - Write
+        - Paper
+      components:
+        - StationMap
+        - SprayPainter
+        - SprayPainterAmmo
+        - NetworkConfigurator
+        - Welder
+        - PowerCell
+        - Geiger
+        - TrayScanner
+        - GasAnalyzer
+        - HandLabeler
+  - type: StorageFill
+    contents:
+      - id: HandLabeler
+      - id: WeaponMeleeBoxcutter
+      - id: AppraisalTool
+  - type: ItemMapper
+    sprite: *BeltOverlay
+    mapLayers:
+      drill:
+        whitelist:
+          tags:
+          - Powerdrill
+      cutters_red:
+        whitelist:
+          tags:
+          - Wirecutter
+          - ImprovisedWirecutter
+      crowbar:
+        whitelist:
+          tags:
+          - Crowbar
+          - ImprovisedCrowbar
+      crowbar_red:
+        whitelist:
+          tags:
+          - CrowbarRed
+      jaws:
+        whitelist:
+          tags:
+          - JawsOfLife
+      screwdriver_nuke:
+        whitelist:
+          tags:
+          - Screwdriver
+          - ImprovisedScrewdriver
+      multitool:
+        whitelist:
+          tags:
+            - Multitool
+            - ImprovisedMultitool
+      wrench:
+        whitelist:
+          tags:
+          - Wrench
+          - ImprovisedWrench
+
 #region Command
 
 - type: entity

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Rig/webbings.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Rig/webbings.yml
@@ -111,6 +111,28 @@
     sprite: _FarHorizons/Clothing/Belt/salvagewebbing.rsi
   - type: Clothing
     sprite: _FarHorizons/Clothing/Belt/salvagewebbing.rsi
+  - type: Storage
+    grid:
+    - 0,0,3,1
+    - 0,3,3,4
+    whitelist:
+      tags:
+        - CigPack
+        - MagazinePistol
+        - MagazineMagnum
+        - CombatKnife
+        - HandGrenade
+        - Radio
+        - Knife
+        - Cartridge
+        - Write
+        - Paper
+        - PocketFireExtinguish
+      components:
+        - DoorRemote
+        - Whistle
+        - BallisticAmmoProvider
+        - CartridgeAmmo
   - type: StorageFill
     contents:
       - id: SurvivalKnife

--- a/Resources/Prototypes/_FarHorizons/tags.yml
+++ b/Resources/Prototypes/_FarHorizons/tags.yml
@@ -56,6 +56,15 @@
   id: GasTurbineStator
 
 - type: Tag
+  id: GrappleGun
+
+- type: Tag
+  id: IntegrityAnalyzer
+
+- type: Tag
+  id: Inorganic
+  
+- type: Tag
   id: IPC
 
 - type: Tag
@@ -63,6 +72,42 @@
 
 - type: Tag
   id: JanicartKeys
+
+- type: Tag
+  id: LaserRifle
+
+- type: Tag
+  id: Lecter
+
+- type: Tag
+  id: Leikha
+
+- type: Tag
+  id: MagazineRifle40
+
+- type: Tag
+  id: MagazinePistolDouble
+
+- type: Tag
+  id: Markalibur1
+
+- type: Tag
+  id: MotorcycleKeys
+
+- type: Tag
+  id: NodeScanner
+
+- type: Tag
+  id: NT
+
+- type: Tag
+  id: OilPack
+
+- type: Tag
+  id: Organic
+
+- type: Tag
+  id: PocketFireExtinguish
 
 - type: Tag
   id: Protogen
@@ -116,43 +161,7 @@
   id: ProtogenCybernetics
 
 - type: Tag
-  id: OilPack
-
-- type: Tag
-  id: IntegrityAnalyzer
-
-- type: Tag
-  id: Inorganic
-
-- type: Tag
-  id: LaserRifle
-
-- type: Tag
-  id: Lecter
-
-- type: Tag
-  id: Leikha
-
-- type: Tag
-  id: MagazineRifle40
-
-- type: Tag
-  id: MagazinePistolDouble
-
-- type: Tag
-  id: Markalibur1
-
-- type: Tag
-  id: MotorcycleKeys
-
-- type: Tag
-  id: NodeScanner
-
-- type: Tag
-  id: NT
-
-- type: Tag
-  id: Organic
+  id: RamChip
 
 - type: Tag
   id: ResearchTreeMapElectronics
@@ -165,9 +174,6 @@
 
 - type: Tag
   id: RiotShotgun
-
-- type: Tag
-  id: RamChip
 
 - type: Tag
   id: RocketAmmo120mm
@@ -197,16 +203,7 @@
   id: Seismic
 
 - type: Tag
-  id: SP91RC
-
-- type: Tag
   id: Shadekin
-
-- type: Tag
-  id: SiliconEmotesFH
-
-- type: Tag
-  id: STVKeys
 
 - type: Tag
   id: ShotgunKammererCitadel
@@ -221,7 +218,16 @@
   id: ShotgunBoxAmmo
 
 - type: Tag
+  id: SiliconEmotesFH
+
+- type: Tag
+  id: SP91RC
+
+- type: Tag
   id: SpeedLoaderPistol # upstream removed or something
+
+- type: Tag
+  id: STVKeys
 
 - type: Tag
   id: Thaven

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/mining_specialist.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/mining_specialist.yml
@@ -25,7 +25,8 @@
   equipment:
     #id: MiningPDA #Far Horizons - Disabling because they can choose between PDA's in loadout.
     ears: ClothingHeadsetMining
-    belt: ClothingBeltSalvageWebbing #Far Horizons
+    rig: ClothingBeltSalvageWebbing #Far Horizons - They have this on top of a belt.
+    belt: ClothingBeltSalvage #Far Horizons - They also get a rig now
     gloves: ClothingHandsGlovesCargo #Far Horizons
   storage: #Far Horizons
     back:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Made a new salvage belt which can attach the grappling gun into (with it's own dedicated space) and it also spawns with a labeler, because salvage are organized insanity. Also can carry paper and pens just in case Salvage Lead actually wants to do their job.
Salvage Webbing can now carry pens, papers, and pocket fire extinguishers (they're small enough).

Salvagers/Miners/Quartermaster will spawn with Salvage Belts and Salvage Webbing now.

Organized our tag list because some people really fucked it up again.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Small QOL for salvagers based on this thread - https://discord.com/channels/1407077238876147783/1466799943900725411

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

<img width="552" height="262" alt="image" src="https://github.com/user-attachments/assets/0dc5c763-7c17-4248-a6c7-6e5c3603217f" />

<img width="495" height="388" alt="image" src="https://github.com/user-attachments/assets/992204b3-f3b4-4c6c-8d6a-add0240092a8" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: CorruptOmega
- add: Added Salvage Utility belt, with side slots for labeler and grappling gun. Can also carry paper and pens cause sometimes they do paperwork (:Doubt:)
- add: Salvage Utility Belt also spawns with a labeler for those organized chaos gremlins.
- tweak: Salvage Utility Rig can now carry pocket fire extinguishers and papers/pens. (No they don't start with them)
- tweak: Salvagers/Miners/Quartermaster now spawn with Salvage Utility Belt in belt slot and Salvage Utility Rig in rig slot
- fix: Our tag list is now organized again you chaos machines.
