### PR TITLE
Subtle text ability is now under AHelp flag

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -121,30 +121,33 @@ namespace Content.Server.Administration.Systems
 
                 if (TryComp(args.Target, out ActorComponent? targetActor))
                 {
-                    // AdminHelp
-                    Verb verb = new();
-                    verb.Text = Loc.GetString("ahelp-verb-get-data-text");
-                    verb.Category = VerbCategory.Admin;
-                    verb.Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/gavel.svg.192dpi.png"));
-                    verb.Act = () =>
-                        _console.RemoteExecuteCommand(player, $"openahelp \"{targetActor.PlayerSession.UserId}\"");
-                    verb.Impact = LogImpact.Low;
-                    args.Verbs.Add(verb);
-
-                    // Subtle Messages
-                    Verb prayerVerb = new();
-                    prayerVerb.Text = Loc.GetString("prayer-verbs-subtle-message");
-                    prayerVerb.Category = VerbCategory.Admin;
-                    prayerVerb.Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/pray.svg.png"));
-                    prayerVerb.Act = () =>
+                    if (adminData.HasFlag(AdminFlags.Adminhelp))  // Far Horizons
                     {
-                        _quickDialog.OpenDialog(player, "Subtle Message", "Message", "Popup Message", (string message, string popupMessage) =>
+                        // AdminHelp
+                        Verb verb = new();
+                        verb.Text = Loc.GetString("ahelp-verb-get-data-text");
+                        verb.Category = VerbCategory.Admin;
+                        verb.Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/gavel.svg.192dpi.png"));
+                        verb.Act = () =>
+                            _console.RemoteExecuteCommand(player, $"openahelp \"{targetActor.PlayerSession.UserId}\"");
+                        verb.Impact = LogImpact.Low;
+                        args.Verbs.Add(verb);
+
+                        // Subtle Messages
+                        Verb prayerVerb = new();
+                        prayerVerb.Text = Loc.GetString("prayer-verbs-subtle-message");
+                        prayerVerb.Category = VerbCategory.Admin;
+                        prayerVerb.Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/pray.svg.png"));
+                        prayerVerb.Act = () =>
                         {
-                            _prayerSystem.SendSubtleMessage(targetActor.PlayerSession, player, message, popupMessage == "" ? Loc.GetString("prayer-popup-subtle-default") : popupMessage);
-                        });
-                    };
-                    prayerVerb.Impact = LogImpact.Low;
-                    args.Verbs.Add(prayerVerb);
+                            _quickDialog.OpenDialog(player, "Subtle Message", "Message", "Popup Message", (string message, string popupMessage) =>
+                            {
+                                _prayerSystem.SendSubtleMessage(targetActor.PlayerSession, player, message, popupMessage == "" ? Loc.GetString("prayer-popup-subtle-default") : popupMessage);
+                            });
+                        };
+                        prayerVerb.Impact = LogImpact.Low;
+                        args.Verbs.Add(prayerVerb);
+                    }
 
                     // Spawn - Like respawn but on the spot.
                     var pref = _prefsManager.GetPreferences(targetActor.PlayerSession.UserId);


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Put subtle text ability under AdminHelp flag (previously was under just Admin)

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
That was never supposed to be used by mentors

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1151" height="692" alt="image" src="https://github.com/user-attachments/assets/bea907f2-a01a-4513-bcc1-e3ae7427c04f" />

<img width="788" height="485" alt="image" src="https://github.com/user-attachments/assets/3e8d9c82-b79c-43d7-a2db-e46d1ccd4f76" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: FAR HORIZONS TEAM
- tweak: Put subtle text under AdminHelp flag.
