### PR TITLE
Salvage Belt/Rig Part 2 - Missing Lockers/Salvage Lead. Also Experimental Security Helmet Sprite Fix

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
@@ -21,7 +21,7 @@
         - id: Screwdriver
         - id: Crowbar
         - id: Wirecutter
-        - id: ClothingBeltUtility
+        - id: ClothingBeltSalvage #Far Horizons - Replaced Utility belt with Salvage
         - id: OreBag
         - id: ClothingBeltSalvageWebbing
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -13,6 +13,7 @@
   table: !type:AllSelector
     children:
     - id: ClothingBeltSalvage #Far Horizons
+    - id: ClothingBeltSalvageWebbing #Far Horizons
     - id: SurvivalKnife
     - id: HandheldGPSBasic
 #    - id: RadioHandheld # Starlight - radio replaced with expedition radio

--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -12,13 +12,14 @@
   id: LockerFillSalvageSpecialist
   table: !type:AllSelector
     children:
-    - id: ClothingBeltUtilityFilled
+    - id: ClothingBeltSalvage #Far Horizons
     - id: SurvivalKnife
     - id: HandheldGPSBasic
 #    - id: RadioHandheld # Starlight - radio replaced with expedition radio
     - id: RadioHandheldExpedition # Starlight
     - id: AppraisalTool
-    - id: FireExtinguisher
+    - id: FireExtinguisherMini #Far Horizons - They can throw this in their rig.
+    - id: FireExtinguisher #Far Horizons - Just in case they want the larger one instead.
     - id: Flare
       prob: 0.3
       rolls: !type:ConstantNumberSelector

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -17,6 +17,7 @@
     - id: RadioHandheldExpedition #starlight
     - id: ClothingOuterHardsuitLuxmax #starlight
     - id: ClothingBeltSalvage #Far Horizons
+    - id: ClothingBeltSalvageWebbing #Far Horizons
     - id: SalvageShuttleConsoleCircuitboard #starlight
     - id: ShipLabeler # Far Horizons
     - id: MiningShuttleConsoleCircuitboard #starlight

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -16,6 +16,7 @@
     - id: PlushieLance #starlight
     - id: RadioHandheldExpedition #starlight
     - id: ClothingOuterHardsuitLuxmax #starlight
+    - id: ClothingBeltSalvage #Far Horizons
     - id: SalvageShuttleConsoleCircuitboard #starlight
     - id: ShipLabeler # Far Horizons
     - id: MiningShuttleConsoleCircuitboard #starlight

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -243,6 +243,7 @@
     - id: MiningDrill
     - id: ClothingEyesGlassesMeson
     - id: ClothingBeltSalvageWebbing
+    - id: ClothingBeltSalvage #Far Horizons
     - id: SeismicCharge
     - id: MineralScanner
       weight: 0.5

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Belt/belts.yml
@@ -153,8 +153,12 @@
   - type: StorageFill
     contents:
       - id: HandLabeler
-      - id: WeaponMeleeBoxcutter
-      - id: AppraisalTool
+      - id: Crowbar
+      - id: Wrench
+      - id: Screwdriver
+      - id: Wirecutter
+      - id: Welder
+      - id: NetworkConfigurator 
   - type: ItemMapper
     sprite: *BeltOverlay
     mapLayers:
@@ -426,7 +430,21 @@
 
 #region Security
 
-#region Syndicate Station #####
+
+
+
+
+
+
+
+
+
+
+
+
+#region Syndicate
+
+
 
 
 

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/cargo.yml
@@ -153,6 +153,7 @@
   table: !type:AllSelector
     children:
     - id: ClothingBeltSalvage #Far Horizons
+    - id: ClothingBeltSalvageWebbing #Far Horizons
     - id: SurvivalKnife
     - id: HandheldGPSBasic
     - id: RadioHandheld

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/cargo.yml
@@ -152,7 +152,7 @@
   id: LockerFillMiningSpecialist
   table: !type:AllSelector
     children:
-    - id: ClothingBeltUtilityFilled
+    - id: ClothingBeltSalvage #Far Horizons
     - id: SurvivalKnife
     - id: HandheldGPSBasic
     - id: RadioHandheld

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -319,6 +319,60 @@
     sprite: _Starlight/Clothing/Head/Hardsuits/experimental_security.rsi
   - type: Clothing
     sprite: _Starlight/Clothing/Head/Hardsuits/experimental_security.rsi
+  #Far Horizons-Start
+  - type: ToggleableVisuals
+    clothingVisuals:
+      head:
+        - state: on-equipped-HELMET 
+          shader: unshaded
+      head-avali:
+        - state: on-equipped-HELMET-avali
+          shader: unshaded
+      #head-dog:
+      #  - state: on-equipped-HELMET-dog
+      #    shader: unshaded
+      #head-reptilian:
+      #  - state: on-equipped-HELMET-reptilian
+      #    shader: unshaded
+      #head-resomi:
+      #  - state: on-equipped-HELMET-resomi
+      #    shader: unshaded
+      head-vox:
+        - state: on-equipped-HELMET-vox
+          shader: unshaded
+      head-vulpkanin:
+        - state: on-equipped-HELMET-vulpkanin
+          shader: unshaded
+  - type: Clothing
+    clothingVisuals:
+      head:
+        - state: off-equipped-HELMET
+      #  - state: equipped-head-unshaded
+      #    shader: unshaded
+      head-avali:
+        - state: off-equipped-HELMET-avali
+          shader: unshaded
+      #head-dog:
+      #  - state: off-equipped-HELMET-dog
+      #  - state: equipped-head-unshaded-dog
+      #    shader: unshaded
+      #head-reptilian:
+      #  - state: off-equipped-HELMET-reptilian
+      #  - state: equipped-head-unshaded-reptilian
+      #    shader: unshaded
+      #head-resomi:
+      #  - state: off-equipped-HELMET-resomi
+      #  - state: equipped-head-unshaded-resomi
+      #    shader: unshaded # Starlight end🌟
+      head-vox:
+        - state: off-equipped-HELMET-vox
+      #  - state: equipped-head-unshaded-vox
+      #    shader: unshaded
+      head-vulpkanin:
+        - state: off-equipped-HELMET-vulpkanin
+      #  - state: equipped-head-unshaded-vulpkanin
+      #    shader: unshaded
+# Far Horizons-End
   - type: PointLight
     color: "#ffeead"
     radius: 7

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -317,8 +317,6 @@
   components:
   - type: Sprite
     sprite: _Starlight/Clothing/Head/Hardsuits/experimental_security.rsi
-  - type: Clothing
-    sprite: _Starlight/Clothing/Head/Hardsuits/experimental_security.rsi
   #Far Horizons-Start
   - type: ToggleableVisuals
     clothingVisuals:
@@ -344,6 +342,7 @@
         - state: on-equipped-HELMET-vulpkanin
           shader: unshaded
   - type: Clothing
+    sprite: _Starlight/Clothing/Head/Hardsuits/experimental_security.rsi
     clothingVisuals:
       head:
         - state: off-equipped-HELMET

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/salvage_lead.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/salvage_lead.yml
@@ -28,7 +28,8 @@
   equipment:
     #id: SalvageLeadPDA - Far Horizons - Disabled because they get one in loadouts...
     ears: ClothingHeadsetSalvageLead
-    belt: ClothingBeltSalvageWebbing #Far Horizons
+    rig: ClothingBeltSalvageWebbing #Far Horizons - They have this on top of a belt.
+    belt: ClothingBeltSalvage #Far Horizons - They also get a rig now
     gloves: ClothingHandsGlovesCargo #Far Horizons
   #storage:
     #back:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
#### Salvage Belt and Rig
Minar kindly called me out on missing Salvage Belt/Rig in Salvage Lead equipment and that none of the lockers had the new belt, still holding the previous UtilityFilled Belt.
So I removed some of the cargo items from the belt - Appraisal tool and boxcutter but gave most of the items from the utility belt in return.
All lockers (Salvage/Mining/Quartermaster) now start with filled Salvage Belt + Rig. Salvage Locker starts with a fire extinguisher AND a pocket fire extinguisher, to utilize their new rig if they want to.


#### Second thing I fixed was the Experimental Security Hardsuit helmet. https://discord.com/channels/1407077238876147783/1467651286689382432
The experimental suit was parented back to the basic security hardsuit helmet, which had the various different layers for species. Experimental suit folder did not have some of the same stuff, like reptilian version. Copied over the layering section and commented out the stuff that didn't exist in the folder. 


## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Because I forgot stuff.



## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
### Salvage Locker
<img width="613" height="879" alt="image" src="https://github.com/user-attachments/assets/66a65e2e-a635-4f68-a1fc-5ad7eda2f84d" />

### Mining Locker
<img width="750" height="689" alt="image" src="https://github.com/user-attachments/assets/5c9c3ae9-782b-4a1c-b513-0714037751d9" />

### Quartermaster Locker
<img width="574" height="624" alt="image" src="https://github.com/user-attachments/assets/07d94fb4-a191-4fd8-9511-023a4cf9c481" />

### Experimental Security Hardsuit
<img width="357" height="568" alt="image" src="https://github.com/user-attachments/assets/ad941f97-c375-46d4-a61a-ecdcbab4cd1c" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: CorruptOmega
- add: Added Salvage Belt and Rig to Salvage Lead.
- tweak: Changed the starting items that are found within the salvage belt.
- add: New Salvage Belt and Rig can now be found in Salvage/Mining/Quartermaster Lockers just in case people don't spawn with them.
- fix: Security Experimental Hardsuit helmet no longer turns certain species into giant walking errors.
