### PR TITLE
auto implanting stuff into nukies and protogens

### DIFF
--- a/Content.Server/Clothing/Systems/OutfitSystem.cs
+++ b/Content.Server/Clothing/Systems/OutfitSystem.cs
@@ -1,7 +1,6 @@
 ﻿using Content.Server._FarHorizons.Factions;
 using Content.Server.Hands.Systems;
 using Content.Server.Preferences.Managers;
-using Content.Server.Storage.EntitySystems;
 using Content.Shared.Access.Components;
 using Content.Shared.Clothing;
 using Content.Shared.Hands.Components;
@@ -32,7 +31,6 @@ public sealed class OutfitSystem : EntitySystem
     [Dependency] private readonly SharedHumanoidAppearanceSystem _appearance = default!; //Starlight
     [Dependency] private readonly IServerFactionManager _factions = default!; // Far Horizons
     [Dependency] private readonly ContainerSystem _container = default!; // Far Horizons
-    [Dependency] private readonly StorageSystem _storage = default!; // Far Horizons
 
     public bool SetOutfit(EntityUid target, string gear, Action<EntityUid, EntityUid>? onEquipped = null, bool unremovable = false)
     {
@@ -81,24 +79,12 @@ public sealed class OutfitSystem : EntitySystem
             if (entProtos.Count == 0)
                 continue;
 
-            EntityUid? slotEnt = null;
-            StorageComponent? storage = null;
-            BaseContainer? container = null;
+            if (!_container.TryGetContainer(target, slotName, out var container)) continue;
 
-            if ((inventoryComponent != null &&
-                _invSystem.TryGetSlotEntity(target, slotName, out slotEnt, inventoryComponent: inventoryComponent) &&
-                TryComp(slotEnt, out storage) ||
-                _container.TryGetContainer(target, slotName, out container)))
+            foreach (var entProto in entProtos)
             {
-                foreach (var entProto in entProtos)
-                {
-                    var spawnedEntity = Spawn(entProto, spawnCoords);
-
-                    if (container != null)
-                        _container.Insert(spawnedEntity, container);
-                    else
-                        _storage.Insert(slotEnt!.Value, spawnedEntity, out _, storageComp: storage!, playSound: false);
-                }
+                var spawnedEntity = Spawn(entProto, spawnCoords);
+                _container.Insert(spawnedEntity, container);
             }
         }
         // Far Horizons end

--- a/Content.Server/Clothing/Systems/OutfitSystem.cs
+++ b/Content.Server/Clothing/Systems/OutfitSystem.cs
@@ -13,9 +13,7 @@ using Content.Shared.Preferences;
 using Content.Shared.Preferences.Loadouts;
 using Content.Shared.Roles;
 using Content.Shared.Station;
-using Content.Shared.Storage;
 using Robust.Server.Containers;
-using Robust.Shared.Containers;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 

--- a/Content.Server/Clothing/Systems/OutfitSystem.cs
+++ b/Content.Server/Clothing/Systems/OutfitSystem.cs
@@ -1,6 +1,7 @@
 ﻿using Content.Server._FarHorizons.Factions;
 using Content.Server.Hands.Systems;
 using Content.Server.Preferences.Managers;
+using Content.Server.Storage.EntitySystems;
 using Content.Shared.Access.Components;
 using Content.Shared.Clothing;
 using Content.Shared.Hands.Components;
@@ -13,6 +14,9 @@ using Content.Shared.Preferences;
 using Content.Shared.Preferences.Loadouts;
 using Content.Shared.Roles;
 using Content.Shared.Station;
+using Content.Shared.Storage;
+using Robust.Server.Containers;
+using Robust.Shared.Containers;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
@@ -27,6 +31,8 @@ public sealed class OutfitSystem : EntitySystem
     [Dependency] private readonly SharedStationSpawningSystem _spawningSystem = default!;
     [Dependency] private readonly SharedHumanoidAppearanceSystem _appearance = default!; //Starlight
     [Dependency] private readonly IServerFactionManager _factions = default!; // Far Horizons
+    [Dependency] private readonly ContainerSystem _container = default!; // Far Horizons
+    [Dependency] private readonly StorageSystem _storage = default!; // Far Horizons
 
     public bool SetOutfit(EntityUid target, string gear, Action<EntityUid, EntityUid>? onEquipped = null, bool unremovable = false)
     {
@@ -42,6 +48,8 @@ public sealed class OutfitSystem : EntitySystem
             profile = _appearance.GetBaseProfile((target, appearanceComponent));
         #endregion Starlight
 
+        var spawnCoords = EntityManager.GetComponent<TransformComponent>(target).Coordinates; // Far Horizons
+
         if (_invSystem.TryGetSlots(target, out var slots))
         {
             foreach (var slot in slots)
@@ -51,7 +59,7 @@ public sealed class OutfitSystem : EntitySystem
                 if (gearStr == string.Empty)
                     continue;
 
-                var equipmentEntity = EntityManager.SpawnEntity(gearStr, EntityManager.GetComponent<TransformComponent>(target).Coordinates);
+                var equipmentEntity = EntityManager.SpawnEntity(gearStr, spawnCoords); // Far Horizons
                 if (slot.Name == "id" &&
                     EntityManager.TryGetComponent(equipmentEntity, out PdaComponent? pdaComponent) &&
                     EntityManager.TryGetComponent<IdCardComponent>(pdaComponent.ContainedId, out var id))
@@ -66,6 +74,34 @@ public sealed class OutfitSystem : EntitySystem
                 onEquipped?.Invoke(target, equipmentEntity);
             }
         }
+
+        // Far Horizons start
+        foreach (var (slotName, entProtos) in startingGear.Storage)
+        {
+            if (entProtos.Count == 0)
+                continue;
+
+            EntityUid? slotEnt = null;
+            StorageComponent? storage = null;
+            BaseContainer? container = null;
+
+            if ((inventoryComponent != null &&
+                _invSystem.TryGetSlotEntity(target, slotName, out slotEnt, inventoryComponent: inventoryComponent) &&
+                TryComp(slotEnt, out storage) ||
+                _container.TryGetContainer(target, slotName, out container)))
+            {
+                foreach (var entProto in entProtos)
+                {
+                    var spawnedEntity = Spawn(entProto, spawnCoords);
+
+                    if (container != null)
+                        _container.Insert(spawnedEntity, container);
+                    else
+                        _storage.Insert(slotEnt!.Value, spawnedEntity, out _, storageComp: storage!, playSound: false);
+                }
+            }
+        }
+        // Far Horizons end
 
         if (EntityManager.TryGetComponent(target, out HandsComponent? handsComponent))
         {

--- a/Content.Server/_FarHorizons/AutoImplanter/AutoImplanterComponent.cs
+++ b/Content.Server/_FarHorizons/AutoImplanter/AutoImplanterComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.Containers;
+
+namespace Content.Server._FarHorizons.AutoImplanter;
+
+[RegisterComponent]
+public sealed partial class AutoImplanterComponent : Component
+{
+    public const string ContainerId = "autoImplant";
+
+    [ViewVariables] public Container Container = default!;
+}

--- a/Content.Server/_FarHorizons/AutoImplanter/AutoImplanterSystem.cs
+++ b/Content.Server/_FarHorizons/AutoImplanter/AutoImplanterSystem.cs
@@ -1,0 +1,30 @@
+using Content.Server.Implants;
+using Content.Shared.Implants.Components;
+using Robust.Shared.Containers;
+
+namespace Content.Server._FarHorizons.AutoImplanter;
+
+public sealed class AutoImplanterSystem : EntitySystem
+{
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly ImplanterSystem _implanter = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<AutoImplanterComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<AutoImplanterComponent, EntInsertedIntoContainerMessage>(OnEntityInserted);
+    }
+
+    private void OnEntityInserted(Entity<AutoImplanterComponent> ent, ref EntInsertedIntoContainerMessage args)
+    {
+        if (args.Container.ID != AutoImplanterComponent.ContainerId ||
+            !TryComp<ImplanterComponent>(args.Entity, out var comp))
+            return;
+
+        _implanter.Implant(ent, ent, args.Entity, comp);
+        QueueDel(args.Entity);
+    }
+
+    private void OnInit(Entity<AutoImplanterComponent> ent, ref ComponentInit args) => 
+        ent.Comp.Container = _container.EnsureContainer<Container>(ent, AutoImplanterComponent.ContainerId);
+}

--- a/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
@@ -49,4 +49,6 @@ public sealed partial class LoadoutPrototype : IPrototype, IEquipmentLoadout
     /// <inheritdoc />
     [DataField]
     public Dictionary<string, List<EntProtoId>> Storage { get; set; } = new();
+
+    [DataField] public Dictionary<string, List<EntProtoId>> Containers { get; set; } = new(); // Far Horizons
 }

--- a/Content.Shared/Station/SharedStationSpawningSystem.cs
+++ b/Content.Shared/Station/SharedStationSpawningSystem.cs
@@ -13,7 +13,8 @@ using Robust.Shared.Map; // Starlight
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
-using Content.Shared.Preferences; // Starlight
+using Content.Shared.Preferences;
+using Robust.Shared.Containers; // Starlight
 
 namespace Content.Shared.Station;
 
@@ -27,6 +28,7 @@ public abstract class SharedStationSpawningSystem : EntitySystem
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] private readonly SharedTransformSystem _xformSystem = default!;
     [Dependency] private readonly ItemSlotsSystem _itemSlots = default!; // Starlight
+    [Dependency] private readonly SharedContainerSystem _container = default!; // Far Horizons
 
     private EntityQuery<HandsComponent> _handsQuery;
     private EntityQuery<InventoryComponent> _inventoryQuery;
@@ -178,18 +180,27 @@ public abstract class SharedStationSpawningSystem : EntitySystem
                 if (entProtos == null || entProtos.Count == 0)
                     continue;
 
-                if (inventoryComp != null &&
-                    InventorySystem.TryGetSlotEntity(entity, slotName, out var slotEnt, inventoryComponent: inventoryComp) &&
-                    _storageQuery.TryComp(slotEnt, out var storage))
-                {
+                // Far Horizons start
+                EntityUid? slotEnt = null;
+                StorageComponent? storage = null;
+                BaseContainer? container = null;
 
+                if ((inventoryComp != null &&
+                    InventorySystem.TryGetSlotEntity(entity, slotName, out slotEnt, inventoryComponent: inventoryComp) &&
+                    _storageQuery.TryComp(slotEnt, out storage) || 
+                    _container.TryGetContainer(entity, slotName, out container)))
+                {
                     foreach (var entProto in entProtos)
                     {
                         var spawnedEntity = Spawn(entProto, coords);
 
-                        _storage.Insert(slotEnt.Value, spawnedEntity, out _, storageComp: storage, playSound: false);
+                        if (container != null)
+                            _container.Insert(spawnedEntity, container);
+                        else
+                            _storage.Insert(slotEnt!.Value, spawnedEntity, out _, storageComp: storage!, playSound: false);
                     }
                 }
+                // Far Horizons end
                 // Starlight start
                 else if (inventoryComp != null &&
                     InventorySystem.TryGetSlotEntity(entity, slotName, out var slotEnt2, inventoryComponent: inventoryComp) &&
@@ -333,17 +344,27 @@ public abstract class SharedStationSpawningSystem : EntitySystem
                 if (entProtos == null || entProtos.Count == 0)
                     continue;
 
-                if (inventoryComp != null &&
-                    InventorySystem.TryGetSlotEntity(entity, slotName, out var slotEnt, inventoryComponent: inventoryComp) &&
-                    _storageQuery.TryComp(slotEnt, out var storage))
+                // Far Horizons start
+                EntityUid? slotEnt = null;
+                StorageComponent? storage = null;
+                BaseContainer? container = null;
+
+                if ((inventoryComp != null &&
+                    InventorySystem.TryGetSlotEntity(entity, slotName, out slotEnt, inventoryComponent: inventoryComp) &&
+                    _storageQuery.TryComp(slotEnt, out storage) || 
+                    _container.TryGetContainer(entity, slotName, out container)))
                 {
                     foreach (var entProto in entProtos)
                     {
                         var spawnedEntity = Spawn(entProto, coords);
 
-                        _storage.Insert(slotEnt.Value, spawnedEntity, out _, storageComp: storage, playSound: false);
+                        if (container != null)
+                            _container.Insert(spawnedEntity, container);
+                        else
+                            _storage.Insert(slotEnt!.Value, spawnedEntity, out _, storageComp: storage!, playSound: false);
                     }
                 }
+                // Far Horizons end
                 else if (inventoryComp != null &&
                     InventorySystem.TryGetSlotEntity(entity, slotName, out var slotEnt2, inventoryComponent: inventoryComp) &&
                     _itemSlotsQuery.TryComp(slotEnt2, out var itemSlots))

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -238,6 +238,7 @@
     - Pet
     - Boop
   # Starlight End
+  - type: AutoImplanter # Far Horizons
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -363,6 +363,7 @@
     tags:
     - SubdermalImplant
     - HideContextMenu
+    - MicroBomb # Far Horizons. A bit hacky but saves on adding new tag just for this. Ensures macro bomb replaces acidifier (since acidifier prevents macro from working properly)
 
 - type: entity
   parent: BaseSubdermalImplant

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -82,6 +82,7 @@
     back:
     - WeaponPistolViper
     - PinpointerSyndicateNuclear
+    autoImplant: # Far Horizons
     - DeathAcidifierImplanter
 
 #Nuclear Operative Gear
@@ -143,6 +144,7 @@
     - PinpointerSyndicateNuclear
     - HandheldHealthAnalyzer
     - CombatMedipen
+    autoImplant: # Far Horizons
     - DeathAcidifierImplanter
 
 - type: chameleonOutfit

--- a/Resources/Prototypes/_FarHorizons/Roles/Jobs/CentComm/administrative.yml
+++ b/Resources/Prototypes/_FarHorizons/Roles/Jobs/CentComm/administrative.yml
@@ -31,8 +31,9 @@
     ears: ClothingHeadsetAltCentCom
     belt: BoxFolderCentComClipboardThreePapers
     suitstorage: WeaponPistolN1984
-    pocket1: MindShieldImplanter
-    pocket2: DeathRattleImplanterCentcomm
+    pocket1: MagazineMagnum
     suitstorage2: NitrogenTankFilled
-  inhand:
-    - MagazineMagnum
+  storage:
+    autoImplant:
+      - MindShieldImplanter
+      - DeathRattleImplanterCentcomm

--- a/Resources/Prototypes/_FarHorizons/Roles/Jobs/CentComm/intelligence.yml
+++ b/Resources/Prototypes/_FarHorizons/Roles/Jobs/CentComm/intelligence.yml
@@ -31,8 +31,9 @@
     ears: ClothingHeadsetAltCentCom
     belt: ClothingBeltSheathFilled
     suitstorage: WeaponSubMachineGunWt550
-    pocket1: MindShieldImplanter
-    pocket2: DeathRattleImplanterCentcomm
+    pocket1: MagazinePistolSubMachineGunTopMounted
     suitstorage2: NitrogenTankFilled
-  inhand:
-    - MagazinePistolSubMachineGunTopMounted
+  storage:
+    autoImplant:
+      - MindShieldImplanter
+      - DeathRattleImplanterCentcomm

--- a/Resources/Prototypes/_FarHorizons/Roles/Jobs/CentComm/security.yml
+++ b/Resources/Prototypes/_FarHorizons/Roles/Jobs/CentComm/security.yml
@@ -31,8 +31,9 @@
     ears: ClothingHeadsetAltCentCom
     belt: ClothingBeltNTNCRigFilled
     suitstorage: WeaponSubMachineGunWt550
-    pocket1: MindShieldImplanter
-    pocket2: DeathRattleImplanterCentcomm
+    pocket1: MagazinePistolSubMachineGunTopMounted
     suitstorage2: NitrogenTankFilled
-  inhand:
-    - MagazinePistolSubMachineGunTopMounted
+  storage:
+    autoImplant:
+      - MindShieldImplanter
+      - DeathRattleImplanterCentcomm

--- a/Resources/Prototypes/_FarHorizons/Species/Loadouts/protogen_loadouts.yml
+++ b/Resources/Prototypes/_FarHorizons/Species/Loadouts/protogen_loadouts.yml
@@ -39,5 +39,5 @@
 - type: loadout
   id: ProtogenTrinaryImplant
   storage:
-    back: 
+    autoImplant: 
     - TrinaryImplanter


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds a slot to every playable species where implanters can be placed and then automatically injected into the character. Slots can be populated with admin commands or with loadouts.

## Why we need to add this
QoL for protogens, enforcing what should be a required gear for nukies

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/39e91abb-1b11-4ad6-adc7-1ee533f8d0ec


https://github.com/user-attachments/assets/ae790f6b-513b-45ba-bca8-a261d0b95138



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- add: Support for automatically implanting subdermal implants from character loadout or admin commands
- add: Protogens now have their radio automatically implanted on spawn
- add: Nukies now have their acidifier automatically implanted on spawn
- add: CC outfits also come with implants on equip
- tweak: Macro-bomb implant now replaces acidifier when installed