### PR TITLE
Small bugfix for Mining Specialists

### DIFF
--- a/Resources/Locale/en-US/_FarHorizons/Factions/loadouts.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/Factions/loadouts.ftl
@@ -1,3 +1,7 @@
+###### GSL
+
+loadout-group-mining-belt = Mining Specialist Belt
+
 ###### NanoTrasen
 
 ## Specific Roles

--- a/Resources/Prototypes/_FarHorizons/Loadouts/Jobs/cargo.yml
+++ b/Resources/Prototypes/_FarHorizons/Loadouts/Jobs/cargo.yml
@@ -1,3 +1,8 @@
+- type: loadout
+  id: GSLSalvageBelt
+  equipment:
+    belt: ClothingBeltSalvage
+
 # Cargo Technician
 
 - type: loadout
@@ -27,6 +32,11 @@
   equipment:
     back: ClothingBackpackSatchelMining
     
+- type: loadout
+  id: MiningOreBag
+  equipment:
+    belt: OreBag
+
 # Salvage Technician
 
 - type: loadout

--- a/Resources/Prototypes/_FarHorizons/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_FarHorizons/Loadouts/loadout_groups.yml
@@ -18,6 +18,13 @@
   - MiningDuffel
   - MiningSatchel
 
+- type: loadoutGroup
+  id: MiningSpecialistBelt
+  name: loadout-group-mining-belt
+  loadouts:
+  - MiningOreBag
+  - GSLSalvageBelt
+
 # Salvage Specialist
 
 - type: loadoutGroup

--- a/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
@@ -92,9 +92,10 @@
   groups:
   - MiningSpecialistBackpack # Far Horizons
   - MiningSpecialistHead
-  - SalvageSpecialistBackpack
+  #- SalvageSpecialistBackpack #Far Horizons
   - MiningSpecialistJumpsuit
   - SalvageSpecialistOuterClothing
+  - MiningSpecialistBelt #Far Horizons
   - SalvageSpecialistShoes
   - MiningSpecialistPDA
   - Glasses

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/mining_specialist.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/mining_specialist.yml
@@ -26,11 +26,11 @@
     #id: MiningPDA #Far Horizons - Disabling because they can choose between PDA's in loadout.
     ears: ClothingHeadsetMining
     rig: ClothingBeltSalvageWebbing #Far Horizons - They have this on top of a belt.
-    belt: ClothingBeltSalvage #Far Horizons - They also get a rig now
+    #belt: ClothingBeltSalvage #Far Horizons - They also get a rig now
     gloves: ClothingHandsGlovesCargo #Far Horizons
-  storage: #Far Horizons
-    back:
-    - OreBag # Unfortunately this just drops to the ground and I don't feel like changing that fact. -Corrupt
+  #storage: #Far Horizons
+  #  back:
+  #  - OreBag #In a moment of brilliance, we have decided it won't be spawned in this way anymore.
 
 - type: chameleonOutfit
   id: MiningSpecialistChameleonOutfit


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Mining Specialist won't spawn with a mining bag AND salvage bag anymore.
Mining Specialist can now choose to spawn with an Ore Bag or a Salvage Utility Belt. 

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Small bug fix so orebags don't drop at their feet at spawn and they don't steal Salvage's bags.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1566" height="711" alt="image" src="https://github.com/user-attachments/assets/42383af1-44a3-446f-87cc-254a1c4049e8" />

<img width="1011" height="340" alt="image" src="https://github.com/user-attachments/assets/0fe34b63-7ca0-4b3c-8313-551830b52b5c" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: CorruptOmega
- fix: Mining Specialists will no longer steal Salvage bags on top of their own at spawn.
- fix: Mining Specialists can now choose to spawn with an Ore Bag or Salvage Belt in their belt slot, so they stop dropping an Ore Bag at their feet.
