### PR TITLE
Fixed Cloaking and Invis module for stealthborg

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/cloaking_device.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/cloaking_device.yml
@@ -15,7 +15,7 @@
       minVisibility: 0.1
       lastVisibility: 0.1
   - type: PowerCellDraw
-    drawRate: 19 # 100 seconds
+    drawRate: 19 # 100 seconds #Far Horizons
   - type: ToggleCellDraw
   - type: PowerCellSlot
     cellSlotId: cell_slot
@@ -26,7 +26,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellMicroreactor
+        startingItem: PowerCellMicroreactor #Far Horizons
         disableEject: true
         swap: false
 
@@ -43,4 +43,4 @@
       minVisibility: -1
       lastVisibility: -1
   - type: PowerCellDraw
-    drawRate: 36 # 30 seconds
+    drawRate: 36 # 30 seconds #Far Horizons

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/cloaking_device.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/cloaking_device.yml
@@ -15,7 +15,7 @@
       minVisibility: 0.1
       lastVisibility: 0.1
   - type: PowerCellDraw
-    drawRate: 3.6 # 100 seconds
+    drawRate: 19 # 100 seconds
   - type: ToggleCellDraw
   - type: PowerCellSlot
     cellSlotId: cell_slot
@@ -26,7 +26,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellSmallNuclear
+        startingItem: PowerCellMicroreactor
         disableEject: true
         swap: false
 
@@ -43,4 +43,4 @@
       minVisibility: -1
       lastVisibility: -1
   - type: PowerCellDraw
-    drawRate: 12 # 30 seconds
+    drawRate: 36 # 30 seconds


### PR DESCRIPTION
Formerly infinite, was not intended, fixed now to reflect intended times in code

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Invis module and cloaking module for stealth xenoborg were both formerly infinite duration, this was not intended in the code, also it was given a nuclear cell which im sure also was not intended as that recharges to full in 10 seconds and completely circumvents the purpose of a cooldown, replaced with a micro.

Invis module - 30 second duration
Cloaking module - 100 second duration

Both now have micros and take much longer to recharge, rather than 10 seconds, since the nuclear cell completely ruins the point of something having a time limit cus its so fast.

## Why we need to add this
Bug fix, was very annoying to deal with ingame too.

## Media (Video/Screenshots)
Unable to send video on github but i have a video of it working, ask and ill ping you on the discord with it, my apologies. 

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**

:cl: Roro
- fix: Cloaking and Invis modules for stealth xenoborg are no longer infinite duration, this was a bug, its intended times were written in code but broken.
