### PR TITLE
Quick Fix for Sirens on Hardsuits

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -36,6 +36,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitAtmos
@@ -77,6 +78,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineering
@@ -115,6 +117,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSpatio
@@ -158,6 +161,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSalvage
@@ -199,6 +203,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitGoliath
@@ -243,7 +248,8 @@
         Caustic: 0.8 
   - type: ClothingSpeedModifier
     walkModifier: 0.85
-    sprintModifier: 0.85 
+    sprintModifier: 0.85
+    requireActivated: false #FH cuz item toggle.
   - type: ExplosionResistance
     damageCoefficient: 0.4 
     # end region starlight
@@ -524,6 +530,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCap
@@ -567,6 +574,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineeringWhite
@@ -603,6 +611,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.0 # Starlight Edit
     sprintModifier: 1.0 # Starlight Edit
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitMedical
@@ -644,6 +653,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: Item
     size: Huge
@@ -784,6 +794,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitLuxury
@@ -835,6 +846,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: FootstepModifier # STARLIGHT
     footstepSoundCollection:
@@ -946,6 +958,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: FootstepModifier # STARLIGHT
     footstepSoundCollection:
@@ -1008,6 +1021,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.95
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: FootstepModifier # STARLIGHT
     footstepSoundCollection:
@@ -1083,6 +1097,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.65
     sprintModifier: 0.65
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: FootstepModifier #starlight
     footstepSoundCollection:
@@ -1137,6 +1152,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWizard
@@ -1179,6 +1195,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitLing
@@ -1215,6 +1232,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.6
     sprintModifier: 0.6
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitPirateEVA
@@ -1254,6 +1272,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitPirateCap
@@ -1470,6 +1489,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitDeathsquad
@@ -1516,6 +1536,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetCBURN
@@ -1552,6 +1573,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: Construction
     graph: ClownHardsuit
@@ -1604,6 +1626,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSanta
@@ -1639,5 +1662,6 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: Unremoveable

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -343,6 +343,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurity
@@ -416,6 +417,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.85 #FH edit
     sprintModifier: 0.85 #FH edit
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBrigmedic
@@ -481,6 +483,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWarden
@@ -720,6 +723,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurityRed

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -43,6 +43,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.80
     sprintModifier: 0.80
+    requireActivated: false
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitHoP
 
@@ -65,6 +66,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.95
+    requireActivated: false
   - type: Pierceable
     level: Metal
   - type: Armor
@@ -146,7 +148,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.80
     sprintModifier: 0.80
-    requireActivated: false #FH cuz item toggle.
+    requireActivated: false
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCorpsman
@@ -203,6 +205,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+    requireActivated: false
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCapSyndi
@@ -278,6 +281,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+    requireActivated: false
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineeringWhiteSyndi
@@ -326,6 +330,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
+    requireActivated: false
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitAtmosSyndi
@@ -368,6 +373,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
+    requireActivated: false
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineeringSyndi
@@ -446,6 +452,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.95
+    requireActivated: false
   - type: Pierceable
     level: Metal
   - type: Armor

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -146,6 +146,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.80
     sprintModifier: 0.80
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCorpsman

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -15,6 +15,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+    requireActivated: false #FH cuz item toggle.
   - type: Pierceable
     level: Metal
   - type: Armor
@@ -53,6 +54,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.95
+    requireActivated: false #FH cuz item toggle.
   - type: Pierceable
     level: Metal
   - type: Armor
@@ -101,6 +103,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.85
     sprintModifier: 0.8
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetBattlesuitClown
@@ -122,6 +125,7 @@
     - type: ClothingSpeedModifier
       walkModifier: 0.9
       sprintModifier: 0.9
+      requireActivated: false #FH cuz item toggle.
     - type: Pierceable
       level: Metal
     - type: Armor
@@ -167,6 +171,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.85
     sprintModifier: 0.85
+    requireActivated: false #FH cuz item toggle.
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSpaceHazard
@@ -255,6 +260,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
+    requireActivated: false #FH cuz item toggle.
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: ToggleClothing


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes hardsuits requiring the siren to be on in order for speed modifiers to be enabled.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Can't have sec be super fast on their hardsuits.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/58e05b79-a331-4089-a0cb-3a7b8bb7a620


https://github.com/user-attachments/assets/4272d691-1064-486a-97ef-3c6d9e4d0315



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: AthenaAI
- fix: Fixed an issue where siren was required to be toggled on for speed penalties to be in effect.
