### PR TITLE
Fix avali and proto-avali stasis and its numbers

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
@@ -2690,6 +2690,16 @@
     - type: Stasis
       enterStasisAction: ActionStasisEnter
       exitStasisAction: ActionStasisExit
+      updateInterval: 1s
+      healingPerUpdate:
+        types:
+          Heat: 2
+          Cold: 2
+        groups:
+          Brute: 6
+      bleedHealPerUpdate: 1.0
+      critHealingModifier: 0.5
+      stasisDamageReduction: 0.7
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
@@ -164,8 +164,10 @@
         groups:
           Brute: 6
       bleedHealPerUpdate: 1.0
-      critHealingModifier: 2.0
-      stasisDamageReduction: 0.5
+      # FarHorizon edit start
+      critHealingModifier: 0.5 
+      stasisDamageReduction: 0.7
+      # FarHorizon edit end
 
 # Chirp!
 


### PR DESCRIPTION
## Short description
This PR fixes stasis for protogen avali, which is not working if it is not having defined numbers,
this PR also fixes the numbers, which were set incorrectly by upstream.

## Why we need to add this
It makes the stasis work as intended.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- tweak: Changed numbers on stasis for both avali and protogen avali.
- fix: Fixed stasis on protogen avali.