### PR TITLE
HOTFIX - Changed some antag role requirements

### DIFF
--- a/Resources/Prototypes/Roles/Antags/dragon.yml
+++ b/Resources/Prototypes/Roles/Antags/dragon.yml
@@ -4,6 +4,8 @@
   antagonist: true
   objective: roles-antag-dragon-objective
   requirements:
-  - !type:RoleTimeRequirement
-    role: JobSalvageSpecialist
-    time: 10800 # 3h STARLIGHT
+  - !type:OverallPlaytimeRequirement #Far Horizons
+    time: 7200 # 2 hours - Far Horizons
+  #- !type:RoleTimeRequirement #Far Horizons
+  #  role: JobSalvageSpecialist
+  #  time: 10800 # 3h STARLIGHT

--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -7,9 +7,11 @@
   guides: [ SpaceNinja ]
   previewStartingGear: SpaceNinjaGear
   requirements:
-  - !type:DepartmentTimeRequirement
-    department: Security
-    time: 10800 # 3h STARLIGHT
+  - !type:OverallPlaytimeRequirement #Far Horizons
+    time: 7200 # 2 hours - Far Horizons
+#  - !type:DepartmentTimeRequirement #Far Horizons
+#    department: Security
+#    time: 10800 # 3h STARLIGHT
 
 #Ninja Gear
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/paradoxClone.yml
+++ b/Resources/Prototypes/Roles/Antags/paradoxClone.yml
@@ -6,7 +6,7 @@
   setPreference: false
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 0 # Far Horizons - Temporary // 86400 # 24h STARLIGHT
+    time: 7200 # 2 hours - Far Horizons // 86400 # 24h STARLIGHT
 
 # they need to be able to espace when spawning inside a locked room
 # TODO: remove this once we got a better spawning loacation selection

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -7,7 +7,7 @@
   guides: [ Revolutionaries ]
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 0 # Far Horizons - Temporary // 86400 # 24h STARLIGHT
+    time: 7200 # 2 hours - Far Horizons // 86400 # 24h STARLIGHT
   - !type:DepartmentTimeRequirement
     department: Security
     time: 0 # Far Horizons - Temporary // 21600 # 6h STARLIGHT

--- a/Resources/Prototypes/Roles/Antags/silicon.yml
+++ b/Resources/Prototypes/Roles/Antags/silicon.yml
@@ -5,8 +5,8 @@
   setPreference: false
   objective: roles-antag-subverted-silicon-objective
   requirements:
-  - !type:OverallPlaytimeRequirement
-    time: 86400 # 24h STARLIGHT
+  #- !type:OverallPlaytimeRequirement #Far Horizons
+  #  time: 86400 # 24h STARLIGHT
   - !type:RoleTimeRequirement
     role: JobBorg
-    time: 21600 # 6h STARLIGHT
+    time: 3600 # 1 hour - Far Horizons // 21600 # 6h STARLIGHT

--- a/Resources/Prototypes/Roles/Antags/vampire.yml
+++ b/Resources/Prototypes/Roles/Antags/vampire.yml
@@ -7,4 +7,4 @@
 #  guides: [ Changelings ]
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 10800 # 3h
+    time: 3600 # 1 hour - Far Horizons // 10800 # 3h Starlight

--- a/Resources/Prototypes/Roles/Antags/wizard.yml
+++ b/Resources/Prototypes/Roles/Antags/wizard.yml
@@ -13,7 +13,7 @@
   objective: roles-antag-wizard-objective # TODO: maybe give random objs and stationary ones from AntagObjectives and AntagRandomObjectives
   requirements: # I hate time locked roles but this should be enough time for someone to be acclimated
     - !type:OverallPlaytimeRequirement
-      time: 0 # Far Horizons - Temporary // 86400 # 24h STARLIGHT
+      time: 7200 # 2 hours - Far Horizons // 86400 # 24h STARLIGHT
     - !type:DepartmentTimeRequirement
       department: Security
       time: 0 # Far Horizons - Temporary // 21600 # 6h STARLIGHT

--- a/Resources/Prototypes/Roles/Antags/xenoborgs.yml
+++ b/Resources/Prototypes/Roles/Antags/xenoborgs.yml
@@ -8,7 +8,7 @@
   requirements:
   - !type:RoleTimeRequirement
     role: JobStationAi # Starlight
-    time: 18000  # 5 hrs
+    time: 3600 # 1 hour - Far Horizons // 18000  # 5 hrs Starlight
   guides: [ Xenoborgs ]
 
 - type: antag
@@ -21,5 +21,5 @@
   requirements:
   - !type:RoleTimeRequirement
     role: JobBorg
-    time: 54000  # Starlight 15 hrs
+    time: 3600 # 1 hour - Far Horizons // 54000  # Starlight 15 hrs
   guides: [ Xenoborgs ]

--- a/Resources/Prototypes/_FarHorizons/Roles/requirement_overrides.yml
+++ b/Resources/Prototypes/_FarHorizons/Roles/requirement_overrides.yml
@@ -269,7 +269,8 @@
       - !type:OverallPlaytimeRequirement
         time: 0
 
-# Easy Time Allocation
+#region Shortcut
+#Easy Time Allocation
 
 # 72000 # 20 hours
 # 36000 # 10 hours
@@ -278,9 +279,9 @@
 # 3600 # 1 hour
 # 0
 
-# 72000 # 20 hours - Far Horizons
-# 36000 # 10 hours - Far Horizons
-# 14400 # 4 Hours - Far Horizons
-# 7200 # 2 hours - Far Horizons
-# 3600 # 1 hour - Far Horizons
-# 0 # - Far Horizons
+# 72000 # 20 hours - Far Horizons // 
+# 36000 # 10 hours - Far Horizons // 
+# 14400 # 4 Hours - Far Horizons // 
+# 7200 # 2 hours - Far Horizons // 
+# 3600 # 1 hour - Far Horizons // 
+# 0 # - Far Horizons // 

--- a/Resources/Prototypes/_StarLight/Roles/Antags/abductor.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Antags/abductor.yml
@@ -6,7 +6,7 @@
   requirements:
   - !type:RoleTimeRequirement
     role: JobSecurityOfficer
-    time: 10800 # 3 hrs
+    time: 3600 # 1 hour - Far Horizons // #Starlight - 10800 # 3 hrs
   - !type:RoleTimeRequirement
     role: JobSurgeon
-    time: 10800 # 3 hrs
+    time: 3600 # 1 hour - Far Horizons // #Starlight - 10800 # 3 hrs

--- a/Resources/Prototypes/_StarLight/Roles/Antags/brighteye.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Antags/brighteye.yml
@@ -8,7 +8,7 @@
   roleLoadout: [ AntagBrighteye ]
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 172800 # 48h
+    time: 14400 # 4 Hours - Far Horizons // #Starlight - 172800 # 48h
   - !type:SpeciesRequirement
     species:
     - Shadekin

--- a/Resources/Prototypes/_StarLight/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Antags/revolutionary.yml
@@ -6,7 +6,7 @@
   objective: roles-antag-ssf-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 72000 # 20h
-  - !type:DepartmentTimeRequirement
-    department: Security
-    time: 36000 # 10h
+    time: 3600 # 1 hour - Far Horizons # Starlight - 72000 # 20h
+  #- !type:DepartmentTimeRequirement - #Far Horizons
+  #  department: Security
+  #  time: 36000 # 10h


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
In previous role requirement updates I didn't hit the entire list of antags that were available. I was made aware of this with the Xenoborg roles that still had SL original times.
This is that pass of roles. https://discord.com/channels/1407077238876147783/1471833224165724364

Dragon > 2 hours overall playtime // Was 3 hours salvage specialist
Ninja > 2 hours overall playtime // Was 3 hours security
Paradox Clone > 2 hours overall playtime // Was 0 hours before (They kind of need to know how to act like someone)
Head Revolutionary > 2 hours overall playtime // Was 0 hours before
Subverted Silicon > 1 hour as Borg // Was 24 hours overall playtime and 6 hours borg.
Vampire (Yes I know it's currently disabled for us) > 1 hour overall playtime (when we port changes) // Was 3 hours
Wizard > 2 hours of overall playtime // Was 0 hours (Probably shouldn't allow new joiners to jump into this role)
Xenoborg Mothership > 1 hour as Station AI // Was 5 hours
Xenoborg > 1 hour as Borg // Was 15 hours

Abductor > 1 hour as SecOff, 1 hour as Surgeon // Was 3 hours as both
Brighteye > 4 hours overall // Was 48 hours
SSF (Revolutionary?) > 1 hour overall playtime // Was 20 hours overall and 10 hours security

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Second pass of role requirements.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: CorruptOmega
- tweak: Tweaked a bunch of antag role timers that were missed previously so maybe we'll get more antags.