### PR TITLE
Makes sign cost 1 point, adds scurret sign for also 1 point, and gives you 3 points for language selection.

### DIFF
--- a/Resources/Locale/en-US/_FarHorizons/traits/language-traits.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/traits/language-traits.ftl
@@ -1,0 +1,2 @@
+trait-language-ScurretSign-name = Scurret Sign
+trait-language-ScurretSign-description = The langauge of scurrets, more simple in structure than galactic common sign but just as complex.

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -30,6 +30,7 @@
       - VoxPidgin
       - Sign
       - Darktongue
+      - ScurretSign #FH
       understands:
       - GalacticCommon
       - Scratch
@@ -47,6 +48,7 @@
       - VoxPidgin
       - Sign
       - Darktongue
+      - ScurretSign #FH
   # Starlight end
 
 - type: startingGear

--- a/Resources/Prototypes/_FarHorizons/Traits/languages.yml
+++ b/Resources/Prototypes/_FarHorizons/Traits/languages.yml
@@ -1,0 +1,12 @@
+- type: trait
+  id: SignLanguageScurret
+  name: trait-language-ScurretSign-name
+  description: trait-language-ScurretSign-description
+  category: LanguageTraits
+  cost: 1
+  components:
+  - type: LanguageSpeaker
+  languagesSpoken:
+    - ScurretSign
+  languagesUnderstood:
+    - ScurretSign

--- a/Resources/Prototypes/_StarLight/Entities/Base/language.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Base/language.yml
@@ -26,6 +26,7 @@
       - Thaveyan
       - Trinary # Far Horizons
       - Darktongue
+      - ScurretSign #FH
 
 - type: entity
   id: BaseBorgiLanguages
@@ -57,6 +58,7 @@
       - Trinary # Far Horizons
       - Dog
       - Darktongue
+      - ScurretSign #FH
 
 - type: entity
   id: BaseSiliconBrainLanguages

--- a/Resources/Prototypes/_StarLight/Traits/categories.yml
+++ b/Resources/Prototypes/_StarLight/Traits/categories.yml
@@ -1,7 +1,7 @@
 - type: traitCategory
   id: LanguageTraits
   name: trait-category-languages
-  maxTraitPoints: 2
+  maxTraitPoints: 3 #FH - Allows for 1 full second language and 1 half language- like sign.
   
 - type: traitCategory
   id: BackgroundTraits

--- a/Resources/Prototypes/_StarLight/Traits/languages.yml
+++ b/Resources/Prototypes/_StarLight/Traits/languages.yml
@@ -24,7 +24,7 @@
   name: trait-language-signlanguage-name
   description: trait-language-signlanguage-desc
   category: LanguageTraits
-  cost: 2
+  cost: 1 #FH
   components:
   - type: LanguageSpeaker
   languagesSpoken:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
yeh
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
We're in space. A way to communicate with your hands is just going to be knowledge most people pick up quite frankly. 
Mechanic wise, the artificial inflation of sign language trait didn't really make sense. People choose mute characters, and, sure, trying to convey things is part of the point of playing mute but really if people want to know sign language just let em.

Given scurret language is also a form of sign language, I see no reason to also add it as something you can pick up and learn- given their proliferation on stations in the form of purchasing them or just sorta existing. Someone's gonna start learning how to talk back to 'em.

Given most people are bi or trilingual, I've also increased the point count of traits to 3. How it's intended to work is pretty simple- Species specific languages cost 2 points, and non species specific languages cost 1. This allows for a total of two extra languages without utilizing foreigner. 

By species specific I mean the species you can choose at loadout, not animals or wildlife. Scurret is kinda weird in that regard since they do have an actual language.. but it's also sign language.. so, eh, I say one point.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="413" height="462" alt="tdykjtuykg" src="https://github.com/user-attachments/assets/28aa79d8-e0ff-41b3-862c-88455f4f140f" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Killer Tamashi
- add: Added Scurret Sign as a 1 point language you can pick on character creation
- add: Added Scurret Sign to both Silicons and Liberians to follow theme of them knowing everything 
- tweak: Changed Galcommon Sign to 1 point
- tweak: Changed Language trait picks to 3 (Allowing you to choose a species specific language like, say, scratch and an additional non-species specific one like, say, sign.)

