### PR TITLE
remove ghost roles from slimes in dungeon

### DIFF
--- a/Resources/Maps/Dungeon/experiment.yml
+++ b/Resources/Maps/Dungeon/experiment.yml
@@ -9588,21 +9588,21 @@ entities:
     - type: Transform
       pos: 30.5,8.5
       parent: 1653
-- proto: SpawnMobAdultSlimesBlueAngry
+- proto: MobAdultSlimesDungeonBlue
   entities:
   - uid: 713
     components:
     - type: Transform
       pos: 32.5,0.5
       parent: 1653
-- proto: SpawnMobAdultSlimesGreenAngry
+- proto: MobAdultSlimesDungeonGreen
   entities:
   - uid: 1328
     components:
     - type: Transform
       pos: 24.5,0.5
       parent: 1653
-- proto: SpawnMobAdultSlimesYellowAngry
+- proto: MobAdultSlimesDungeonYellow
   entities:
   - uid: 1333
     components:

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/NPCs/slime.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/NPCs/slime.yml
@@ -1,0 +1,65 @@
+- type: entity
+  parent: BaseMobAdultSlimes
+  id: MobAdultSlimesDungeon
+  abstract: true
+  name: basic slime
+  description: It looks so much like jelly. I wonder what it tastes like?
+  suffix: No Ghostrole
+  components:
+  - type: NpcFactionMember
+    factions:
+    - SimpleHostile
+  - type: HTN
+    rootTask:
+      task: SimpleHostileCompound
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 6
+        Structural: 4
+        Caustic: 1
+        Poison: 4
+
+- type: entity
+  parent: MobAdultSlimesDungeon
+  id: MobAdultSlimesDungeonBlue
+  name: Blue Slime
+  components:
+  - type: DamageStateVisuals
+    states:
+      Alive:
+        Base: blue_adult_slime
+      Dead:
+        Base: blue_adult_slime_dead
+
+- type: entity
+  parent: MobAdultSlimesDungeon
+  id: MobAdultSlimesDungeonGreen
+  name: Green Slime
+  components:
+    - type: Sprite
+      layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: green_adult_slime
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: green_adult_slime
+        Dead:
+          Base: green_adult_slime_dead
+
+- type: entity
+  parent: MobAdultSlimesDungeon
+  id: MobAdultSlimesDungeonYellow
+  name: Yellow Slime
+  components:
+    - type: Sprite
+      layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: yellow_adult_slime
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: yellow_adult_slime
+        Dead:
+          Base: yellow_adult_slime_dead


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
same slimes but without endless spawning and ghost roles

## Why we need to add this
Nobody ever intended for them to have ghost roles, upstream just doesn't have slimes with no ghostroles on them

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

:cl: princess_gurchi
- fix: Replaced infinite spawners of ghostrole slimes in dungeons with normal mob slimes