### PR TITLE
Reactor Content Update 8 Hotfix

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -1094,11 +1094,7 @@ public sealed partial class AdminVerbSystem
             Text = fuelRodifyName,
             Category = VerbCategory.Smite,
             Icon = new SpriteSpecifier.Rsi(new("/Textures/_FarHorizons/Objects/Power/FissionGenerator/reactor_parts.rsi"), "default_rod"),
-            Act = () =>
-            {
-                _bodySystem.GibBody(args.Target);
-                _polymorphSystem.PolymorphEntity(args.Target, "AdminFuelRodSmite");
-            },
+            Act = () => _polymorphSystem.PolymorphEntity(args.Target, "AdminFuelRodSmite"),
             Impact = LogImpact.Extreme,
             Message = string.Join(": ", fuelRodifyName, Loc.GetString("admin-smite-become-fuelrod-description"))
         };

--- a/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/GasTurbineSystem.cs
+++ b/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/GasTurbineSystem.cs
@@ -25,6 +25,7 @@ using Content.Shared.Electrocution;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
+using Content.Shared.Rejuvenate;
 using Content.Shared.Repairable;
 using Robust.Server.Audio;
 using Robust.Server.GameObjects;
@@ -87,6 +88,7 @@ public sealed class GasTurbineSystem : EntitySystem
         SubscribeLocalEvent<GasTurbineComponent, ComponentShutdown>(OnShutdown);
 
         SubscribeLocalEvent<GasTurbineComponent, DamageChangedEvent>(OnDamaged);
+        SubscribeLocalEvent<GasTurbineComponent, RejuvenateEvent>(OnRejuvenate);
 
         SubscribeLocalEvent<GasTurbineComponent, ItemSlotInsertAttemptEvent>(OnInsertAttempt);
         SubscribeLocalEvent<GasTurbineComponent, ItemSlotEjectAttemptEvent>(OnEjectAttempt);
@@ -626,6 +628,19 @@ public sealed class GasTurbineSystem : EntitySystem
             comp.CurrentStator = null;
         }
         comp.Ruined = true;
+    }
+
+    private void OnRejuvenate(EntityUid uid, GasTurbineComponent comp, ref RejuvenateEvent args)
+    {
+        comp.RPM = 0;
+        comp.CurrentBlade ??= SpawnInContainerOrDrop("SteelGasTurbineBlade", uid, BladeContainer);
+        comp.CurrentStator ??= SpawnInContainerOrDrop("SteelGasTurbineStator", uid, StatorContainer);
+        UpdatePartValues(comp);
+        comp.Ruined = false;
+        comp.FlowRate = 200;
+        comp.StatorLoad = 35000;
+        comp.IsSmoking = false;
+        comp.IsSparking = false;
     }
 
     private void OnEjectAttempt(EntityUid uid, GasTurbineComponent comp, ref ItemSlotEjectAttemptEvent args)

--- a/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/NuclearReactorSystem.cs
+++ b/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/NuclearReactorSystem.cs
@@ -27,6 +27,7 @@ using Content.Shared.Radiation.Components;
 using Content.Shared.Radio;
 using Content.Shared.Random;
 using Content.Shared.Random.Helpers;
+using Content.Shared.Rejuvenate;
 using Content.Shared.Throwing;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
@@ -93,6 +94,7 @@ public sealed class NuclearReactorSystem : EntitySystem
         SubscribeLocalEvent<NuclearReactorComponent, ComponentRemove>(OnCompRemove);
 
         SubscribeLocalEvent<NuclearReactorComponent, DamageChangedEvent>(OnDamaged);
+        SubscribeLocalEvent<NuclearReactorComponent, RejuvenateEvent>(OnRejuvenate);
 
         // Atmos events
         SubscribeLocalEvent<NuclearReactorComponent, AtmosDeviceUpdateEvent>(OnUpdate);
@@ -560,6 +562,7 @@ public sealed class NuclearReactorSystem : EntitySystem
                     comp.ComponentGrid[x, y] = null;
                     comp.NeutronGrid[x, y] = 0;
                     comp.FluxGrid[x, y] = [];
+                    QueueDel(comp.GridEntities[new(x, y)]);
                 }
             }
         }
@@ -1124,5 +1127,18 @@ public sealed class NuclearReactorSystem : EntitySystem
                     UpdateGridVisual((uid, comp));
                     UpdateGasVolume(comp);
                 }
+    }
+
+    private void OnRejuvenate(EntityUid uid, NuclearReactorComponent comp, ref RejuvenateEvent args)
+    {
+        comp.Temperature = Atmospherics.T20C;
+        comp.LastSendTemperature = comp.Temperature;
+        comp.Melted = false;
+        comp.IsBurning = false;
+        comp.IsSmoking = false;
+        comp.RadiationLevel = 0;
+        comp.ThermalPower = 0;
+        comp.ControlRodInsertion = 2;
+        comp.ApplyPrefab = true;
     }
 }

--- a/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/ReactorPartSystem.Item.cs
+++ b/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/ReactorPartSystem.Item.cs
@@ -13,6 +13,7 @@ namespace Content.Server._FarHorizons.Power.Generation.FissionGenerator;
 public sealed partial class ReactorPartSystem
 {
     [Dependency] private readonly EntityManager _entityManager = default!;
+    [Dependency] private readonly MetaDataSystem _metaDataSystem = default!;
     [Dependency] private readonly SharedPointLightSystem _lightSystem = default!;
 
     private float _burnDiv => (ReactorPartBurnTemp - ReactorPartHotTemp) / 5; // The 5 is how much heat damage insulated gloves protect from
@@ -133,6 +134,10 @@ public sealed partial class ReactorPartSystem
 
     private void OnAtmosExposed(EntityUid uid, ReactorPartComponent component, ref AtmosExposedUpdateEvent args)
     {
+        // Stops it from cooking the room while in the reactor
+        if(!TryComp(uid, out MetaDataComponent? metaData) || (metaData.Flags & MetaDataFlags.InContainer) == MetaDataFlags.InContainer)
+            return;
+
         // Can't use args.GasMixture because then it wouldn't excite the tile
         var gasMix = _atmosphereSystem.GetContainingMixture(uid, false, true) ?? GasMixture.SpaceGas;
         if(gasMix.TotalMoles < Atmospherics.GasMinMoles)

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Power/FissionGenerator/reactor_parts.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Power/FissionGenerator/reactor_parts.yml
@@ -240,6 +240,7 @@
 - type: entity
   id: MeatReactorFuelRod
   parent: BaseReactorFuelRod
+  suffix: Admeme
   name: Meat Fuel Rod
   description: A fuel rod fo- wait, is it alive?
   components:

--- a/Resources/ServerInfo/_FarHorizons/Guidebook/Engineering/NuclearReactor.xml
+++ b/Resources/ServerInfo/_FarHorizons/Guidebook/Engineering/NuclearReactor.xml
@@ -97,7 +97,6 @@
 	The Change View button can be used to alternate between the different views:
 	- Temperature View: shows the temperature of the components
 	- Neutron View: shows the number of neutrons at any given position
-	- Target View: shows the current target location
 	- Fuel View: shows the fuel level of the components
 
 	### Status Panel


### PR DESCRIPTION
## Short description
Fixed a few bugs and added a suggestion.

## Why we need to add this
Bugfixes

## Media (Video/Screenshots)
### Rejuvenation

https://github.com/user-attachments/assets/6ad6deea-4162-40f9-836c-6b86c8e0cfc4


https://github.com/user-attachments/assets/f4932265-9fe4-400a-a90d-50808dbc92f0

### Heat contained
<img width="1299" height="453" alt="image" src="https://github.com/user-attachments/assets/c31dc54f-267c-42ce-9fc2-ca624d9306e1" />

Devlog/Discussion thread: https://discord.com/channels/1407077238876147783/1428831494318850102

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**
:cl: jhrushbe
- add: The rejuvenate command will now reset nuclear reactors and gas turbines.
- remove: Removed the mention of target view in the nuclear reactor's guidebook.
- fix: Fixed a bug where the nuclear reactor would not delete the parts inside it after a meltdown.
- fix: Fixed a bug where the nuclear reactor would leak heat into its surroundings.
- fix: Fixed a bug where the fuel rod smite would not correctly polymorph the target, at the sacrifice of some VFX.
