### PR TITLE
Fix for two issues associated with secway crafting

### DIFF
--- a/Resources/Locale/en-US/_FarHorizons/crafting-menu/vehicle-armor.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/crafting-menu/vehicle-armor.ftl
@@ -1,6 +1,6 @@
 crafting-menu-name-SecwayArmorLightKit = Secway Light Armor Upgrade Kit
 crafting-menu-name-SecwayArmoredLight = Lightly Armored Secway
-crafting-menu-text-SecwayArmoredLight = Upgrade your Secway to have light armor plating, boasting the protection of a Type 1 vest.
+crafting-menu-text-SecwayArmoredLight = REMOVE THE KEYS FIRST! Upgrade your Secway to have light armor plating, boasting the protection of a Type 1 vest.
 crafting-menu-name-Secway = Secway
 
 construction-category-vehicles = Vehicles

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Vehicles/vehicles_battery.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Vehicles/vehicles_battery.yml
@@ -28,9 +28,9 @@
         - SecSiren
 
 - type: entity
-  id: VehicleSecwayArmoredLightBatterywithKeysNT
+  id: VehicleSecwayArmoredLightBatteryNT
   parent: VehicleSecway
-  suffix: Battery, Keys, NT
+  suffix: Battery, NT
   description: A simple yet efficent modifcation of station-issued Secways, able to hold up to light arms fire fairly well.
   name: Lightly Armored Secway
   components:
@@ -76,8 +76,6 @@
       containers:
         cell_slot:
         - PowerCellMedium
-        key_slot:
-        - VehicleKeySecway
         vehicle_mods_container:
         - SecwayLightBright
         - SecSiren
@@ -162,6 +160,9 @@
         - PowerCellMedium
         key_slot:
         - VehicleKeySegway
+    - type: Tag
+      tags:
+      - Segway
 
 #Syndicate devider
 - type: entity

--- a/Resources/Prototypes/_FarHorizons/Recipes/Crafting/Graphs/Vehicle_Armor/secway_armor_light.yml
+++ b/Resources/Prototypes/_FarHorizons/Recipes/Crafting/Graphs/Vehicle_Armor/secway_armor_light.yml
@@ -18,4 +18,4 @@
           state: icon
         name: crafting-menu-name-Secway
   - node: vehicle
-    entity: VehicleSecwayArmoredLightBatterywithKeysNT
+    entity: VehicleSecwayArmoredLightBatteryNT

--- a/Resources/Prototypes/_FarHorizons/Recipes/Crafting/vehicle_armor.yml
+++ b/Resources/Prototypes/_FarHorizons/Recipes/Crafting/vehicle_armor.yml
@@ -1,6 +1,6 @@
 - type: construction
   name: crafting-menu-name-SecwayArmoredLight
-  id: VehicleSecwayArmoredLightBatterywithKeysNT
+  id: VehicleSecwayArmoredLightBatteryNT
   graph: SecwayArmoredLightGraph
   startNode: start
   targetNode: vehicle

--- a/Resources/Prototypes/_FarHorizons/tags.yml
+++ b/Resources/Prototypes/_FarHorizons/tags.yml
@@ -236,6 +236,9 @@
   id: SecwayArmorLightKit
 
 - type: Tag
+  id: Segway
+
+- type: Tag
   id: SegwayKeys
 
 - type: Tag


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Title.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Fixes, specifically, being able to craft a segway into a secway with the upgrade kit and changes the prototype to be keyless so you can't just make a new key, even if that's a bit niche tbh.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Killer Tamashi
- fix: Fixed Segways being a valid item for a Lightly Armored Secway 
- fix: Fixed Lightly Armored Secways spawning with keys. Remember to remove the secway's keys first before upgrading or you WILL lose it.
