### PR TITLE
fix shadekin trying to breathe

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/shadekin.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/shadekin.yml
@@ -1,7 +1,7 @@
 - type: entity
   save: false
   name: Urist McShadow
-  parent: [MobBloodstream, MobAtmosStandard, MobFlammable, BaseSpeciesMobOrganic]
+  parent: [MobBloodstream, MobAtmosStandard, MobFlammable, BaseSpeciesMob]
   id: BaseMobShadekin
   abstract: true
   components:
@@ -150,6 +150,10 @@
           amount: 5
     - type: FireVisuals
       alternateState: Standing
+    - type: StunVisuals
+    - type: HumanoidEMP # Far Horizons - HumanoidEMP is needed to receive EMP effects, it may carry its own innate effects, but doesn't have to
+      effectCooldown: 2
+    - type: HumanoidEMPComposite # Far Horizons - HumanoidEMPComposite is used to gather EMP effects from HumanoidEMPCompositeElement components on all limbs and organs. These effects added in addition to effects in HumanoidEMP and won't work without it
     - type: Tag  # Far Horizons
       tags:
         - CanPilot


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Removes `RespiratorComponent` from shadekin to stop them trying to breathe while having no lungs.

## Why we need to add this
Shadekin are literally unplayable with the bug this PR fixes.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/3e323727-35cc-456f-b2e9-380e7f4b70a2

Sorry for the choppy video, that is an issue with the shit specs of my laptop.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: a_Beaver
- fix: Fixed shadekin trying to breathe with no lungs.
