### PR TITLE
add the taser pistol as a loadout option for sec

### DIFF
--- a/Resources/Prototypes/_StarLight/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Jobs/Security/security_officer.yml
@@ -14,10 +14,10 @@
   equipment:
     pocket2: WeaponDominator
 
-#- type: loadout
-#  id: SecurityTaser
-#  equipment:
-#    pocket2: WeaponAdvancedTaser FH
+- type: loadout
+  id: SecurityTaser
+  equipment:
+    pocket2: WeaponDisabler
 
 # Sidearm Options
 - type: loadout

--- a/Resources/Prototypes/_StarLight/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Jobs/Security/security_officer.yml
@@ -17,7 +17,7 @@
 - type: loadout
   id: SecurityTaser
   equipment:
-    pocket2: WeaponDisabler
+    pocket2: WeaponDisabler # FH
 
 # Sidearm Options
 - type: loadout

--- a/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
@@ -272,7 +272,7 @@
   id: SecurityNonLethalWeapon
   name: loadout-group-security-non-lethal-weapon
   loadouts:
-#  - SecurityTaser
+  - SecurityTaser
   - SecurityDominator
 
 - type: loadoutGroup

--- a/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
@@ -272,7 +272,7 @@
   id: SecurityNonLethalWeapon
   name: loadout-group-security-non-lethal-weapon
   loadouts:
-  - SecurityTaser
+  - SecurityTaser # FH
   - SecurityDominator
 
 - type: loadoutGroup


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Exactly what the title says, this adds the taser pistol to sec loadouts as an alternative to the dominator.

## Why we need to add this
A side effect of the advanced taser removal in #813 was removing any choice for the non-lethal weapon in sec loadouts, this brings back a choice.

## Media (Video/Screenshots)
<img width="772" height="261" alt="image" src="https://github.com/user-attachments/assets/fa929051-965d-4ef0-91f6-27909951be77" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: a_Beaver
- add: Added the taser pistol to sec loadouts as an alternative to the dominator pistol.
