### PR TITLE
Allow for crawling when wearing ignoreKnockdown armor

### DIFF
--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Clothing.Components;
+using Content.Shared.Clothing.Components;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Examine;
@@ -42,8 +42,10 @@ public abstract class SharedArmorSystem : EntitySystem
     /// </summary>
     private void OnKnockdownAttempt(EntityUid uid, ArmorComponent component, InventoryRelayedEvent<KnockDownAttemptEvent> args)
     {
-        if (component.IgnoreKnockdown)
+        // Starlight edit start - add check for voluntary value, cancel only involuntary knockdown
+        if (component.IgnoreKnockdown && !args.Args.Voluntary)
             args.Args.Cancelled = true;
+        // Starlight edit end
     }
     #endregion
 

--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -271,7 +271,9 @@ public abstract partial class SharedStunSystem
 
         if (!Resolve(entity, ref entity.Comp2, false))
         {
-            TryKnockdown(entity.Owner, entity.Comp1.DefaultKnockedDuration, true, false, false);
+            // Starlight edit start - Add voluntary value
+            TryKnockdown(entity.Owner, entity.Comp1.DefaultKnockedDuration, true, false, false, false, true);
+            // Starlight edit end
             return;
         }
 

--- a/Content.Shared/Stunnable/SharedStunSystem.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.cs
@@ -181,7 +181,9 @@ public abstract partial class SharedStunSystem : EntitySystem
         if (!Resolve(entity, ref entity.Comp, false))
             return false;
 
-        return TryKnockdown(entity, time, refresh, autoStand, drop, force);
+        // Starlight edit start - add voluntary value
+        return TryKnockdown(entity, time, refresh, autoStand, drop, force, voluntary: true);
+        // Starlight edit end
     }
 
     /// <inheritdoc cref="TryCrawling(Entity{CrawlerComponent?},TimeSpan?,bool,bool,bool,bool)"/>
@@ -195,7 +197,9 @@ public abstract partial class SharedStunSystem : EntitySystem
         if (!Resolve(entity, ref entity.Comp, false))
             return false;
 
-        return TryKnockdown(entity, entity.Comp.DefaultKnockedDuration, refresh, autoStand, drop, force);
+        // Starlight edit start - add voluntary value
+        return TryKnockdown(entity, entity.Comp.DefaultKnockedDuration, refresh, autoStand, drop, force, voluntary: true);
+        // Starlight edit end
     }
 
     /// <summary>
@@ -206,8 +210,11 @@ public abstract partial class SharedStunSystem : EntitySystem
     /// <param name="autoStand">Whether we want to automatically stand when knockdown ends.</param>
     /// <param name="drop">Whether we should drop items.</param>
     /// <param name="force">Should we force the status effect?</param>
-    public bool CanKnockdown(Entity<StandingStateComponent?> entity, ref TimeSpan? time, ref bool autoStand, ref bool drop, bool force = false)
+    /// <param name="voluntary">Indicates whether the knockdown is voluntary</param>
+    // Starlight edit start - add voluntary value
+    public bool CanKnockdown(Entity<StandingStateComponent?> entity, ref TimeSpan? time, ref bool autoStand, ref bool drop, bool force = false, bool voluntary = false)
     {
+    // Starlight edit end
         if (time <= TimeSpan.Zero)
             return false;
 
@@ -215,7 +222,9 @@ public abstract partial class SharedStunSystem : EntitySystem
         if (!Resolve(entity, ref entity.Comp, false))
             return false;
 
-        var evAttempt = new KnockDownAttemptEvent(autoStand, drop, time);
+        // Starlight edit start - add voluntary value
+        var evAttempt = new KnockDownAttemptEvent(autoStand, drop, time, voluntary);
+        // Starlight edit end
         RaiseLocalEvent(entity, ref evAttempt);
 
         autoStand = evAttempt.AutoStand;
@@ -233,10 +242,13 @@ public abstract partial class SharedStunSystem : EntitySystem
     /// <param name="autoStand">Whether we want to automatically stand when knockdown ends.</param>
     /// <param name="drop">Whether we should drop items.</param>
     /// <param name="force">Should we force the status effect?</param>
-    public bool TryKnockdown(Entity<CrawlerComponent?> entity, TimeSpan? time, bool refresh = true, bool autoStand = true, bool drop = true, bool force = false)
+    /// <param name="voluntary">Indicates whether the knockdown is voluntary</param>
+    // Starlight edit start - add voluntary value
+    public bool TryKnockdown(Entity<CrawlerComponent?> entity, TimeSpan? time, bool refresh = true, bool autoStand = true, bool drop = true, bool force = false, bool voluntary = false)
     {
-        if (!CanKnockdown(entity.Owner, ref time, ref autoStand, ref drop, force))
+        if (!CanKnockdown(entity.Owner, ref time, ref autoStand, ref drop, force, voluntary))
             return false;
+    // Starlight edit end
 
         // If the entity can't crawl they also need to be stunned, and therefore we should be using paralysis status effect.
         // Also time shouldn't be null if we're and trying to add time but, we check just in case anyways.

--- a/Content.Shared/Stunnable/StunnableEvents.cs
+++ b/Content.Shared/Stunnable/StunnableEvents.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Alert;
+using Content.Shared.Alert;
 using Content.Shared.DoAfter;
 using Content.Shared.Popups;
 using Robust.Shared.Serialization;
@@ -26,9 +26,11 @@ public record struct StunEndAttemptEvent(bool Cancelled);
 ///     Raised directed on an entity before it is knocked down to see if it should be cancelled, and to determine
 ///     knocked down arguments.
 /// </summary>
+// Starlight edit start -  Make it inventory relayed, add voluntary value to indicate whether the knockdown is voluntary
 [ByRefEvent]
-public record struct KnockDownAttemptEvent(bool AutoStand, bool Drop, TimeSpan? Time) : IInventoryRelayEvent // Starlight-edit: Make it inventory relayed
+public record struct KnockDownAttemptEvent(bool AutoStand, bool Drop, TimeSpan? Time, bool Voluntary = false) : IInventoryRelayEvent
 {
+// Starlight edit end 
     public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET; // Starlight-edit
 
     public bool Cancelled;


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This is a fix to being unable to enter crawling while wearing a hardsuit that provides taser immunity, it allows to enter crawling, and also keeps the taser immunity by defining self inflicted knockdown.

original PR from SL (Note, this PR is missing the hardsuit and web vest rebalancing, its just the commit for crawling without yaml changes):
https://github.com/ss14Starlight/space-station-14/pull/2919/changes

## Why we need to add this
Its rather bad for UX to lose the ability to crawl as soon as you enter a hardsuit.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [ ] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

Changes are licensed under [Starlight modified MIT](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE-Starlight.TXT)

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- fix: Fixed taser immunity preventing crawling.
