### PR TITLE
Fix translator working on an empty bettery

### DIFF
--- a/Content.Server/_Starlight/Language/TranslatorSystem.cs
+++ b/Content.Server/_Starlight/Language/TranslatorSystem.cs
@@ -142,8 +142,9 @@ public sealed class TranslatorSystem : SharedTranslatorSystem
 
     private void OnPowerCellChanged(EntityUid translator, HandheldTranslatorComponent component, PowerCellChangedEvent args)
     {
-        component.Enabled = !args.Ejected;
-        _powerCell.SetDrawEnabled(translator, !args.Ejected);
+        var canEnable = !args.Ejected && _powerCell.HasDrawCharge(translator);
+        component.Enabled = canEnable;
+        _powerCell.SetDrawEnabled(translator, canEnable);
         OnAppearanceChange(translator, component);
 
         if (_containers.TryGetContainingContainer((translator, null, null), out var holderCont) && HasComp<LanguageSpeakerComponent>(holderCont.Owner))
@@ -152,8 +153,9 @@ public sealed class TranslatorSystem : SharedTranslatorSystem
 
     private void OnItemToggled(EntityUid translator, HandheldTranslatorComponent component, ItemToggledEvent args)
     {
-        component.Enabled = args.Activated;
-        _powerCell.SetDrawEnabled(translator, args.Activated);
+        var canEnable = args.Activated && _powerCell.HasDrawCharge(translator);
+        component.Enabled = canEnable;
+        _powerCell.SetDrawEnabled(translator, canEnable);
         OnAppearanceChange(translator, component);
 
         if (_containers.TryGetContainingContainer((translator, null, null), out var holderCont) && HasComp<LanguageSpeakerComponent>(holderCont.Owner))


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR fixes translator bug that allows to abuse how batteries work to make them work without one.

## Why we need to add this
It fixes a bug.
Original PR:
https://github.com/ss14Starlight/space-station-14/pull/2756

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [ ] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

Changes are licensed under [Starlight modified MIT](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE-Starlight.TXT)

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- fix: Fixed translators working on empty batteries.
