### PR TITLE
Fix protogen avali having incorrect 0g speed

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
@@ -1904,7 +1904,7 @@
           layer:
             - MobLayer
     - type: MovementSpeedModifier
-      baseWeightlessAcceleration: 1.7 # Avalis are specifically built to fly in low-g environments
+      baseWeightlessAcceleration: 1.6 # Avalis are specifically built to fly in low-g environments
       baseWeightlessFriction: 1
       baseWeightlessModifier: 1
     - type: Damageable

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
@@ -1904,9 +1904,9 @@
           layer:
             - MobLayer
     - type: MovementSpeedModifier
-      weightlessAcceleration: 1.7 # Avalis are specifically built to fly in low-g environments
-      weightlessFriction: 1
-      weightlessModifier: 1
+      baseWeightlessAcceleration: 1.7 # Avalis are specifically built to fly in low-g environments
+      baseWeightlessFriction: 1
+      baseWeightlessModifier: 1
     - type: Damageable
       damageContainer: Biological
       damageModifierSet: ProtoAvali


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This fixes protogen avali having incorrectly set 0g speed values, it should be using the same properties as moths.

## Why we need to add this
Its defined but its not working, this PR fixes that.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- fix: Fixed protogen avali 0g movement speed.
