### PR TITLE
Ipc bleeding tweaks/fixes

### DIFF
--- a/Content.Client/_FarHorizons/Silicons/IPC/IPCBoundUserInterface.cs
+++ b/Content.Client/_FarHorizons/Silicons/IPC/IPCBoundUserInterface.cs
@@ -30,4 +30,20 @@ public sealed partial class IPCBoundUserInterface(EntityUid owner, Enum uiKey) :
             SendMessage(new IPCSetNameBuiMessage(name));
         };
     }
+
+    // This is cringe
+    // Sadly cringe is how this game runs
+    // Eventually prediction for bloodstream will be fixed, and we will once again remove this and switch to 100% client side UI
+    // Then something else will break and make me do this shit again
+    // And so the cycle continues
+    protected override void ReceiveMessage(BoundUserInterfaceMessage message)
+    {
+        if (_menu == null)
+            return;
+
+        if (message is not IPCHealthMessage cast)
+            return;
+
+        _menu.SetHealth(cast);
+    }
 }

--- a/Content.Client/_FarHorizons/Silicons/IPC/IPCMenu.xaml.cs
+++ b/Content.Client/_FarHorizons/Silicons/IPC/IPCMenu.xaml.cs
@@ -1,8 +1,8 @@
 using System.Linq;
 using Content.Client.Stylesheets;
 using Content.Client.UserInterface.Controls;
+using Content.Shared._FarHorizons.Silicons.IPC;
 using Content.Shared._FarHorizons.Silicons.IPC.Components;
-using Content.Shared.Body.Components;
 using Content.Shared.CCVar;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
@@ -54,6 +54,7 @@ public sealed partial class IPCMenu : FancyWindow
 
     public EntityUid Entity;
 
+    private float _bloodLevel;
 
     private DamageableComponent? _damage = null;
     public DamageableComponent? Damage
@@ -67,13 +68,6 @@ public sealed partial class IPCMenu : FancyWindow
     {
         get => _blind ?? TryGetAssignComp(_entity, Entity, ref _blind);
         set => _blind = value;
-    }
-
-    private BloodstreamComponent? _blood = null;
-    public BloodstreamComponent? Blood
-    {
-        get => _blood ?? TryGetAssignComp(_entity, Entity, ref _blood);
-        set => _blood = value;
     }
 
     private MobStateComponent? _state = null;
@@ -133,6 +127,9 @@ public sealed partial class IPCMenu : FancyWindow
         NameLineEdit.OnFocusExit += OnNameFocusExit;
     }
 
+    public void SetHealth(IPCHealthMessage healthMessage) =>
+        _bloodLevel = (float)healthMessage.BloodLevel;
+
     public void SetEntity(EntityUid entity)
     {
         Entity = entity;
@@ -173,10 +170,6 @@ public sealed partial class IPCMenu : FancyWindow
         if (Blind != null)
             eyeDamage = Blind.EyeDamage;
 
-        var bloodLevel = 0f;
-        if (Blood != null && Blood.BloodSolution != null)
-            bloodLevel = Blood.BloodSolution.Value.Comp.Solution.FillFraction;
-
         var damage = new DamageSpecifier();
         if (Damage != null)
             damage = Damage.Damage;
@@ -203,7 +196,7 @@ public sealed partial class IPCMenu : FancyWindow
             batteryCharge = _batterySystem.GetChargeLevel((checkedBattery.Owner, checkedBattery.Comp));
         }
 
-        FullText = PrintConsole(LastKnownState.ToString(), batteryInserted, batteryCharge, eyeDamage, bloodLevel, temp, fanMode, fansEfficiency, Brain, damage);
+        FullText = PrintConsole(LastKnownState.ToString(), batteryInserted, batteryCharge, eyeDamage, _bloodLevel, temp, fanMode, fansEfficiency, Brain, damage);
         UpdateBrainButton(Brain);
         EjectBatteryButton.Disabled = !batteryInserted;
         ChargeBar.Value = batteryCharge;

--- a/Content.Server/_FarHorizons/Silicons/IPC/IPCSystem.Ui.cs
+++ b/Content.Server/_FarHorizons/Silicons/IPC/IPCSystem.Ui.cs
@@ -1,14 +1,7 @@
 using Content.Shared._FarHorizons.Silicons.IPC;
 using Content.Shared._FarHorizons.Silicons.IPC.Components;
-using Content.Shared.Body.Components;
 using Content.Shared.CCVar;
-using Content.Shared.Damage;
 using Content.Shared.Database;
-using Content.Shared.Eye.Blinding.Components;
-using Content.Shared.Lock;
-using Content.Shared.Mobs;
-using Content.Shared.Mobs.Components;
-using Content.Shared.UserInterface;
 
 namespace Content.Server._FarHorizons.Silicons.IPC;
 
@@ -19,36 +12,67 @@ public sealed partial class IPCSystem
 
     private void InitializeUI()
     {
-        SubscribeLocalEvent<IPCLockComponent, IPCEjectBrainBuiMessage>(OnEjectBrainBuiMessage);
-        SubscribeLocalEvent<IPCLockComponent, IPCEjectBatteryBuiMessage>(OnEjectBatteryBuiMessage);
-        SubscribeLocalEvent<IPCLockComponent, IPCSetNameBuiMessage>(OnSetNameBuiMessage);
+        SubscribeLocalEvent<IPCUserInterfaceComponent, IPCEjectBrainBuiMessage>(OnEjectBrainBuiMessage);
+        SubscribeLocalEvent<IPCUserInterfaceComponent, IPCEjectBatteryBuiMessage>(OnEjectBatteryBuiMessage);
+        SubscribeLocalEvent<IPCUserInterfaceComponent, IPCSetNameBuiMessage>(OnSetNameBuiMessage);
+        SubscribeLocalEvent<IPCUserInterfaceComponent, BoundUIOpenedEvent>(OnUIOpened);
 
         Subs.CVar(_cfgManager, CCVars.MaxNameLength, value => _maxNameLength = value, true);
     }
 
-    private void OnEjectBrainBuiMessage(Entity<IPCLockComponent> ent, ref IPCEjectBrainBuiMessage args)
-    {   
-        if (ent.Comp.Lock.Locked || !ent.Comp.WiresPanel.Open)
+    protected override void UpdateUI(float frameTime)
+    {
+        var query = EntityQueryEnumerator<IPCUserInterfaceComponent>();
+        while (query.MoveNext(out var uid, out var comp))
         {
-            _popup.PopupEntity(Loc.GetString(ent.Comp.LockedPopupMessage), ent);
-            _audio.PlayPvs(ent.Comp.LockedSound, ent);
+            if (!_ui.IsUiOpen(uid, IPCUiKey.Key)) continue;
+
+            if (_timing.CurTime < comp.NextUpdate) continue;
+
+            comp.NextUpdate = _timing.CurTime + comp.RefreshRate;
+
+            UpdateUIHealth(uid);
+        }
+    }
+
+    private void OnUIOpened(Entity<IPCUserInterfaceComponent> ent, ref BoundUIOpenedEvent args) =>
+        UpdateUIHealth(ent.Owner);
+        
+    private void UpdateUIHealth(EntityUid ent)
+    {
+        var healthMessage = new IPCHealthMessage(_bloodstream.GetBloodLevel(ent));
+
+        _ui.ServerSendUiMessage(ent, IPCUiKey.Key, healthMessage);
+    }
+
+    private void OnEjectBrainBuiMessage(Entity<IPCUserInterfaceComponent> ent, ref IPCEjectBrainBuiMessage args)
+    {
+        if (!TryComp<IPCLockComponent>(ent.Owner, out var lockComp)) return;
+
+        if (lockComp.Lock.Locked || !lockComp.WiresPanel.Open)
+        {
+            _popup.PopupEntity(Loc.GetString(lockComp.LockedPopupMessage), ent);
+            _audio.PlayPvs(lockComp.LockedSound, ent);
             return;
         }
 
         EjectBrain(ent.Owner, args.Actor);
     }
-    private void OnEjectBatteryBuiMessage(Entity<IPCLockComponent> ent, ref IPCEjectBatteryBuiMessage args)
+
+    private void OnEjectBatteryBuiMessage(Entity<IPCUserInterfaceComponent> ent, ref IPCEjectBatteryBuiMessage args)
     {
-        if (ent.Comp.Lock.Locked || !ent.Comp.WiresPanel.Open)
+        if (!TryComp<IPCLockComponent>(ent.Owner, out var lockComp)) return;
+
+        if (lockComp.Lock.Locked || !lockComp.WiresPanel.Open)
         {
-            _popup.PopupEntity(Loc.GetString(ent.Comp.LockedPopupMessage), ent);
-            _audio.PlayPvs(ent.Comp.LockedSound, ent);
+            _popup.PopupEntity(Loc.GetString(lockComp.LockedPopupMessage), ent);
+            _audio.PlayPvs(lockComp.LockedSound, ent);
             return;
         }
 
         EjectBattery(ent.Owner, args.Actor);
     }
-    private void OnSetNameBuiMessage(Entity<IPCLockComponent> ent, ref IPCSetNameBuiMessage args)
+    private void OnSetNameBuiMessage(Entity<IPCUserInterfaceComponent> ent, ref IPCSetNameBuiMessage args)
     {
         if (args.Name.Length > _maxNameLength ||
             args.Name.Length == 0 ||

--- a/Content.Server/_FarHorizons/Silicons/IPC/IPCSystem.Weld.cs
+++ b/Content.Server/_FarHorizons/Silicons/IPC/IPCSystem.Weld.cs
@@ -1,0 +1,20 @@
+using Content.Shared._FarHorizons.Silicons.IPC.Components;
+using Content.Shared.Body.Components;
+using Content.Shared.Repairable;
+
+namespace Content.Server._FarHorizons.Silicons.IPC;
+
+public sealed partial class IPCSystem
+{
+    private void InitializeWeld()
+    {
+        SubscribeLocalEvent<IPCWeldClosesWoundsComponent, RepairDoAfterEvent>(OnIPCRepaired);
+    }
+
+    private void OnIPCRepaired(Entity<IPCWeldClosesWoundsComponent> ent, ref RepairDoAfterEvent args)
+    {
+        if (!TryComp<BloodstreamComponent>(ent.Owner, out var bloodstream)) return;
+
+        _bloodstream.TryModifyBleedAmount((ent, bloodstream), ent.Comp.BloodlossModifier);
+    }
+}

--- a/Content.Server/_FarHorizons/Silicons/IPC/IPCSystem.Weld.cs
+++ b/Content.Server/_FarHorizons/Silicons/IPC/IPCSystem.Weld.cs
@@ -13,7 +13,7 @@ public sealed partial class IPCSystem
 
     private void OnIPCRepaired(Entity<IPCWeldClosesWoundsComponent> ent, ref RepairDoAfterEvent args)
     {
-        if (!TryComp<BloodstreamComponent>(ent.Owner, out var bloodstream)) return;
+        if (args.Cancelled || !TryComp<BloodstreamComponent>(ent.Owner, out var bloodstream)) return;
 
         _bloodstream.TryModifyBleedAmount((ent, bloodstream), ent.Comp.BloodlossModifier);
     }

--- a/Content.Server/_FarHorizons/Silicons/IPC/IPCSystem.cs
+++ b/Content.Server/_FarHorizons/Silicons/IPC/IPCSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Administration.Logs;
 using Content.Server.Atmos.EntitySystems;
+using Content.Server.Body.Systems;
 using Content.Server.Chat.Systems;
 using Content.Server.DoAfter;
 using Content.Server.EUI;
@@ -52,6 +53,7 @@ public sealed partial class IPCSystem : SharedIPCSystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly AtmosphereSystem _atmos = default!;
     [Dependency] private readonly TagSystem _tag = default!;
+    [Dependency] private readonly BloodstreamSystem _bloodstream = default!;
     
 
     public override void Initialize()

--- a/Content.Server/_FarHorizons/Silicons/IPC/IPCSystem.cs
+++ b/Content.Server/_FarHorizons/Silicons/IPC/IPCSystem.cs
@@ -61,6 +61,7 @@ public sealed partial class IPCSystem : SharedIPCSystem
         base.Initialize();
 
         InitializeUI();
+        InitializeWeld();
 
         SubscribeLocalEvent<GetVerbsEvent<Verb>>(AddVerbs);
     }

--- a/Content.Shared/_FarHorizons/Silicons/IPC/Components/IPCUIComponent.cs
+++ b/Content.Shared/_FarHorizons/Silicons/IPC/Components/IPCUIComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared._FarHorizons.Silicons.IPC.Components;
+
+[RegisterComponent]
+public sealed partial class IPCUserInterfaceComponent : Component
+{
+    public TimeSpan NextUpdate = TimeSpan.Zero;
+
+    public TimeSpan RefreshRate = TimeSpan.FromSeconds(5);
+}

--- a/Content.Shared/_FarHorizons/Silicons/IPC/Components/IPCWeldClosesWoundsComponent.cs
+++ b/Content.Shared/_FarHorizons/Silicons/IPC/Components/IPCWeldClosesWoundsComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared._FarHorizons.Silicons.IPC.Components;
+
+[RegisterComponent]
+public sealed partial class IPCWeldClosesWoundsComponent : Component
+{
+    [DataField] public float BloodlossModifier = -10f;
+}

--- a/Content.Shared/_FarHorizons/Silicons/IPC/IPCSystem.cs
+++ b/Content.Shared/_FarHorizons/Silicons/IPC/IPCSystem.cs
@@ -56,5 +56,8 @@ public abstract partial class SharedIPCSystem : EntitySystem
 
         UpdateBattery(frameTime);
         UpdateThermals(frameTime);
+        UpdateUI(frameTime);
     }
+
+    protected virtual void UpdateUI(float frameTime) { }
 }

--- a/Content.Shared/_FarHorizons/Silicons/IPC/IPCSystem.cs
+++ b/Content.Shared/_FarHorizons/Silicons/IPC/IPCSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Body.Systems;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands.EntitySystems;
@@ -27,6 +28,7 @@ public abstract partial class SharedIPCSystem : EntitySystem
     [Dependency] private readonly PowerCellSystem _powerCell = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedBloodstreamSystem _bloodstream = default!;
 
     public override void Initialize()
     {

--- a/Content.Shared/_FarHorizons/Silicons/IPC/IPCUI.cs
+++ b/Content.Shared/_FarHorizons/Silicons/IPC/IPCUI.cs
@@ -1,3 +1,4 @@
+using Content.Shared.FixedPoint;
 using Content.Shared.Mobs;
 using Robust.Shared.Serialization;
 
@@ -7,16 +8,6 @@ namespace Content.Shared._FarHorizons.Silicons.IPC;
 public enum IPCUiKey : byte
 {
     Key
-}
-
-[Serializable, NetSerializable]
-public sealed class IPCBuiState(float chargePercent, bool hasBattery, MobState mobState) : BoundUserInterfaceState
-{
-    public float ChargePercent = chargePercent;
-
-    public bool HasBattery = hasBattery;
-
-    public MobState MobState = mobState;
 }
 
 [Serializable, NetSerializable]
@@ -32,4 +23,7 @@ public sealed class IPCSetNameBuiMessage(string name) : BoundUserInterfaceMessag
 }
 
 [Serializable, NetSerializable]
-public sealed class IPCRequestUpdateBuiMessage : BoundUserInterfaceMessage;
+public sealed class IPCHealthMessage(FixedPoint2 bloodLevel) : BoundUserInterfaceMessage
+{
+    public FixedPoint2 BloodLevel = bloodLevel;
+}

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
@@ -298,6 +298,7 @@
     useAccess: false # IPCLock handles this
     unlockOnClick: false # IPCLock handles this
     showLockVerbs: false # IPCLock handles this
+  - type: IPCUserInterface
   - type: UserInterface
     interfaces:
       enum.IPCUiKey.Key:

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
@@ -137,6 +137,7 @@
       reagents:
       - ReagentId: Oil
         Quantity: 300
+  - type: IPCWeldClosesWounds
   - type: Icon
     sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: full

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
@@ -137,6 +137,8 @@
       reagents:
       - ReagentId: Oil
         Quantity: 300
+    bleedReductionAmount: 0 # No natural wound closing whatsoever
+    bloodlossThreshold: 0.75 # Everyone else start taking bloodloss damage at 90%, but with no natural bleeding stop - IPC can last for a bit longer
   - type: IPCWeldClosesWounds
   - type: Icon
     sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
@@ -124,6 +124,14 @@
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: IPC
+  - type: SolutionContainerManager
+    solutions:
+      bloodstream:
+        canReact: false # My robots aren't beakers! (oil -> ash conversion is evil and needs to go)
+      bloodstreamTemporary:
+        canReact: false
+      metabolites:
+        canReact: false
   - type: Bloodstream
     bloodReferenceSolution:
       reagents:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Changing how robots bleed

## Why we need to add this
fixes + QoL

## Media (Video/Screenshots)

<img width="566" height="461" alt="image" src="https://github.com/user-attachments/assets/a3b1a93d-2538-45d6-8055-37940d7195aa" />


https://github.com/user-attachments/assets/77a56ef2-9cf2-4c38-8603-78a247890e4e



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- fix: Fixed IPC UI showing wrong blood level
- tweak: Chemical reactions will no longer occur in IPCs bloodstream (while it may be fun to use robot as a beaker, converting entire oil supply into ash and preventing any healing until body is drained entirely of all solutions by injecting 5u of hot water isn't)
- tweak: IPCs will no longer heal bleeding naturally at all
- tweak: Welding will heal bleed for IPCs (no effect on protogens)
- tweak: IPCs will start taking bloodloss damage at 75% oil (down from 90%)

