### PR TITLE
Radio keycodes

### DIFF
--- a/Content.Client/Silicons/Laws/Ui/LawDisplay.xaml.cs
+++ b/Content.Client/Silicons/Laws/Ui/LawDisplay.xaml.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Client.Chat.Managers;
 using Content.Client.Message;
 using Content.Shared.Chat;
@@ -65,6 +66,9 @@ public sealed partial class LawDisplay : Control
 
         if (radioChannels == null)
             return;
+        
+        var radioChannelProtos = radioChannels.Select(id => _prototypeManager.Index(id)).ToHashSet(); // Far Horizons
+        var keyCodes = SharedChatSystem.GetIndexedKeycodes(radioChannelProtos); // Far Horizons
 
         foreach (var radioChannel in radioChannels)
         {
@@ -84,13 +88,13 @@ public sealed partial class LawDisplay : Control
 
             radioChannelButton.OnPressed += _ =>
             {
-                if (radioChannel == SharedChatSystem.CommonChannel)
+                if (SharedChatSystem.CommonChannels.Contains(radioChannel)) // Far Horizons
                 {
-                    _chatManager.SendMessage($"{SharedChatSystem.RadioCommonPrefix} {lawIdentifierPlaintext}: {lawDescriptionPlaintext}", ChatSelectChannel.Radio);
+                    _chatManager.SendMessage($"{keyCodes[radioChannel]} {lawIdentifierPlaintext}: {lawDescriptionPlaintext}", ChatSelectChannel.Radio); // Far Horizons
                 }
                 else
                 {
-                    _chatManager.SendMessage($"{SharedChatSystem.RadioChannelPrefix}{radioChannelProto.KeyCode} {lawIdentifierPlaintext}: {lawDescriptionPlaintext}", ChatSelectChannel.Radio);
+                    _chatManager.SendMessage($"{SharedChatSystem.RadioChannelPrefix}{keyCodes[radioChannel]} {lawIdentifierPlaintext}: {lawDescriptionPlaintext}", ChatSelectChannel.Radio); // Far Horizons
                 }
                 _nextAllowedPress[radioChannelButton] = _timing.CurTime + PressCooldown;
             };

--- a/Content.Server/Implants/RadioImplantSystem.cs
+++ b/Content.Server/Implants/RadioImplantSystem.cs
@@ -26,6 +26,8 @@ public sealed class RadioImplantSystem : EntitySystem
                 ent.Comp.ActiveAddedChannels.Add(channel);
         }
 
+        Dirty<ActiveRadioComponent>((args.Implanted, activeRadio)); // Far Horizons - update available channels on client
+
         EnsureComp<IntrinsicRadioReceiverComponent>(args.Implanted);
 
         var intrinsicRadioTransmitter = EnsureComp<IntrinsicRadioTransmitterComponent>(args.Implanted);
@@ -53,6 +55,8 @@ public sealed class RadioImplantSystem : EntitySystem
             {
                 RemCompDeferred<ActiveRadioComponent>(args.Implanted);
             }
+            else
+                Dirty<ActiveRadioComponent>((args.Implanted, activeRadioComponent)); 
         }
 
         if (!TryComp<IntrinsicRadioTransmitterComponent>(args.Implanted, out var radioTransmitterComponent))

--- a/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
+++ b/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
@@ -43,7 +43,13 @@ public sealed class HeadsetSystem : SharedHeadsetSystem
         if (keyHolder.Channels.Count == 0)
             RemComp<ActiveRadioComponent>(uid);
         else
-            EnsureComp<ActiveRadioComponent>(uid).Channels = new(keyHolder.Channels);
+        // Far Horizons start
+        {
+            var activeRadio = EnsureComp<ActiveRadioComponent>(uid);
+            activeRadio.Channels = new(keyHolder.Channels);
+            Dirty<ActiveRadioComponent>((uid, activeRadio));
+        }
+        // Far Horizons end
     }
 
     private void OnSpeak(EntityUid uid, WearingHeadsetComponent component, EntitySpokeEvent args)
@@ -62,7 +68,11 @@ public sealed class HeadsetSystem : SharedHeadsetSystem
         base.OnGotEquipped(uid, component, args);
         if (component.IsEquipped && component.Enabled)
         {
-            EnsureComp<WearingHeadsetComponent>(args.Equipee).Headset = uid;
+            // Far Horizons start
+            var wearingHeadset = EnsureComp<WearingHeadsetComponent>(args.Equipee);
+            wearingHeadset.Headset = uid;
+            Dirty<WearingHeadsetComponent>((args.Equipee, wearingHeadset));
+            // Far Horizons end
             UpdateRadioChannels(uid, component);
         }
     }
@@ -94,7 +104,12 @@ public sealed class HeadsetSystem : SharedHeadsetSystem
         }
         else if (component.IsEquipped)
         {
-            EnsureComp<WearingHeadsetComponent>(Transform(uid).ParentUid).Headset = uid;
+            // Far Horizons start
+            var parentEnt = Transform(uid).ParentUid;
+            var wearingHeadset = EnsureComp<WearingHeadsetComponent>(parentEnt);
+            wearingHeadset.Headset = uid;
+            Dirty<WearingHeadsetComponent>((parentEnt, wearingHeadset));
+            // Far Horizons end
             UpdateRadioChannels(uid, component);
         }
     }

--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -75,7 +75,13 @@ public sealed class RadioDeviceSystem : SharedRadioDeviceSystem
     private void OnSpeakerInit(EntityUid uid, RadioSpeakerComponent component, ComponentInit args)
     {
         if (component.Enabled)
-            EnsureComp<ActiveRadioComponent>(uid).Channels.UnionWith(component.Channels);
+        // Far Horizons start
+        {
+            var activeRadio = EnsureComp<ActiveRadioComponent>(uid);
+            activeRadio.Channels.UnionWith(component.Channels);
+            Dirty<ActiveRadioComponent>((uid, activeRadio));
+        }
+        // Far Horizons end
         else
             RemCompDeferred<ActiveRadioComponent>(uid);
     }

--- a/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
@@ -26,7 +26,10 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
             transmitter.Channels = [.. radioChannels];
 
         if (TryComp(ent, out ActiveRadioComponent? activeRadio))
+        {
             activeRadio.Channels = [.. radioChannels];
+            Dirty<ActiveRadioComponent>((ent, activeRadio)); // Far Horizons
+        }
 
         // Borg transponder for the robotics console
         if (TryComp(ent, out BorgTransponderComponent? transponder))

--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -168,6 +168,7 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
             if (TryComp(uid, out ActiveRadioComponent? activeRadio))
             {
                 activeRadio.Channels.UnionWith(emag.ChannelAdd);
+                Dirty<ActiveRadioComponent>((uid, activeRadio)); // Far Horizons
             }
             if (TryComp(uid, out IntrinsicRadioTransmitterComponent? transmitter))
             {

--- a/Content.Server/_FarHorizons/Silicons/IPC/IPCSystem.Radio.cs
+++ b/Content.Server/_FarHorizons/Silicons/IPC/IPCSystem.Radio.cs
@@ -35,6 +35,8 @@ public sealed partial class IPCSystem
                 ent.Comp.RadioTransmitter.Channels.UnionWith(keyComp.Channels);
                 ent.Comp.RadioReceiver.Channels.UnionWith(keyComp.Channels);
             }
+
+        Dirty<ActiveRadioComponent>((ent, ent.Comp.RadioReceiver));
     }
 
     private void OnRadioStartingGear(Entity<IPCRadioComponent> ent, ref StartingGearEquippedEvent args)

--- a/Content.Shared/Chat/SharedChatSystem.FarHorizons.cs
+++ b/Content.Shared/Chat/SharedChatSystem.FarHorizons.cs
@@ -1,0 +1,88 @@
+using System.Collections.Frozen;
+using System.Linq;
+using Content.Shared.Radio;
+using Content.Shared.Radio.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Chat;
+
+public abstract partial class SharedChatSystem
+{
+    private FrozenDictionary<char, List<RadioChannelPrototype>> _keyCodes = default!;
+
+    private void CacheRadios()
+    {
+        _keyCodes = _prototypeManager.EnumeratePrototypes<RadioChannelPrototype>()
+            .GroupBy(r => r.KeyCode)
+            .ToFrozenDictionary(
+                group => group.Key,
+                group => group.ToList());
+    }
+
+    private RadioChannelPrototype? GetBestMatchingChannel(EntityUid source,
+        List<ProtoId<RadioChannelPrototype>> channels, string oldOutput, out string newOutput) =>
+        GetBestMatchingChannel(source, channels.Select(c => _prototypeManager.Index(c)).ToList(), oldOutput,
+            out newOutput);
+
+    private RadioChannelPrototype? GetBestMatchingChannel(EntityUid source, List<RadioChannelPrototype> channels, string oldOutput, out string newOutput)
+    {
+        var availableChannels = AvailableChannels(source);
+
+        var matchingChannels = channels.Where(channel => availableChannels.Contains(channel)).OrderBy(channel => channel.ID).ToList();
+
+        if (matchingChannels.Count == 1)
+        {
+            newOutput = oldOutput;
+            return matchingChannels.First();
+        }
+        else if (matchingChannels.Count > 1 && oldOutput.Length > 0)
+        {
+            var index = oldOutput[0].ToString();
+            if (int.TryParse(index, out var parsedIndex))
+            {
+                newOutput = SanitizeMessageCapital(oldOutput[1..].TrimStart());
+                return matchingChannels[parsedIndex - 1];
+            }
+        }
+
+        newOutput = oldOutput;
+        return null;
+    }
+
+    private List<ProtoId<RadioChannelPrototype>> AvailableChannels(EntityUid source)
+    {
+        List<ProtoId<RadioChannelPrototype>> result = [];
+
+        if (TryComp<ActiveRadioComponent>(source, out var activeRadio))
+            result.AddRange(activeRadio.Channels);
+
+        if (TryComp<WearingHeadsetComponent>(source, out var wearingHeadset) &&
+            TryComp<ActiveRadioComponent>(wearingHeadset.Headset, out var headsetRadio))
+            result.AddRange(headsetRadio.Channels);
+
+        return result;
+    }
+
+    public static Dictionary<ProtoId<RadioChannelPrototype>, string> GetIndexedKeycodes(
+        HashSet<RadioChannelPrototype> radioChannels)
+    {
+        Dictionary<ProtoId<RadioChannelPrototype>, string> keyCodes = new();
+
+        foreach (var channel in radioChannels)
+        {
+            var matchingCodes = radioChannels.Where(p => p.KeyCode == channel.KeyCode).OrderBy(p => p.ID).ToList();
+            switch (matchingCodes.Count)
+            {
+                case 1:
+                    keyCodes[channel.ID] = channel.KeyCode.ToString();
+                    break;
+                case > 1:
+                    var index = matchingCodes.FindIndex(p => p.ID == channel.ID) + 1;
+                    keyCodes[channel.ID] = $"{channel.KeyCode}{index}";
+                    break;
+            }
+        }
+
+        return keyCodes;
+    }
+}

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -50,7 +50,8 @@ public abstract partial class SharedChatSystem : EntitySystem
 
     public static readonly char[] ICDisallowedCharacters = ['[', ']', '\\']; // Starlight
 
-    public static readonly ProtoId<RadioChannelPrototype> CommonChannel = "Common";
+    public static readonly ProtoId<RadioChannelPrototype> DefaultCommonChannel = "Common"; // Far Horizons
+    public static readonly List<ProtoId<RadioChannelPrototype>> CommonChannels = new() { "Common", "SyndiCommon" }; // Far Horizons
 
     public static readonly string DefaultChannelPrefix = $"{RadioChannelPrefix}{DefaultChannelKey}";
     public static readonly ProtoId<SpeechVerbPrototype> DefaultSpeechVerb = "Default";
@@ -71,7 +72,8 @@ public abstract partial class SharedChatSystem : EntitySystem
     /// <summary>
     /// Cache of the keycodes for faster lookup.
     /// </summary>
-    private FrozenDictionary<char, RadioChannelPrototype> _keyCodes = default!;
+    /// Far Horizons - moved to separate file
+    // private FrozenDictionary<char, RadioChannelPrototype> _keyCodes = default!;
     
     private FrozenDictionary<char, CollectiveMindPrototype> _mindKeyCodes = default!;
 
@@ -79,7 +81,8 @@ public abstract partial class SharedChatSystem : EntitySystem
     {
         base.Initialize();
 
-        DebugTools.Assert(_prototypeManager.HasIndex(CommonChannel));
+        foreach (var commonChannel in CommonChannels) // Far Horizons
+            DebugTools.Assert(_prototypeManager.HasIndex(commonChannel));
 
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypeReload);
         CacheRadios();
@@ -100,11 +103,12 @@ public abstract partial class SharedChatSystem : EntitySystem
             CacheCollectiveMinds(); // Starlight
     }
 
-    private void CacheRadios()
-    {
-        _keyCodes = _prototypeManager.EnumeratePrototypes<RadioChannelPrototype>()
-            .ToFrozenDictionary(x => x.KeyCode);
-    }
+    // Far Horizons - moved to separate file
+    // private void CacheRadios()
+    // {
+    //     _keyCodes = _prototypeManager.EnumeratePrototypes<RadioChannelPrototype>()
+    //         .ToFrozenDictionary(x => x.KeyCode);
+    // }
     
     private void CacheCollectiveMinds()
     {
@@ -192,7 +196,7 @@ public abstract partial class SharedChatSystem : EntitySystem
         if (input.StartsWith(RadioCommonPrefix))
         {
             output = SanitizeMessageCapital(input[1..].TrimStart());
-            channel = _prototypeManager.Index<RadioChannelPrototype>(CommonChannel);
+            channel = GetBestMatchingChannel(source, CommonChannels, output, out output); // Far Horizons
             return true;
         }
 
@@ -221,11 +225,14 @@ public abstract partial class SharedChatSystem : EntitySystem
             return true;
         }
 
-        if (!_keyCodes.TryGetValue(channelKey, out channel) && !quiet)
+        if (!_keyCodes.TryGetValue(channelKey, out var channels) && !quiet) // Far Horizons - match channel list
         {
             var msg = Loc.GetString("chat-manager-no-such-channel", ("key", channelKey));
             _popup.PopupEntity(msg, source, source);
         }
+
+        if (channels != null)
+            channel = GetBestMatchingChannel(source, channels, output, out output); // Far Horizons
 
         return true;
     }

--- a/Content.Shared/Radio/Components/ActiveRadioComponent.cs
+++ b/Content.Shared/Radio/Components/ActiveRadioComponent.cs
@@ -6,13 +6,13 @@ namespace Content.Shared.Radio.Components;
 /// <summary>
 ///     This component is required to receive radio message events.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ActiveRadioComponent : Component
 {
     /// <summary>
     ///     The channels that this radio is listening on.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField] // Far Horizons - make field auto networked
     public HashSet<ProtoId<RadioChannelPrototype>> Channels = new();
 
     /// <summary>

--- a/Content.Shared/Radio/Components/IntrinsicRadioTransmitterComponent.cs
+++ b/Content.Shared/Radio/Components/IntrinsicRadioTransmitterComponent.cs
@@ -12,5 +12,5 @@ namespace Content.Shared.Radio.Components;
 public sealed partial class IntrinsicRadioTransmitterComponent : Component
 {
     [DataField]
-    public HashSet<ProtoId<RadioChannelPrototype>> Channels = new() { SharedChatSystem.CommonChannel };
+    public HashSet<ProtoId<RadioChannelPrototype>> Channels = new() { SharedChatSystem.DefaultCommonChannel };
 }

--- a/Content.Shared/Radio/Components/RadioMicrophoneComponent.cs
+++ b/Content.Shared/Radio/Components/RadioMicrophoneComponent.cs
@@ -13,7 +13,7 @@ namespace Content.Shared.Radio.Components;
 public sealed partial class RadioMicrophoneComponent : Component
 {
     [DataField]
-    public ProtoId<RadioChannelPrototype> BroadcastChannel = SharedChatSystem.CommonChannel;
+    public ProtoId<RadioChannelPrototype> BroadcastChannel = SharedChatSystem.DefaultCommonChannel;
 
     [DataField]
     public int ListenRange = 4;

--- a/Content.Shared/Radio/Components/RadioSpeakerComponent.cs
+++ b/Content.Shared/Radio/Components/RadioSpeakerComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class RadioSpeakerComponent : Component
     public bool ToggleOnInteract = true;
 
     [DataField]
-    public HashSet<ProtoId<RadioChannelPrototype>> Channels = new() { SharedChatSystem.CommonChannel };
+    public HashSet<ProtoId<RadioChannelPrototype>> Channels = new() { SharedChatSystem.DefaultCommonChannel };
 
     [DataField, AutoNetworkedField]
     public bool Enabled;

--- a/Content.Shared/Radio/Components/WearingHeadsetComponent.cs
+++ b/Content.Shared/Radio/Components/WearingHeadsetComponent.cs
@@ -5,9 +5,9 @@ namespace Content.Shared.Radio.Components;
 /// <summary>
 ///     This component is used to tag players that are currently wearing an ACTIVE headset.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class WearingHeadsetComponent : Component
 {
-    [DataField]
+    [DataField, AutoNetworkedField] // Far Horizons - make field auto networked
     public EntityUid Headset;
 }

--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -209,23 +209,25 @@ public sealed partial class EncryptionKeySystem : EntitySystem
     /// <param name="channelFTLPattern">String that provide id of pattern in .ftl files to format channel with variables of it.</param>
     public void AddChannelsExamine(HashSet<ProtoId<RadioChannelPrototype>> channels, string? defaultChannel, ExaminedEvent examineEvent, IPrototypeManager protoManager, string channelFTLPattern)
     {
-        RadioChannelPrototype? proto;
-        foreach (var id in channels)
-        {
-            proto = _protoManager.Index<RadioChannelPrototype>(id);
+        // Far Horizons start
+        var radioChannels = channels.Select(id => _protoManager.Index(id)).ToHashSet();
+        var keyCodes = SharedChatSystem.GetIndexedKeycodes(radioChannels);
 
-            var key = id == SharedChatSystem.CommonChannel
-                ? SharedChatSystem.RadioCommonPrefix.ToString()
-                : $"{SharedChatSystem.RadioChannelPrefix}{proto.KeyCode}";
+        foreach (var channel in radioChannels)
+        {
+            var key = SharedChatSystem.CommonChannels.Contains(channel.ID)
+                ? keyCodes[channel.ID]
+                : $"{SharedChatSystem.RadioChannelPrefix}{keyCodes[channel.ID]}";
 
             examineEvent.PushMarkup(Loc.GetString(channelFTLPattern,
-                ("color", proto.Color),
+                ("color", channel.Color),
                 ("key", key),
-                ("id", proto.LocalizedName),
-                ("freq", proto.Frequency / 10f)));
+                ("id", channel.LocalizedName),
+                ("freq", channel.Frequency / 10f)));
         }
+        // Far Horizons end
 
-        if (defaultChannel != null && _protoManager.TryIndex(defaultChannel, out proto))
+        if (defaultChannel != null && _protoManager.TryIndex(defaultChannel, out RadioChannelPrototype? proto))
         {
             if (HasComp<HeadsetComponent>(examineEvent.Examined))
             {

--- a/Content.Shared/Radio/EntitySystems/SharedRadioDeviceSystem.cs
+++ b/Content.Shared/Radio/EntitySystems/SharedRadioDeviceSystem.cs
@@ -44,7 +44,13 @@ public abstract class SharedRadioDeviceSystem : EntitySystem
 
         _appearance.SetData(uid, RadioDeviceVisuals.Speaker, component.Enabled);
         if (component.Enabled)
-            EnsureComp<ActiveRadioComponent>(uid).Channels.UnionWith(component.Channels);
+        // Far Horizons start
+        {
+            var activeRadio = EnsureComp<ActiveRadioComponent>(uid);
+            activeRadio.Channels.UnionWith(component.Channels);
+            Dirty<ActiveRadioComponent>((uid, activeRadio));
+        }
+        // Far Horizons end
         else
             RemCompDeferred<ActiveRadioComponent>(uid);
     }

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
@@ -320,6 +320,8 @@ public abstract partial class SharedBorgSystem : EntitySystem
                 {
                     activeRadio.Channels.Add(channel);
                 }
+
+                Dirty<ActiveRadioComponent>((ent, activeRadio)); // Far Horizons
             }
             if (TryComp(ent, out IntrinsicRadioTransmitterComponent? transmitter))
             {

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Ears/headsets.yml
@@ -56,7 +56,7 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyStationMaster
+      - EncryptionKeySyndiMaster
   - type: Sprite
     sprite: _FarHorizons/Clothing/Ears/Headsets/syndicommand.rsi #Far Horizons
   - type: Clothing
@@ -74,7 +74,7 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyStationMaster
+      - EncryptionKeySyndiMaster
   - type: Sprite
     sprite: _FarHorizons/Clothing/Ears/Headsets/syndicommand.rsi #Far Horizons
   - type: Clothing
@@ -93,9 +93,9 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeySecurity
-      - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      - EncryptionKeySyndiSecurity
+      - EncryptionKeySyndiCommand
+      - EncryptionKeySyndiCommon
   - type: Sprite
     sprite: _FarHorizons/Clothing/Ears/Headsets/security-syndi.rsi
   - type: Clothing
@@ -114,9 +114,9 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeySecurity
-      - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      - EncryptionKeySyndiSecurity
+      - EncryptionKeySyndiCommand
+      - EncryptionKeySyndiCommon
   - type: Sprite
     sprite: _FarHorizons/Clothing/Ears/Headsets/security-syndi.rsi
   - type: Clothing
@@ -135,9 +135,9 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyEngineering
-      - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      - EncryptionKeySyndiEngi
+      - EncryptionKeySyndiCommand
+      - EncryptionKeySyndiCommon
   - type: Sprite
     sprite: _FarHorizons/Clothing/Ears/Headsets/engineering-syndi.rsi
   - type: Clothing
@@ -156,9 +156,9 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyEngineering
-      - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      - EncryptionKeySyndiEngi
+      - EncryptionKeySyndiCommand
+      - EncryptionKeySyndiCommon
   - type: Sprite
     sprite: _FarHorizons/Clothing/Ears/Headsets/engineering-syndi.rsi
   - type: Clothing
@@ -179,8 +179,8 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyEngineering
-      - EncryptionKeyCommon
+      - EncryptionKeySyndiEngi
+      - EncryptionKeySyndiCommon
   - type: Sprite
     sprite: _FarHorizons/Clothing/Ears/Headsets/engineering-syndi.rsi
   - type: Clothing
@@ -199,8 +199,8 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeySecurity
-      - EncryptionKeyCommon
+      - EncryptionKeySyndiSecurity
+      - EncryptionKeySyndiCommon
   - type: Sprite
     sprite: _FarHorizons/Clothing/Ears/Headsets/security-syndi.rsi
   - type: Clothing
@@ -219,8 +219,8 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeySecurity
-      - EncryptionKeyCommon
+      - EncryptionKeySyndiSecurity
+      - EncryptionKeySyndiCommon
   - type: Sprite
     sprite: _FarHorizons/Clothing/Ears/Headsets/security-syndi.rsi
   - type: Clothing
@@ -241,8 +241,8 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeySecurity
-      - EncryptionKeyCommon
+      - EncryptionKeySyndiSecurity
+      - EncryptionKeySyndiCommon
   - type: Sprite
     sprite: _FarHorizons/Clothing/Ears/Headsets/security-syndi.rsi
   - type: Clothing
@@ -261,8 +261,8 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeySecurity
-      - EncryptionKeyCommon
+      - EncryptionKeySyndiSecurity
+      - EncryptionKeySyndiCommon
   - type: Sprite
     sprite: _FarHorizons/Clothing/Ears/Headsets/security-syndi.rsi
   - type: Clothing
@@ -283,8 +283,8 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeySecurityMedical
-      - EncryptionKeyCommon
+      - EncryptionKeySyndiSecMed
+      - EncryptionKeySyndiCommon
   - type: Sprite
     sprite: _FarHorizons/Clothing/Ears/Headsets/secmed-syndi.rsi
   - type: Clothing
@@ -303,8 +303,8 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeySecurityMedical
-      - EncryptionKeyCommon
+      - EncryptionKeySyndiSecMed
+      - EncryptionKeySyndiCommon
   - type: Sprite
     sprite: _FarHorizons/Clothing/Ears/Headsets/secmed-syndi.rsi
   - type: Clothing

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/encryption_keys.yml
@@ -6,6 +6,7 @@
   id: EncryptionKeySyndi
   name: Encryption Key
   description: A small cipher chip for headsets.
+  suffix: S
   components:
   - type: EncryptionKey
   - type: Item
@@ -79,6 +80,8 @@
     - SyndiMed
     - SyndiService
     - SyndiCommon
+    - GSL # Far Horizons
+    - Law
     defaultChannel: SyndiCommand
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Machines/telecomms.yml
@@ -7,3 +7,96 @@
     containers:
       key_slots:
       - EncryptionKeyTrinary
+
+---
+
+# Syndicate
+# Todo: add sprites for syndie channels on screen
+
+- type: entity
+  parent: TelecomServer
+  id: TelecomServerFilledSyndi
+  suffix: Filled All S
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeySyndiCommon
+      - EncryptionKeyCargo
+      - EncryptionKeySyndiEngi
+      - EncryptionKeySyndiMed
+      - EncryptionKeySyndiSci
+      - EncryptionKeySyndiSecurity
+      - EncryptionKeySyndiService
+      - EncryptionKeySyndiCommand
+      - EncryptionKeyTrinary #FH
+
+- type: entity
+  parent: TelecomServer
+  id: TelecomServerFilledSyndiCommon
+  suffix: Common S
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeySyndiCommon
+
+- type: entity
+  parent: TelecomServer
+  id: TelecomServerFilledSyndiEngineering
+  suffix: Engineering S
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeySyndiEngi
+
+- type: entity
+  parent: TelecomServer
+  id: TelecomServerFilledSyndiMedical
+  suffix: Medical S
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeySyndiMed
+
+- type: entity
+  parent: TelecomServer
+  id: TelecomServerFilledSyndiScience
+  suffix: Science S
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeySyndiSci
+
+- type: entity
+  parent: TelecomServer
+  id: TelecomServerFilledSyndiSecurity
+  suffix: Security S
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeySyndiSecurity
+
+- type: entity
+  parent: TelecomServer
+  id: TelecomServerFilledSyndiService
+  suffix: Service S
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeySyndiService
+
+- type: entity
+  parent: TelecomServer
+  id: TelecomServerFilledSyndiCommand
+  suffix: Command S
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeySyndiCommand

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Machines/telecomms.yml
@@ -16,7 +16,7 @@
 - type: entity
   parent: TelecomServer
   id: TelecomServerFilledSyndi
-  suffix: Filled All S
+  suffix: All, S
   components:
   - type: ContainerFill
     containers:
@@ -34,7 +34,7 @@
 - type: entity
   parent: TelecomServer
   id: TelecomServerFilledSyndiCommon
-  suffix: Common S
+  suffix: Common, S
   components:
   - type: ContainerFill
     containers:
@@ -44,7 +44,7 @@
 - type: entity
   parent: TelecomServer
   id: TelecomServerFilledSyndiEngineering
-  suffix: Engineering S
+  suffix: Engineering, S
   components:
   - type: ContainerFill
     containers:
@@ -54,7 +54,7 @@
 - type: entity
   parent: TelecomServer
   id: TelecomServerFilledSyndiMedical
-  suffix: Medical S
+  suffix: Medical, S
   components:
   - type: ContainerFill
     containers:
@@ -64,7 +64,7 @@
 - type: entity
   parent: TelecomServer
   id: TelecomServerFilledSyndiScience
-  suffix: Science S
+  suffix: Science, S
   components:
   - type: ContainerFill
     containers:
@@ -74,7 +74,7 @@
 - type: entity
   parent: TelecomServer
   id: TelecomServerFilledSyndiSecurity
-  suffix: Security S
+  suffix: Security, S
   components:
   - type: ContainerFill
     containers:
@@ -84,7 +84,7 @@
 - type: entity
   parent: TelecomServer
   id: TelecomServerFilledSyndiService
-  suffix: Service S
+  suffix: Service, S
   components:
   - type: ContainerFill
     containers:
@@ -94,7 +94,7 @@
 - type: entity
   parent: TelecomServer
   id: TelecomServerFilledSyndiCommand
-  suffix: Command S
+  suffix: Command, S
   components:
   - type: ContainerFill
     containers:

--- a/Resources/Prototypes/_FarHorizons/radio_channels.yml
+++ b/Resources/Prototypes/_FarHorizons/radio_channels.yml
@@ -17,7 +17,7 @@
 - type: radioChannel
   id: Lambda
   name: chat-radio-lambda
-  keycode: "o"
+  keycode: "t"
   frequency: 6767
   color: "#007bff"
   longRange: true
@@ -30,49 +30,49 @@
 - type: radioChannel
   id: SyndiCommand
   name: chat-radio-syndi-command
-  keycode: "1"
+  keycode: "c"
   frequency: 3368
   color: "#E0AA3E"
 
 - type: radioChannel
   id: SyndiSec
   name: chat-radio-syndi-security
-  keycode: "2"
+  keycode: "s"
   frequency: 3325
   color: "#8a1313"
 
 - type: radioChannel
   id: SyndiSci
   name: chat-radio-syndi-science
-  keycode: "3"
+  keycode: "n"
   frequency: 3371
   color: "#a94ac2"
 
 - type: radioChannel
   id: SyndiMed
   name: chat-radio-syndi-medical
-  keycode: "4"
+  keycode: "m"
   frequency: 3333
   color: "#038ae1"
 
 - type: radioChannel
   id: SyndiEngi
   name: chat-radio-syndi-engineering
-  keycode: "5"
+  keycode: "e"
   frequency: 3364
   color: "#f27803"
 
 - type: radioChannel
   id: SyndiService
   name: chat-radio-syndi-service
-  keycode: '6'
+  keycode: "v"
   frequency: 3337
   color: "#F1C232"
 
 - type: radioChannel
   id: SyndiCommon
   name: chat-radio-syndi-common
-  keycode: "7"
+  keycode: ";"
   frequency: 3465
   color: "#2cdb2c"
 
@@ -81,7 +81,7 @@
 - type: radioChannel
   id: SHC
   name: chat-radio-neosol-high-command
-  keycode: "r"
+  keycode: "y"
   frequency: 3214
   color: "#ff0000"
   longRange: true
@@ -89,7 +89,7 @@
 - type: radioChannel
   id: GMN
   name: chat-radio-gorlex-marauder-navy
-  keycode: "g"
+  keycode: "i"
   frequency: 3584
   color: "#990000"
   longRange: true


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
* Allow multiple radio channels to use the same keycode
* Keycode is selected based on what's available for the character. 
* When multiple channels with the same keycode available - adds numbered index
* Changed all "mirrored" channels to the same keycode
* Also added syndie telecom prototypes because I needed to test radios a lot. And added some suffixes for the same reason

## Why we need to add this
So syndicate round can use the same radio keycodes people are used to.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/186567f1-8d0d-4d4f-92ad-82eb699e4a33



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- add: Adds support for reusing keycodes between different radio channels
- tweak: Changed all "mirrored" radio channels to use the same keycode (example: syndicate and NT command both use ":c" to speak in their radio; both syndicate and NT nukies will use ":t" for theirs)
- add: Syndicate telecom servers for mapping