### PR TITLE
Fun With Spawners

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Markers/Spawners/Random/Machines.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Markers/Spawners/Random/Machines.yml
@@ -1,0 +1,206 @@
+- type: entity
+  name: Engine Generator Spawner
+  id: SpawnerEngineGenerator
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Power\Generation\Singularity\generator.rsi
+      state: icon
+  - type: RandomSpawner
+    prototypes:
+    - SingularityGenerator
+    - TeslaGenerator
+    offset: 0.0
+
+- type: entity
+  name: Engine Generator Spawner
+  id: SpawnerEngineGenerator70
+  suffix: 70%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Power\Generation\Singularity\generator.rsi
+      state: icon
+  - type: RandomSpawner
+    prototypes:
+    - SingularityGenerator
+    - TeslaGenerator
+    chance: 0.7
+    offset: 0.0
+
+- type: entity
+  name: Rad Collector Spawner
+  id: SpawnerRadCollectorTank
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Power\Generation\Singularity\collector.rsi
+      state: ca_off
+  - type: RandomSpawner
+    rarePrototypes:
+    - RadiationCollectorFullTank
+    rareChance: 0.3
+    prototypes:
+    - RadiationCollector
+    - RadiationCollectorNoTank 
+    offset: 0.0
+
+- type: entity
+  name: Rad Collector Spawner
+  id: SpawnerRadCollectorr70
+  suffix: 70%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Power\Generation\Singularity\collector.rsi
+      state: ca_off
+  - type: RandomSpawner
+    rarePrototypes:
+    - RadiationCollectorFullTank
+    rareChance: 0.1
+    prototypes:
+    - RadiationCollector
+    - RadiationCollectorNoTank 
+    chance: 0.6
+    offset: 0.0
+
+- type: entity
+  name: Rad Collector Spawner
+  id: SpawnerRadCollectorr50
+  suffix: 50%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Power\Generation\Singularity\collector.rsi
+      state: ca_off
+  - type: RandomSpawner
+    rarePrototypes:
+    - RadiationCollectorFullTank
+    rareChance: 0.1
+    prototypes:
+    - RadiationCollector
+    - RadiationCollectorNoTank 
+    chance: 0.4
+    offset: 0.0
+
+- type: entity
+  name: Rad Collector Spawner
+  id: SpawnerRadCollectorr30
+  suffix: 30%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Power\Generation\Singularity\collector.rsi
+      state: ca_off
+  - type: RandomSpawner
+    rarePrototypes:
+    - RadiationCollectorFullTank
+    rareChance: 0.1
+    prototypes:
+    - RadiationCollector
+    - RadiationCollectorNoTank 
+    chance: 0.2
+    offset: 0.0
+
+- type: entity
+  name: TeslaCoil Spawner
+  id: SpawnerTeslaCoil70
+  suffix: 70%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Power\Generation\Tesla\coil.rsi
+      state: coil
+  - type: RandomSpawner
+    prototypes:
+    - TeslaCoil
+    chance: 0.7
+    offset: 0.0
+
+- type: entity
+  name: TeslaCoil Spawner
+  id: SpawnerTeslaCoil50
+  suffix: 50%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Power\Generation\Tesla\coil.rsi
+      state: coil
+  - type: RandomSpawner
+    prototypes:
+    - TeslaCoil
+    chance: 0.5
+    offset: 0.0
+
+- type: entity
+  name: TeslaCoil Spawner
+  id: SpawnerTeslaCoil30
+  suffix: 30%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Power\Generation\Tesla\coil.rsi
+      state: coil
+  - type: RandomSpawner
+    prototypes:
+    - TeslaCoil
+    chance: 0.3
+    offset: 0.0
+
+- type: entity
+  name: Artifact Analyzer Spawner
+  id: SpawnerMachineArtifactAnalyzer80
+  suffix: 80%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Machines\artifact_analyzer.rsi
+      state: display
+  - type: RandomSpawner
+    rarePrototypes:
+    - MachineFrame
+    rareChance: 0.1
+    prototypes:
+    - MachineArtifactAnalyzer
+    chance: 0.8
+    offset: 0.0
+
+- type: entity
+  name: Analysis Console Spawner
+  id: SpawnerComputerAnalysisConsole80
+  suffix: 80%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Machines\computers.rsi
+      state: computer
+  - type: RandomSpawner
+    rarePrototypes:
+    - ComputerFrame
+    rareChance: 0.1
+    prototypes:
+    - ComputerAnalysisConsole
+    chance: 0.8
+    offset: 0.0

--- a/Resources/Prototypes/_FarHorizons/Entities/Markers/Spawners/Random/cables.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Markers/Spawners/Random/cables.yml
@@ -1,0 +1,41 @@
+- type: entity
+  parent: MarkerBase
+  id: RandomCableHVSpawner80
+  name: HV power cable spawner
+  suffix: 80%
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures/Power/Cables/hv_cable.rsi
+      state: hvcable_3
+    - sprite: Structures/Power/Cables/hv_cable.rsi
+      state: hvcable_12
+  - type: RandomSpawner
+    prototypes:
+    - CableHV
+    chance: 0.8
+
+- type: entity
+  parent: MarkerBase
+  id: RandomCableMVSpawner70
+  name: MV power cable spawner
+  suffix: 70%
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures/Power/Cables/mv_cable.rsi
+      state: mvcable_3
+      color: Yellow
+    - sprite: Structures/Power/Cables/mv_cable.rsi
+      state: mvstripes_3
+    - sprite: Structures/Power/Cables/mv_cable.rsi
+      state: mvcable_12
+      color: Yellow
+    - sprite: Structures/Power/Cables/mv_cable.rsi
+      state: mvstripes_12
+  - type: RandomSpawner
+    prototypes:
+    - CableMV
+    chance: 0.7

--- a/Resources/Prototypes/_FarHorizons/Entities/Markers/Spawners/Random/crates.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Markers/Spawners/Random/crates.yml
@@ -1,0 +1,35 @@
+- type: entity
+  name: Engineering engine crate spawner
+  id: SpawnerEngineeringEngineCrate
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures/Storage/Crates/engineering.rsi
+      state: icon
+  - type: RandomSpawner
+    prototypes:
+    - CrateEngineeringSingularityGenerator
+    - CrateEngineeringTeslaGenerator
+    offset: 0.0
+
+- type: entity
+  name: Engineering engine crate spawner
+  id: SpawnerEngineeringEngineCrate70
+  suffix: 70%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures/Storage/Crates/engineering.rsi
+      state: icon
+  - type: RandomSpawner
+    rarePrototypes:
+    - CrateEngineeringSecure
+    rareChance: 0.3
+    prototypes:
+    - CrateEngineeringSingularityGenerator
+    - CrateEngineeringTeslaGenerator
+    offset: 0.0

--- a/Resources/Prototypes/_FarHorizons/Entities/Markers/Spawners/Random/walls.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Markers/Spawners/Random/walls.yml
@@ -1,0 +1,203 @@
+- type: entity
+  name: Syndicate Wall Spawner
+  id: SpawnerWallSolidSyndicate70
+  suffix: 70%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: _FarHorizons\Structures\Walls\solid_syndie.rsi
+      state: full
+  - type: RandomSpawner
+    prototypes:
+    - WallSolidSyndicate
+    chance: 0.7
+    offset: 0.0
+
+- type: entity
+  name: Syndicate Wall Spawner
+  id: SpawnerWallSolidSyndicate50
+  suffix: 50%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: _FarHorizons\Structures\Walls\solid_syndie.rsi
+      state: full
+  - type: RandomSpawner
+    prototypes:
+    - WallSolidSyndicate
+    chance: 0.5
+    offset: 0.0
+
+- type: entity
+  name: Syndicate Wall Spawner
+  id: SpawnerWallSolidSyndicate30
+  suffix: 30%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: _FarHorizons\Structures\Walls\solid_syndie.rsi
+      state: full
+  - type: RandomSpawner
+    prototypes:
+    - WallSolidSyndicate
+    chance: 0.3
+    offset: 0.0
+
+- type: entity
+  name: Syndicate Reinforced Wall Spawner
+  id: SpawnerWallReinforcedSyndicate70
+  suffix: 70%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: _FarHorizons\Structures\Walls\solid_syndie.rsi
+      state: rgeneric
+  - type: RandomSpawner
+    prototypes:
+    - WallReinforcedSyndicate
+    chance: 0.7
+    offset: 0.0
+
+- type: entity
+  name: Syndicate Reinforced Wall Spawner
+  id: SpawnerWallReinforcedSyndicate50
+  suffix: 50%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: _FarHorizons\Structures\Walls\solid_syndie.rsi
+      state: rgeneric
+  - type: RandomSpawner
+    prototypes:
+    - WallReinforcedSyndicate
+    chance: 0.5
+    offset: 0.0
+
+- type: entity
+  name: Syndicate Reinforced Wall Spawner
+  id: SpawnerWallReinforcedSyndicate30
+  suffix: 30%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: _FarHorizons\Structures\Walls\solid_syndie.rsi
+      state: rgeneric
+  - type: RandomSpawner
+    prototypes:
+    - WallReinforcedSyndicate
+    chance: 0.3
+    offset: 0.0
+
+- type: entity
+  name: Wall Spawner
+  id: SpawnerWallSolid70
+  suffix: 70%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Walls\solid.rsi
+      state: full
+  - type: RandomSpawner
+    prototypes:
+    - WallSolid
+    chance: 0.7
+    offset: 0.0
+
+- type: entity
+  name: Wall Spawner
+  id: SpawnerWallSolid50
+  suffix: 50%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Walls\solid.rsi
+      state: full
+  - type: RandomSpawner
+    prototypes:
+    - WallSolid
+    chance: 0.5
+    offset: 0.0
+
+- type: entity
+  name: Wall Spawner
+  id: SpawnerWallSolid30
+  suffix: 30%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Walls\solid.rsi
+      state: full
+  - type: RandomSpawner
+    prototypes:
+    - WallSolid
+    chance: 0.3
+    offset: 0.0
+
+- type: entity
+  name: Reinforced Wall Spawner
+  id: SpawnerWallReinforced70
+  suffix: 70%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Walls\solid.rsi
+      state: rgeneric
+  - type: RandomSpawner
+    prototypes:
+    - WallReinforced
+    chance: 0.7
+    offset: 0.0
+
+- type: entity
+  name: Reinforced Wall Spawner
+  id: SpawnerWallReinforced50
+  suffix: 50%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Walls\solid.rsi
+      state: rgeneric
+  - type: RandomSpawner
+    prototypes:
+    - WallReinforced
+    chance: 0.5
+    offset: 0.0
+
+- type: entity
+  name: Reinforced Wall Spawner
+  id: SpawnerWallReinforced30
+  suffix: 30%
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures\Walls\solid.rsi
+      state: rgeneric
+  - type: RandomSpawner
+    prototypes:
+    - WallReinforced
+    chance: 0.3
+    offset: 0.0


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds some spawners for mapping, here they are
- A spawner for spawning MV and HV cables at increased rates (RandomCableHVSpawner80 and RandomCableMVSpawner70)
- A spawner for Spawning either a Crate with a Singularity or Tesla Flat pack crate (SpawnerEngineeringEngineCrate)
- A spawner that spawns either a Crate with a Singularity or Tesla Flat pack crate 70% of the time otherwise spawning a empty crate (SpawnerEngineeringEngineCrate70)
- Spawners for the above two spawners but for the unpacked version (SpawnerEngineGenerator and SpawnerEngineGenerator70)
- A spawner that spawns a Radiation collector that either has a empty tank, no tank or on a 30% chance to have a full tank (SpawnerRadCollectorTank)
- A spawner that has a chance (70%, 50% and 30%) to spawn a Radiation collector with a 10% chance to spawn a full collector (SpawnerRadCollectorr70, SpawnerRadCollectorr50 and SpawnerRadCollectorr30)
- A spawner that has a chance (70%, 50% and 30%) to spawn a Tesla Coil (SpawnerTeslaCoil70, SpawnerTeslaCoil50 and SpawnerTeslaCoil30)
- A spawner that has 80% chance spawn either Artifact Analyzer or a Analysis Console respectively, if they don’t spawn there will either be a Half-finished machine frame version or nothing (SpawnerMachineArtifactAnalyzer80 and SpawnerComputerAnalysisConsole80)
- A spawner that has a chance (70%, 50% and 30%) to spawn a wall of the two most common types for both factions (SpawnerWall[Wall Prototype name]70 , SpawnerWall[Wall Prototype name]50 and SpawnerWall[Wall Prototype name]30)
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
TLDR: These spawners add more variety to rounds below are some recommended use cases
-	Walls – the wall spawners are for randomly generating mazes or rooms
-	Science – for the Science Spawners they can be used for incomplete artifact chambers that Science can rebilled with there lathes, best to make sure that there is always at attest one working chamber and put a Multi tool on a table nearby as the devices as when they spawn they wont be linked
-	Engine Spawners – with all the different power sources these mix things up a bit, probably best to put one spawner that has a chance to not spawn one and one that guarantees one or the other, otherwise if you want there to be a chance that engineering has neither I would still recommend using 2 spawns as it will make it a once in a blue moon thing
-	Rad Collector Tank spawner – this spawner can be used in the place of regular Radiation collectors as it always guarantees that one spawns just randomizes the type
-	Chance Based Radiation collector and Tesla Coil spawner – these can be used to give a set up a Half set up look, if one doesn’t spawn there should still be a replacement nearby
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Not really sure if I should put anything here 

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: AirJab
- add: Adds random wall spawners
- add: Adds random Engineering spawners
- add: Adds random Science spawners
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: FAR HORIZONS TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->