### PR TITLE
Fix holo-parasyte injector acting exactly like a hypospray

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Fun/prunks.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Fun/prunks.yml
@@ -50,6 +50,14 @@
       reagents:
       - ReagentId: Ipecac
         Quantity: 0.1
+  # Far Horizons start - please dont make this into basically a hypopen???????
+  - type: Injector
+    solutionName: hypospray
+    currentTransferAmount: 10
+    activeModeProtoId: HyposprayInjectMode
+    allowedModes:
+    - HyposprayInjectMode
+  # Far Horizons end
   - type: UseDelay
     delay: 0.5
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Currently holo-parasyte injector toy that can be bought by a clown for some 300 spesos-ish, acts exactly like a hypospray.

## Why we need to add this
As much as i play clown regularly, i don't believe this is an intended behaviour.

## Media (Video/Screenshots)
BEFORE FIX

https://github.com/user-attachments/assets/c85d4f51-e053-488a-8006-7390b8f21180

AFTER FIX 

https://github.com/user-attachments/assets/f3d0cadc-d279-4da3-95d6-a844c95f52b4

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- fix: Fixed holo-parasyte injector acting like a hypopen.
