### PR TITLE
pickupable speed relay

### DIFF
--- a/Content.Shared/_FarHorizons/VisualPickupable/PickupableSpeedRelayComponent.cs
+++ b/Content.Shared/_FarHorizons/VisualPickupable/PickupableSpeedRelayComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._FarHorizons.VisualPickupable;
+
+[RegisterComponent]
+public sealed partial class PickupableSpeedRelayComponent : Component;

--- a/Content.Shared/_FarHorizons/VisualPickupable/PickupableSpeedRelaySystem.cs
+++ b/Content.Shared/_FarHorizons/VisualPickupable/PickupableSpeedRelaySystem.cs
@@ -23,10 +23,10 @@ public sealed class PickupableSpeedRelaySystem : EntitySystem
         var walkModifier = 1f;
 
         if (ev.SprintSpeedModifier < 1)
-            sprintModifier = ev.SprintSpeedModifier;
+            sprintModifier = (ev.SprintSpeedModifier + 1) / 2;
 
         if (ev.WalkSpeedModifier < 1)
-            walkModifier = ev.WalkSpeedModifier;
+            walkModifier = (ev.WalkSpeedModifier + 1) / 2;
         
         args.Args.ModifySpeed(walkModifier, sprintModifier);
     }

--- a/Content.Shared/_FarHorizons/VisualPickupable/PickupableSpeedRelaySystem.cs
+++ b/Content.Shared/_FarHorizons/VisualPickupable/PickupableSpeedRelaySystem.cs
@@ -1,0 +1,39 @@
+using Content.Shared.Hands;
+using Content.Shared.Movement.Systems;
+
+namespace Content.Shared._FarHorizons.VisualPickupable;
+
+public sealed class PickupableSpeedRelaySystem : EntitySystem
+{
+    [Dependency] private readonly MovementSpeedModifierSystem _movementSpeedModifier = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<PickupableSpeedRelayComponent, GotEquippedHandEvent>(OnGotPickedUp);
+        SubscribeLocalEvent<PickupableSpeedRelayComponent, GotUnequippedHandEvent>(OnGotDropped);
+        SubscribeLocalEvent<PickupableSpeedRelayComponent, HeldRelayedEvent<RefreshMovementSpeedModifiersEvent>>(OnRelaySpeed);
+    }
+
+    private void OnRelaySpeed(Entity<PickupableSpeedRelayComponent> ent, ref HeldRelayedEvent<RefreshMovementSpeedModifiersEvent> args)
+    {
+        var ev = new RefreshMovementSpeedModifiersEvent();
+        RaiseLocalEvent(ent.Owner, ev);
+
+        var sprintModifier = 1f;
+        var walkModifier = 1f;
+
+        if (ev.SprintSpeedModifier < 1)
+            sprintModifier = ev.SprintSpeedModifier;
+
+        if (ev.WalkSpeedModifier < 1)
+            walkModifier = ev.WalkSpeedModifier;
+        
+        args.Args.ModifySpeed(walkModifier, sprintModifier);
+    }
+
+    private void OnGotPickedUp(Entity<PickupableSpeedRelayComponent> ent, ref GotEquippedHandEvent args) =>
+        _movementSpeedModifier.RefreshMovementSpeedModifiers(args.User);
+    
+    private void OnGotDropped(Entity<PickupableSpeedRelayComponent> ent, ref GotUnequippedHandEvent args) =>
+        _movementSpeedModifier.RefreshMovementSpeedModifiers(args.User);
+}

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/base.yml
@@ -13,6 +13,7 @@
   - type: CanEscapeInventory
     baseResistTime: 2
   - type: VisualPickupable
+  - type: PickupableSpeedRelay
 
 - type: entity
   id: VisualPickupableCloneEntity

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/base.yml
@@ -15,3 +15,4 @@
   - type: VisualPickupable # Far Horizons
     offsetFront: 0.0, -0.15
     offsetBack: 0.0, 0.05
+  - type: PickupableSpeedRelay # Far Horizons


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Makes it so a bird carrying jugsuit doesn't go at mach 10 anymore.

## Why we need to add this
It was a bit too much speed.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/b34cf23c-3be5-4d82-9d58-00574c110aa1



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- tweak: When carrying someone, half of their movement speed penalties will also apply to you (buffs will not)
