### PR TITLE
Allow TTS to play messages longer than the limit, but shorten them to the cap

### DIFF
--- a/Content.Server/_Starlight/TextToSpeech/TTSSystem.cs
+++ b/Content.Server/_Starlight/TextToSpeech/TTSSystem.cs
@@ -118,12 +118,12 @@ public sealed partial class TTSSystem : EntitySystem
         // Far Horizons Start - add logic to shorten the message instead of rejecting when its too long
         if (!_isEnabled)
             return;
+        // Far Horizons End
 
         await Task.Yield();
         try
         {
-            var text = ShortenMessage(CleanText(args.Message));
-        // Far Horizons End
+            var text = ShortenMessage(CleanText(args.Message)); // Far Horizons - shorten the message to the max length
             var filter = Filter.Entities(args.Receivers).RemovePlayers(_ignoredRecipients);
             var voice = GetOrAssignVoice(args.Source);
 
@@ -144,12 +144,12 @@ public sealed partial class TTSSystem : EntitySystem
         // Far Horizons Start - add logic to shorten the message instead of rejecting when its too long
         if (!_isEnabled)
             return;
+        // Far Horizons End
 
         await Task.Yield();
         try
         {
-            var text = ShortenMessage(CleanText(args.Message.Tts ?? args.Message.Text));
-        // Far Horizons End
+            var text = ShortenMessage(CleanText(args.Message.Tts ?? args.Message.Text)); // Far Horizons - shorten the message to the max length
             var filter = args.Receivers.RemovePlayers(_ignoredRecipients);
             var voice = args.SpeakerUid.HasValue
                 ? GetOrAssignVoice(GetEntity(args.SpeakerUid.Value), fallbackVoice: DefaultAnnounceVoice)

--- a/Content.Server/_Starlight/TextToSpeech/TTSSystem.cs
+++ b/Content.Server/_Starlight/TextToSpeech/TTSSystem.cs
@@ -36,16 +36,18 @@ public sealed partial class TTSSystem : EntitySystem
 
     private const int DefaultAnnounceVoice = 2001;
     private const int DefaultVoice = 0;
-    private const int MaxChars = 200;
+    // private const int MaxChars = 200; // Far Horizons - Change to a CVar
     private const float WhisperVoiceVolumeModifier = 0.6f;
     private readonly ISawmill _sawmill = Logger.GetSawmill(nameof(TTSSystem));
     private readonly List<ICommonSession> _ignoredRecipients = [];
 
     private bool _isEnabled;
+    private int _maxChars; // Far Horizons - Add max characters length as a CVar
 
     public override void Initialize()
     {
         _cfg.OnValueChanged(StarlightCCVars.TTSEnabled, v => _isEnabled = v, true);
+        _cfg.OnValueChanged(StarlightCCVars.TTSMaxLengthMessage, v => _maxChars = v, true); // Far Horizons - Add max characters length as a CVar
 
         SubscribeNetworkEvent<PreviewTTSRequestEvent>(OnRequestPreviewTTS);
         SubscribeNetworkEvent<ClientOptionTTSEvent>(OnClientOptionTTS);
@@ -83,11 +85,12 @@ public sealed partial class TTSSystem : EntitySystem
 
     private async void OnRadioReceiveEvent(RadioSpokeEvent args)
     {
-        args.Message.Tts ??= args.Message.Text;
+        // Far Horizons Start - add logic to shorten the message instead of rejecting when its too long
+        args.Message.Tts ??= ShortenMessage(args.Message.Text);
         if (!_isEnabled
-            || args.Message.Tts.Length > MaxChars
             || args.SuppressTTS)
             return;
+        // Far Horizons End
 
         await Task.Yield();
         try
@@ -112,14 +115,15 @@ public sealed partial class TTSSystem : EntitySystem
 
     private async void OnCollectiveMindReceiveEvent(CollectiveMindSpokeEvent args)
     {
-        if (!_isEnabled
-            || args.Message.Length > MaxChars)
+        // Far Horizons Start - add logic to shorten the message instead of rejecting when its too long
+        if (!_isEnabled)
             return;
 
         await Task.Yield();
         try
         {
-            var text = CleanText(args.Message);
+            var text = ShortenMessage(CleanText(args.Message));
+        // Far Horizons End
             var filter = Filter.Entities(args.Receivers).RemovePlayers(_ignoredRecipients);
             var voice = GetOrAssignVoice(args.Source);
 
@@ -137,14 +141,15 @@ public sealed partial class TTSSystem : EntitySystem
 
     private async void OnAnnouncementSpoke(AnnouncementSpokeEvent args)
     {
-        if (!_isEnabled
-            || args.Message.Text.Length > MaxChars * 2)
+        // Far Horizons Start - add logic to shorten the message instead of rejecting when its too long
+        if (!_isEnabled)
             return;
 
         await Task.Yield();
         try
         {
-            var text = CleanText(args.Message.Tts ?? args.Message.Text);
+            var text = ShortenMessage(CleanText(args.Message.Tts ?? args.Message.Text));
+        // Far Horizons End
             var filter = args.Receivers.RemovePlayers(_ignoredRecipients);
             var voice = args.SpeakerUid.HasValue
                 ? GetOrAssignVoice(GetEntity(args.SpeakerUid.Value), fallbackVoice: DefaultAnnounceVoice)
@@ -164,11 +169,12 @@ public sealed partial class TTSSystem : EntitySystem
 
     private async void OnEntitySpoke(EntityUid uid, TextToSpeechComponent component, EntitySpokeEvent args)
     {
-        args.Message.Tts ??= args.Message.Text;
+        // Far Horizons Start - add logic to shorten the message instead of rejecting when its too long
+        args.Message.Tts ??= ShortenMessage(args.Message.Text);
         if (!_isEnabled
-            || args.Message.Tts.Length > MaxChars
             || !args.Language.SpeechOverride.RequireSpeech)
             return;
+        // Far Horizons End
 
         await Task.Yield();
         try
@@ -264,4 +270,8 @@ public sealed partial class TTSSystem : EntitySystem
 
     [GeneratedRegex(@"\[[^\]]*\]")]
     private static partial Regex TagStripperRegex();
+    
+    // Far Horizons-Start shorten all messages for TTS to 50 characters
+    private string ShortenMessage(string text) => text.Substring(0, Math.Min(text.Length, _maxChars));
+    // Far Horizons-End
 }

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.TTS.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.TTS.cs
@@ -11,7 +11,16 @@ public sealed partial class StarlightCCVars
 
     public static readonly CVarDef<string> TTSConnectionString =
         CVarDef.Create("tts.connection_string", "", CVar.SERVERONLY | CVar.CONFIDENTIAL);
-
+    
+    // Far Horizons Start - Create a new CVar to change max length of a message
+    /// <summary>
+    /// This value defines max length of a message to be pronounced by a TTS system,
+    /// messages longer than this will be shortened to this length.
+    /// </summary>
+    public static readonly CVarDef<int> TTSMaxLengthMessage =
+        CVarDef.Create("tts.max_length_message", 50, CVar.ARCHIVE | CVar.SERVER);
+    // Far Horizons End
+    
     /// <summary>
     /// Option to disable TTS events for client
     /// </summary>


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR removes the limitation that the original TTS implementation places on us, namely if a message is longer than 200 characters, it will not be handled. Instead of this we are shortening the message to the limit set by a CVar(Default 50).

## Why we need to add this
Currently the implementation of TTS that we are possibly considering would be alright when shortened messages, since no real message will be pronounced, this limitation serves no use to us.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- tweak: Changed TTS message limitations to allow for longer messages.
