### PR TITLE
fix(Clothing): Allow translators to go into pin slots

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Devices/translators.yml
@@ -33,7 +33,7 @@
     - type: HandheldTranslator
       enabled: false
     - type: Clothing
-      slots: [neck, pin]
+      slots: [neck, pin] # Far Horizons
     - type: Tag
       tags:
       - Pin # FH

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Devices/translators.yml
@@ -33,7 +33,7 @@
     - type: HandheldTranslator
       enabled: false
     - type: Clothing
-      slots: [neck]
+      slots: [neck, pin]
     - type: Tag
       tags:
       - Pin # FH


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR aims to return the option to put a translator into your pin slot.

## Why we need to add this
this was a regression made by this PR
https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/pull/938

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- fix: Fixed translator not fitting in the pin slots.
