### PR TITLE
FIXED HOLOGRAPHIC FIELD GENERATOR SOURCE SIGNALS 

### DIFF
--- a/Content.Server/_FarHorizons/GenericFieldGenerator/EntitySystems/GenericFieldGeneratorSystem.cs
+++ b/Content.Server/_FarHorizons/GenericFieldGenerator/EntitySystems/GenericFieldGeneratorSystem.cs
@@ -178,8 +178,8 @@ public sealed class GenericFieldGeneratorSystem : EntitySystem
     {
         if (TryComp<DeviceLinkSourceComponent>(generator, out _))
         {
-        _signalSystem.SendSignal(generator, generator.Comp.ConnectionStatusPort, false);
-        _signalSystem.InvokePort(generator, generator.Comp.FieldDisconnectedPort);
+            _signalSystem.SendSignal(generator, generator.Comp.ConnectionStatusPort, false);
+            _signalSystem.InvokePort(generator, generator.Comp.FieldDisconnectedPort);
         }
 
         var (uid, component) = generator;
@@ -200,8 +200,8 @@ public sealed class GenericFieldGeneratorSystem : EntitySystem
 
         if (TryComp<DeviceLinkSourceComponent>(value.Item1, out _))
         {
-            _signalSystem.SendSignal(value.Item1, generator.Comp.ConnectionStatusPort, false);
-            _signalSystem.InvokePort(value.Item1, generator.Comp.FieldDisconnectedPort);
+            _signalSystem.SendSignal(value.Item1, value.Item1.Comp.ConnectionStatusPort, false);
+            _signalSystem.InvokePort(value.Item1, value.Item1.Comp.FieldDisconnectedPort);
         }
 
         value.Item1.Comp.IsConnected = false;
@@ -384,8 +384,12 @@ public sealed class GenericFieldGeneratorSystem : EntitySystem
         if (TryComp<DeviceLinkSourceComponent>(firstGen, out _))
         {
             _signalSystem.SendSignal(firstGen, firstGen.Comp.ConnectionStatusPort, true);
-            _signalSystem.SendSignal(secondGen, secondGen.Comp.ConnectionStatusPort, true);
             _signalSystem.InvokePort(firstGen, firstGen.Comp.FieldConnectedPort);
+        }
+
+        if (TryComp<DeviceLinkSourceComponent>(secondGen, out _))
+        {
+            _signalSystem.SendSignal(secondGen, secondGen.Comp.ConnectionStatusPort, true);
             _signalSystem.InvokePort(secondGen, secondGen.Comp.FieldConnectedPort);
         }
 

--- a/Content.Server/_FarHorizons/GenericFieldGenerator/EntitySystems/GenericFieldSystem.cs
+++ b/Content.Server/_FarHorizons/GenericFieldGenerator/EntitySystems/GenericFieldSystem.cs
@@ -47,7 +47,7 @@ public sealed class GenericFieldSystem : EntitySystem
 
     public void TempTileCleanup(Entity<GenericFieldComponent> field)
     {
-        if (field.Comp.TempTile)
+        if (field.Comp.TempTile && !TerminatingOrDeleted(field.Comp.GridUid))
         {
             if (!_tiledef.TryGetDefinition("Space", out var tileDef))
                 return;


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
ITS FIXED NOW I SWEAR
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Source signals broke after I converted the component to not using a dictionary, wasn't invoking ports on correct entity
Fixes crash caused by grid not existing when TempTileCleanup is run
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/eca665d6-20f1-4c43-90f2-b80d3ae0dc48


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: KarusKardin
- fix: I SWEAR THE SIGNALS FOR THE HOLOGRAPHIC GENERATORS ARE FIXED NOW AND WILL NOT CAUSE EXPLOSIONS
- fix: GenericFieldComponent crash caused by grid being deleted when TempTileCleanup is run
