### PR TITLE
Make all subdermal radios silent

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -27,6 +27,7 @@ using Content.Shared.Players;
 using Content.Shared.Players.RateLimiting;
 using Content.Shared.Popups;
 using Content.Shared.Radio;
+using Content.Shared.Radio.Components;
 // Starlight Start
 using Content.Shared.Speech;
 using Content.Shared.Station.Components;
@@ -703,44 +704,51 @@ public sealed partial class ChatSystem : SharedChatSystem
         || (CultureInfo.CurrentCulture.IsNeutralCulture && CultureInfo.CurrentCulture.Name == "en")); // Starlight
 
 
-        foreach (var (session, data) in GetRecipients(source, WhisperMuffledRange))
+        // Far Horizons Start - skip local whisper when using subdermal radio
+        if (channel == null
+            || !TryComp<IntrinsicRadioTransmitterComponent>(source, out var subdermalRadio)
+            || !subdermalRadio.Channels.Contains(channel.ID))
         {
-            if (session.AttachedEntity is not { Valid: true } listener) // Starlight-edit: Languages
-                continue;
-
-            if (MessageRangeCheck(session, data, range) != MessageRangeCheckResult.Full)
-                continue; // Won't get logged to chat, and ghosts are too far away to see the pop-up, so we just won't send it to them.
-
-            // Starlight - Start
-            var canUnderstandLanguage = _language.CanUnderstand(listener, language.ID);
-            // How the entity perceives the message depends on whether it can understand its language
-            var perceivedMessage = canUnderstandLanguage ? message.Text : languageObfuscatedMessage; // Starlight
-            var obfuscated = canUnderstandLanguage != true;
-
-            // Result is the intermediate message derived from the perceived one via obfuscation
-            // Wrapped message is the result wrapped in an "x says y" string
-            string result, wrappedMessage;
-            if (data.Range <= WhisperClearRange || data.Observer)
+            foreach (var (session, data) in GetRecipients(source, WhisperMuffledRange))
             {
-                // Scenario 1: the listener can clearly understand the message
-                result = perceivedMessage;
-                wrappedMessage = WrapWhisperMessage(source, "chat-manager-entity-whisper-wrap-message", name, result, language, obfuscated);
-            }
-            else if (_examineSystem.InRangeUnOccluded(source, listener, WhisperMuffledRange))
-            {
-                // Scenario 2: if the listener is too far, they only hear fragments of the message
-                result = ObfuscateMessageReadability(perceivedMessage);
-                wrappedMessage = WrapWhisperMessage(source, "chat-manager-entity-whisper-wrap-message", nameIdentity, result, language, obfuscated);
-            }
-            else
-            {
-                // Scenario 3: If listener is too far and has no line of sight, they can't identify the whisperer's identity
-                result = ObfuscateMessageReadability(perceivedMessage);
-                wrappedMessage = WrapWhisperMessage(source, "chat-manager-entity-whisper-unknown-wrap-message", string.Empty, result, language, obfuscated);
-            }
+                if (session.AttachedEntity is not { Valid: true } listener) // Starlight-edit: Languages
+                    continue;
 
-            _chatManager.ChatMessageToOne(ChatChannel.Whisper, result, wrappedMessage, source, false, session.Channel);
-            // Starlight - End
+                if (MessageRangeCheck(session, data, range) != MessageRangeCheckResult.Full)
+                    continue; // Won't get logged to chat, and ghosts are too far away to see the pop-up, so we just won't send it to them.
+
+                // Starlight - Start
+                var canUnderstandLanguage = _language.CanUnderstand(listener, language.ID);
+                // How the entity perceives the message depends on whether it can understand its language
+                var perceivedMessage = canUnderstandLanguage ? message.Text : languageObfuscatedMessage; // Starlight
+                var obfuscated = canUnderstandLanguage != true;
+
+                // Result is the intermediate message derived from the perceived one via obfuscation
+                // Wrapped message is the result wrapped in an "x says y" string
+                string result, wrappedMessage;
+                if (data.Range <= WhisperClearRange || data.Observer)
+                {
+                    // Scenario 1: the listener can clearly understand the message
+                    result = perceivedMessage;
+                    wrappedMessage = WrapWhisperMessage(source, "chat-manager-entity-whisper-wrap-message", name, result, language, obfuscated);
+                }
+                else if (_examineSystem.InRangeUnOccluded(source, listener, WhisperMuffledRange))
+                {
+                    // Scenario 2: if the listener is too far, they only hear fragments of the message
+                    result = ObfuscateMessageReadability(perceivedMessage);
+                    wrappedMessage = WrapWhisperMessage(source, "chat-manager-entity-whisper-wrap-message", nameIdentity, result, language, obfuscated);
+                }
+                else
+                {
+                    // Scenario 3: If listener is too far and has no line of sight, they can't identify the whisperer's identity
+                    result = ObfuscateMessageReadability(perceivedMessage);
+                    wrappedMessage = WrapWhisperMessage(source, "chat-manager-entity-whisper-unknown-wrap-message", string.Empty, result, language, obfuscated);
+                }
+
+                _chatManager.ChatMessageToOne(ChatChannel.Whisper, result, wrappedMessage, source, false, session.Channel);
+                // Starlight - End
+            }
+            // Far Horizons End
         }
 
         var replayWrap = WrapWhisperMessage(source, "chat-manager-entity-whisper-wrap-message", name, message.Text, language); // Starlight-edit: Languages


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR aims to make all subdermal radios silent, there is no whisper when speaking on them.

## Why we need to add this
This was brought up as a point when making nexus work as a radio, that it changes its feeling, from speeking through your mind its suddenly just a regular radio, this changes that so the messages are silent.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/2834ca05-3e36-40fe-a874-ff89dfced5a8

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- add: Added silent mode to all subdermal radios, IPC and borg built-in radios.