### PR TITLE
fix species loadouts

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.FarHorizons.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.FarHorizons.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Client.Lobby.UI.Loadouts;
 using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Preferences.Loadouts;
+using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Prototypes;
 
 namespace Content.Client.Lobby.UI;
@@ -62,6 +63,7 @@ public sealed partial class HumanoidProfileEditor
     private void UpdateSpeciesLoadout()
     {
         CSpeciesLoadout.Visible = false;
+        SpeciesLoadout.OnPressed -= SpeciesLoadoutPressed;
 
         if (Profile == null || 
             !_prototypeManager.TryIndex(Profile.Species, out var species) || 
@@ -71,21 +73,29 @@ public sealed partial class HumanoidProfileEditor
         
 
         CSpeciesLoadout.Visible = true;
-        SpeciesLoadout.OnPressed += args =>
+        SpeciesLoadout.OnPressed += SpeciesLoadoutPressed;
+    }
+
+    private void SpeciesLoadoutPressed(BaseButton.ButtonEventArgs args)
+    {
+         if (Profile == null || 
+            !_prototypeManager.TryIndex(Profile.Species, out var species) || 
+            species.Loadout == null ||
+            !_prototypeManager.TryIndex(species.Loadout, out var loadoutProto))
+            return;
+
+        RoleLoadout? loadout = null;
+
+        if (Profile!.SpeciesLoadout == null)
         {
-            RoleLoadout? loadout = null;
+            loadout = Profile.GetSpeciesLoadoutOrDefault(_playerManager.LocalSession, _prototypeManager);
+            loadout!.SetDefault(Profile, _playerManager.LocalSession, _prototypeManager);
+        } else {
+            loadout = Profile.SpeciesLoadout!.Clone();
+            loadout!.SetDefault(Profile, _playerManager.LocalSession, _prototypeManager);
+        }
 
-            if (Profile.SpeciesLoadout == null)
-            {
-                loadout = Profile.GetSpeciesLoadoutOrDefault(_playerManager.LocalSession, _prototypeManager);
-                loadout!.SetDefault(Profile, _playerManager.LocalSession, _prototypeManager);
-            } else {
-                loadout = Profile.SpeciesLoadout!.Clone();
-                loadout!.SetDefault(Profile, _playerManager.LocalSession, _prototypeManager);
-            }
-
-            OpenSpeciesLoadout(species, loadout, loadoutProto);
-        };
+        OpenSpeciesLoadout(species, loadout, loadoutProto);
     }
 
     private void OpenSpeciesLoadout(SpeciesPrototype species, RoleLoadout speciesLoadout, RoleLoadoutPrototype speciesLoadoutProto)


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
A bug that would crash client while running in debug and editing avali after protogen

## Why we need to add this
bugfix

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- fix: Fixed species loadout window breaking when looking at nexus user after looking at protogen or vise versa