### PR TITLE
Remove common radio from radio implants

### DIFF
--- a/Content.Shared/Radio/Components/IntrinsicRadioTransmitterComponent.cs
+++ b/Content.Shared/Radio/Components/IntrinsicRadioTransmitterComponent.cs
@@ -12,5 +12,5 @@ namespace Content.Shared.Radio.Components;
 public sealed partial class IntrinsicRadioTransmitterComponent : Component
 {
     [DataField]
-    public HashSet<ProtoId<RadioChannelPrototype>> Channels = new() { SharedChatSystem.DefaultCommonChannel };
+    public HashSet<ProtoId<RadioChannelPrototype>> Channels = new(); // FH - Remove default common radio, we don't need it really?
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Did you know that implanted radios all gave you common channel additionally to whatever channel they implanted?

now you know, and i am removing that.

## Why we need to add this
This affects changes to how implanted radios work, currently when you are avali or resomi or any proto you will not whisper to speak on common radio.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- fix: Fixed the common radio not requiring you to whisper on avali and resomi.
