### PR TITLE
hotfix ntnc suits/helmets

### DIFF
--- a/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -19,8 +19,8 @@
         - state: off-equipped-HELMET-cyclorite
       head-resomi:
         - state: off-equipped-HELMET-resomi
-      head-felionoid:
-        - state: off-equipped-HELMET-felionoid
+      # head-felionoid:
+      #   - state: off-equipped-HELMET-felionoid
       head-avali:
         - state: off-equipped-HELMET-avali
   - type: ToggleableVisuals  # FH: hardsuit fixes
@@ -35,8 +35,8 @@
         - state: off-equipped-HELMET-cyclorite
       head-resomi:
         - state: off-equipped-HELMET-resomi
-      head-felionoid:
-        - state: off-equipped-HELMET-felionoid
+      # head-felionoid:
+      #   - state: off-equipped-HELMET-felionoid
       head-avali:
         - state: off-equipped-HELMET-avali
   - type: Item

--- a/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -72,7 +72,7 @@
     sprite: _Starlight/Admeme/Clothing/Head/Hardsuits/ntnc_med_hardsuit_helmet.rsi
     clothingVisuals:  # TODO: Requires actual sprites
       head:
-        - state: on-equipped-HELMET
+        - state: off-equipped-HELMET
   - type: ToggleableVisuals  # FH: hardsuit fixes
     clothingVisuals:  # TODO: Requires actual sprites
       head:

--- a/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -73,7 +73,7 @@
   - type: ToggleableVisuals  # FH: hardsuit fixes
     clothingVisuals:  # TODO: Requires actual sprites
       head:
-        - state: off-equipped-HELMET
+        - state: equipped-HELMET
   - type: PointLight
     color: "#addbff"
   - type: Pierceable

--- a/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -70,6 +70,9 @@
     sprite: _Starlight/Admeme/Clothing/Head/Hardsuits/ntnc_med_hardsuit_helmet.rsi
   - type: Clothing
     sprite: _Starlight/Admeme/Clothing/Head/Hardsuits/ntnc_med_hardsuit_helmet.rsi
+    clothingVisuals:  # TODO: Requires actual sprites
+      head:
+        - state: on-equipped-HELMET
   - type: ToggleableVisuals  # FH: hardsuit fixes
     clothingVisuals:  # TODO: Requires actual sprites
       head:

--- a/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -26,19 +26,19 @@
   - type: ToggleableVisuals  # FH: hardsuit fixes
     clothingVisuals:  # TODO: Requires actual sprites
       head:
-        - state: off-equipped-HELMET
+        - state: on-equipped-HELMET
       head-vox:
-        - state: off-equipped-HELMET-vox
+        - state: on-equipped-HELMET-vox
       head-vulpkanin:
-        - state: off-equipped-HELMET-vulpkanin
+        - state: on-equipped-HELMET-vulpkanin
       head-cyclorite:
-        - state: off-equipped-HELMET-cyclorite
+        - state: on-equipped-HELMET-cyclorite
       head-resomi:
-        - state: off-equipped-HELMET-resomi
+        - state: on-equipped-HELMET-resomi
       # head-felionoid:
-      #   - state: off-equipped-HELMET-felionoid
+      #   - state: on-equipped-HELMET-felionoid
       head-avali:
-        - state: off-equipped-HELMET-avali
+        - state: on-equipped-HELMET-avali
   - type: Item
     size: Small
   - type: PointLight
@@ -73,7 +73,7 @@
   - type: ToggleableVisuals  # FH: hardsuit fixes
     clothingVisuals:  # TODO: Requires actual sprites
       head:
-        - state: equipped-HELMET
+        - state: on-equipped-HELMET
   - type: PointLight
     color: "#addbff"
   - type: Pierceable

--- a/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -70,6 +70,10 @@
     sprite: _Starlight/Admeme/Clothing/Head/Hardsuits/ntnc_med_hardsuit_helmet.rsi
   - type: Clothing
     sprite: _Starlight/Admeme/Clothing/Head/Hardsuits/ntnc_med_hardsuit_helmet.rsi
+  - type: ToggleableVisuals  # FH: hardsuit fixes
+    clothingVisuals:  # TODO: Requires actual sprites
+      head:
+        - state: off-equipped-HELMET
   - type: PointLight
     color: "#addbff"
   - type: Pierceable

--- a/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -14,7 +14,7 @@
       head-vox:
         - state: off-equipped-HELMET-vox
       head-vulpkanin:
-        - state: off-equipped-HELMET-vulpkanine
+        - state: off-equipped-HELMET-vulpkanin
       head-cyclorite:
         - state: off-equipped-HELMET-cyclorite
       head-resomi:
@@ -30,7 +30,7 @@
       head-vox:
         - state: off-equipped-HELMET-vox
       head-vulpkanin:
-        - state: off-equipped-HELMET-vulpkanine
+        - state: off-equipped-HELMET-vulpkanin
       head-cyclorite:
         - state: off-equipped-HELMET-cyclorite
       head-resomi:

--- a/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -9,23 +9,23 @@
       sprite: _Starlight/Admeme/Clothing/OuterClothing/Hardsuits/ntnc_hardsuit.rsi
     - type: Clothing
       sprite: _Starlight/Admeme/Clothing/OuterClothing/Hardsuits/ntnc_hardsuit.rsi
-        clothingvisuals:
-          outerClothing:
-            - state: equipped-OUTERCLOTHING
-          outerClothing-cyclorite:
-            - state: equipped-OUTERCLOTHING-cyclorite
-          outerClothing-diona:
-            - state: equipped-OUTERCLOTHING-diona
-          outerClothing-moth:
-            - state: equipped-OUTERCLOTHING-moth
-          outerClothing-reptilian:
-            - state: equipped-OUTERCLOTHING-reptilian
-          outerClothing-resomi:
-            - state: equipped-OUTERCLOTHING-resomi
-          outerClothing-vox:
-            - state: equipped-OUTERCLOTHING-vox
-          outerClothing-vulpkanin:
-            - state: equipped-OUTERCLOTHING-vulpkanin
+      clothingvisuals:
+        outerClothing:
+          - state: equipped-OUTERCLOTHING
+        outerClothing-cyclorite:
+          - state: equipped-OUTERCLOTHING-cyclorite
+        outerClothing-diona:
+          - state: equipped-OUTERCLOTHING-diona
+        outerClothing-moth:
+          - state: equipped-OUTERCLOTHING-moth
+        outerClothing-reptilian:
+          - state: equipped-OUTERCLOTHING-reptilian
+        outerClothing-resomi:
+          - state: equipped-OUTERCLOTHING-resomi
+        outerClothing-vox:
+          - state: equipped-OUTERCLOTHING-vox
+        outerClothing-vulpkanin:
+          - state: equipped-OUTERCLOTHING-vulpkanin
     - type: ToggleableClothing
       clothingPrototype: ClothingHeadHelmetHardsuitNTNCConsortium
     #region FH

--- a/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -9,6 +9,23 @@
       sprite: _Starlight/Admeme/Clothing/OuterClothing/Hardsuits/ntnc_hardsuit.rsi
     - type: Clothing
       sprite: _Starlight/Admeme/Clothing/OuterClothing/Hardsuits/ntnc_hardsuit.rsi
+        clothingvisuals:
+          outerclothing:
+            - state: equipped-OUTERCLOTHING
+          outerclothing-cyclorite:
+            - state: equipped-OUTERCLOTHING-cyclorite
+          outerclothing-diona:
+            - state: equipped-OUTERCLOTHING-diona
+          outerclothing-moth:
+            - state: equipped-OUTERCLOTHING-moth
+          outerclothing-reptilian:
+            - state: equipped-OUTERCLOTHING-reptilian
+          outerclothing-resomi:
+            - state: equipped-OUTERCLOTHING-resomi
+          outerclothing-vox:
+            - state: equipped-OUTERCLOTHING-vox
+          outerclothing-vulpkanin:
+            - state: equipped-OUTERCLOTHING-vulpkanin
     - type: ToggleableClothing
       clothingPrototype: ClothingHeadHelmetHardsuitNTNCConsortium
     #region FH
@@ -29,6 +46,9 @@
       sprite: _Starlight/Admeme/Clothing/OuterClothing/Hardsuits/ntnc_med_hardsuit.rsi
     - type: Clothing
       sprite: _Starlight/Admeme/Clothing/OuterClothing/Hardsuits/ntnc_med_hardsuit.rsi
+      clothingvisuals:
+        outerclothing:
+          - state: equipped-OUTERCLOTHING
     - type: ToggleableClothing
       clothingPrototype: ClothingHeadHelmetHardsuitNTNCConsortiumMedic
     - type: Tag

--- a/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -9,7 +9,7 @@
       sprite: _Starlight/Admeme/Clothing/OuterClothing/Hardsuits/ntnc_hardsuit.rsi
     - type: Clothing
       sprite: _Starlight/Admeme/Clothing/OuterClothing/Hardsuits/ntnc_hardsuit.rsi
-      clothingvisuals:
+      clothingVisuals:
         outerClothing:
           - state: equipped-OUTERCLOTHING
         outerClothing-cyclorite:
@@ -46,7 +46,7 @@
       sprite: _Starlight/Admeme/Clothing/OuterClothing/Hardsuits/ntnc_med_hardsuit.rsi
     - type: Clothing
       sprite: _Starlight/Admeme/Clothing/OuterClothing/Hardsuits/ntnc_med_hardsuit.rsi
-      clothingvisuals:
+      clothingVisuals:
         outerClothing:
           - state: equipped-OUTERCLOTHING
     - type: ToggleableClothing

--- a/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_StarLight/Admeme/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -10,21 +10,21 @@
     - type: Clothing
       sprite: _Starlight/Admeme/Clothing/OuterClothing/Hardsuits/ntnc_hardsuit.rsi
         clothingvisuals:
-          outerclothing:
+          outerClothing:
             - state: equipped-OUTERCLOTHING
-          outerclothing-cyclorite:
+          outerClothing-cyclorite:
             - state: equipped-OUTERCLOTHING-cyclorite
-          outerclothing-diona:
+          outerClothing-diona:
             - state: equipped-OUTERCLOTHING-diona
-          outerclothing-moth:
+          outerClothing-moth:
             - state: equipped-OUTERCLOTHING-moth
-          outerclothing-reptilian:
+          outerClothing-reptilian:
             - state: equipped-OUTERCLOTHING-reptilian
-          outerclothing-resomi:
+          outerClothing-resomi:
             - state: equipped-OUTERCLOTHING-resomi
-          outerclothing-vox:
+          outerClothing-vox:
             - state: equipped-OUTERCLOTHING-vox
-          outerclothing-vulpkanin:
+          outerClothing-vulpkanin:
             - state: equipped-OUTERCLOTHING-vulpkanin
     - type: ToggleableClothing
       clothingPrototype: ClothingHeadHelmetHardsuitNTNCConsortium
@@ -47,7 +47,7 @@
     - type: Clothing
       sprite: _Starlight/Admeme/Clothing/OuterClothing/Hardsuits/ntnc_med_hardsuit.rsi
       clothingvisuals:
-        outerclothing:
+        outerClothing:
           - state: equipped-OUTERCLOTHING
     - type: ToggleableClothing
       clothingPrototype: ClothingHeadHelmetHardsuitNTNCConsortiumMedic


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes a typo for vulp helmets, comments out felinoids as having unique sprites for the normal helmet. Also adds clothingvisuals to the NTNC hardsuit and medic hardsuit

## Why we need to add this
turns out my testing wasn't foolproof. Also curse some upstream for introducing clothingvisuals whilst I was away from doing sprites. Fixed now

## Media (Video/Screenshots)
It takes an hour for my dev environment to load. No chance.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: R3v3l4t1on
- remove: Removed reference to a non-existing felinoid helmet.
- fix: Typo causing vulps to not get a proper helmet.
- fix: All species should now be able to wear the navy's hardsuits without getting error sprites.
