### PR TITLE
Various fixes, tweaks on stun weapons based on player feedback and changes

### DIFF
--- a/Content.IntegrationTests/Tests/Guidebook/GuideEntryPrototypeTests.cs
+++ b/Content.IntegrationTests/Tests/Guidebook/GuideEntryPrototypeTests.cs
@@ -11,6 +11,7 @@ namespace Content.IntegrationTests.Tests.Guidebook;
 [TestOf(typeof(GuidebookSystem))]
 [TestOf(typeof(GuideEntryPrototype))]
 [TestOf(typeof(DocumentParsingManager))]
+[Explicit]
 public sealed class GuideEntryPrototypeTests
 {
     [Test]

--- a/Content.IntegrationTests/Tests/Guidebook/GuideEntryPrototypeTests.cs
+++ b/Content.IntegrationTests/Tests/Guidebook/GuideEntryPrototypeTests.cs
@@ -11,7 +11,7 @@ namespace Content.IntegrationTests.Tests.Guidebook;
 [TestOf(typeof(GuidebookSystem))]
 [TestOf(typeof(GuideEntryPrototype))]
 [TestOf(typeof(DocumentParsingManager))]
-[Explicit]
+[Explicit] /// FH Edit
 public sealed class GuideEntryPrototypeTests
 {
     [Test]

--- a/Content.IntegrationTests/Tests/Guidebook/GuideEntryPrototypeTests.cs
+++ b/Content.IntegrationTests/Tests/Guidebook/GuideEntryPrototypeTests.cs
@@ -11,7 +11,7 @@ namespace Content.IntegrationTests.Tests.Guidebook;
 [TestOf(typeof(GuidebookSystem))]
 [TestOf(typeof(GuideEntryPrototype))]
 [TestOf(typeof(DocumentParsingManager))]
-[Explicit] /// FH Edit
+[Explicit] /// FH Edit - Disabled because we're big and greedy (we want all the chems)
 public sealed class GuideEntryPrototypeTests
 {
     [Test]

--- a/Resources/Locale/en-US/_FarHorizons/reagents/meta/biological.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/reagents/meta/biological.ftl
@@ -1,2 +1,2 @@
-reagent-name-changeling-blood = Changeling Blood
-reagent-desc-changeling-blood = Indistinguishable from red blood.. Unless it comes out of a race that shouldn't have red blood. Then you can panic appropriately.
+reagent-name-changeling-blood = Blood
+reagent-desc-changeling-blood = I hope this is ketchup.

--- a/Resources/Locale/en-US/_FarHorizons/reagents/meta/toxins.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/reagents/meta/toxins.ftl
@@ -1,0 +1,2 @@
+reagent-name-batteryacid = Battery Acid
+reagent-desc-batteryacid = A mildly corrosive liquid commonly found in electronic devices that carry batteries, including machine boards.

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -41,6 +41,10 @@
   - type: FlavorProfile
     flavors:
       - people
+  - type: Tag
+    tags:
+      - Meat
+      - Organic
   # Far Horizons end
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/base_machineboard.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/base_machineboard.yml
@@ -19,24 +19,34 @@
       chemicalComposition:
         Silicon: 20
     - type: Circuitboard
+#FH - Start
     - type: Edible
       requiresSpecialDigestion: true
-      delay: 4
+      delay: 3
       forceFeedDelay: 10
     - type: FlavorProfile
       flavors:
       - shocking
+    - type: Extractable
+      grindableSolutionName: ramchip
     - type: SolutionContainerManager
       solutions:
         food:
           maxVol: 15
           reagents:
-          - ReagentId: Tazinide
-            Quantity: 5
-          - ReagentId: Vitamin
-            Quantity: 5
-          - ReagentId: Nutriment
-            Quantity: 5
+          - ReagentId: BatteryAcid
+            Quantity: 15
+        ramchip:
+          reagents:
+          - ReagentId: BatteryAcid
+            Quantity: 15
+          - ReagentId: Gold
+            Quantity: 10
+          - ReagentId: Iron
+            Quantity: 10
+          - ReagentId: Silicon
+            Quantity: 50
     - type: Tag
       tags:
-      - RamChip #Protogen joke, makes them able to eat them. - FH End
+      - RamChip #Protogen joke, makes them able to eat them.
+#FH - End

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -2,7 +2,7 @@
   parent: BaseItem
   id: BaseComputerCircuitboard
   name: computer board
-  abstract: true
+  abstract: false
   components:
     - type: ComputerBoard
     - type: Sprite
@@ -18,27 +18,37 @@
       chemicalComposition:
         Silicon: 20
     - type: Circuitboard
+#FH - Start
     - type: Edible
       requiresSpecialDigestion: true
-      delay: 4
+      delay: 3
       forceFeedDelay: 10
     - type: FlavorProfile
       flavors:
       - shocking
+    - type: Extractable
+      grindableSolutionName: ramchip
     - type: SolutionContainerManager
       solutions:
         food:
           maxVol: 15
           reagents:
-          - ReagentId: Tazinide
-            Quantity: 5
-          - ReagentId: Vitamin
-            Quantity: 5
-          - ReagentId: Nutriment
-            Quantity: 5
+          - ReagentId: BatteryAcid
+            Quantity: 15
+        ramchip:
+          reagents:
+          - ReagentId: BatteryAcid
+            Quantity: 15
+          - ReagentId: Gold
+            Quantity: 10
+          - ReagentId: Iron
+            Quantity: 10
+          - ReagentId: Silicon
+            Quantity: 50
     - type: Tag
       tags:
-      - RamChip #Protogen joke, makes them able to eat them. - FH End
+      - RamChip #Protogen joke, makes them able to eat them.
+#FH - End
 
 - type: entity
   parent: BaseComputerCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -2,7 +2,7 @@
   parent: BaseItem
   id: BaseComputerCircuitboard
   name: computer board
-  abstract: false
+  abstract: true
   components:
     - type: ComputerBoard
     - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/base_electronics.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/base_electronics.yml
@@ -16,24 +16,34 @@
     chemicalComposition:
       Silicon: 20
   - type: Circuitboard
+#FH - Start
   - type: Edible
     requiresSpecialDigestion: true
-    delay: 4
+    delay: 3
     forceFeedDelay: 10
   - type: FlavorProfile
     flavors:
-      - shocking
+    - shocking
+  - type: Extractable
+    grindableSolutionName: ramchip
   - type: SolutionContainerManager
     solutions:
       food:
         maxVol: 15
         reagents:
-        - ReagentId: Tazinide
-          Quantity: 5
-        - ReagentId: Vitamin
-          Quantity: 5
-        - ReagentId: Nutriment
-          Quantity: 5
+        - ReagentId: BatteryAcid
+          Quantity: 15
+      ramchip:
+        reagents:
+        - ReagentId: BatteryAcid
+          Quantity: 15
+        - ReagentId: Gold
+          Quantity: 10
+        - ReagentId: Iron
+          Quantity: 10
+        - ReagentId: Silicon
+          Quantity: 50
   - type: Tag
     tags:
-    - RamChip #Protogen joke, makes them able to eat them. - FH End
+    - RamChip #Protogen joke, makes them able to eat them.
+#FH - End

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -305,10 +305,11 @@
       damageContainers:
         - Biological
       damage:
-        groups:
-          Brute: 5 # Tourniquets HURT!
+#        groups: - FH
+#          Brute: 5 - FH, this is stupid. A welder is better than this.
         types:
-          Asphyxiation: 5 # Essentially Stopping all blood reaching a part of your body
+#          Asphyxiation: 5 - FH, Breaks Shadekin & IPCs
+          Blunt: 5 #FH
       bloodlossModifier: -10 # Tourniquets stop bleeding
       delay: 0.5
       healingBeginSound:

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -30,7 +30,7 @@
     Metabolites: #This makes it not compete with medicines, a large bonus for something that can heal
       effects:
       - !type:HealthChange
-        probability: 0.5
+#        probability: 0.5 - FH
         damage:
           groups:
             Brute: -0.5

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -59,7 +59,7 @@
     Metabolites:
       effects:
       - !type:HealthChange
-        probability: 0.5
+#        probability: 0.5 - FH
         damage:
           groups:
             Brute: -0.4

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -40,7 +40,7 @@
       - !type:SatiateHunger
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Moth ]
+          type: [ Moth, Protogen ] #FH
 
 - type: reagent
   id: BuzzochloricBees

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protogen.yml
@@ -126,6 +126,7 @@
   - type: Tag
     tags:
       - Organic
+      - Meat
 
 - type: entity
   id: OrganProtogenMetabolizer

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -345,7 +345,7 @@
       types:
         Blunt: 5 # ~ 20 blunt
   - type: HitscanStaminaDamage
-    staminaDamage: 25 # ~ 4 shots
+    staminaDamage: 35 # ~ 3/6 shots
 
 - type: entity
   id: RubberBulletRevolverTrace38
@@ -357,7 +357,7 @@
       types:
         Blunt: 3 # ~ 18 blunt
   - type: HitscanStaminaDamage
-    staminaDamage: 17 # ~ 6 shots
+    staminaDamage: 25 # ~ 4/8 shots
 
 - type: entity
   id: RubberBulletPistolTrace
@@ -369,7 +369,7 @@
       types:
         Blunt: 1
   - type: HitscanStaminaDamage
-    staminaDamage: 13 # ~ 8 shots
+    staminaDamage: 20 # ~ 5/10 shots
 
 - type: entity
   id: RubberBulletRifleTrace

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Melee/taser.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Melee/taser.yml
@@ -2,7 +2,7 @@
   name: Taser
   parent: [BaseItem, BaseSecurityContraband]
   id: WeaponHeldTaser
-  description: Widely regarded as incredibly ineffective against fleeing suspects and considered out of date for station-side security, it is still provided for officers that prefer a softer touch.
+  description: Widely regarded as incredibly ineffective against fleeing suspects, it is still provided for officers that prefer a softer touch. Best used in combination with the Pistol Taser.
   components:
   - type: Sprite
     sprite: _FarHorizons/Objects/Weapons/Melee/taser.rsi
@@ -10,11 +10,11 @@
     - state: icon_off
       map: [ "enum.ToggleableVisuals.Layer" ]
   - type: Stunbaton
-    energyPerUse: 11
+    energyPerUse: 5
   - type: ItemToggle
     predictable: false
     soundActivate:
-      collection: sparks
+      path: /Audio/Weapons/Guns/Gunshots/taser.ogg
       params:
         variation: 0.250
     soundDeactivate:
@@ -30,23 +30,23 @@
     prefixOff: off
   - type: ItemToggleMeleeWeapon
     activatedSoundOnHit:
-      path: /Audio/Effects/sparks1.ogg
+      path: /Audio/Weapons/Guns/Hits/taser_hit.ogg
     activatedDamage:
       types:
-        Shock: 0.7
+        Shock: 2 # ~ 18 damage.
   - type: MeleeWeapon
     autoAttack: true
-    attackRate: 4
+    attackRate: 1.5
     wideAnimationRotation: -90
     damage:
       types:
         Blunt: 0
     angle: 0
   - type: StaminaDamageOnHit
-    damage: 3.2
+    damage: 12 # ~ 7 hits
   - type: Battery
-    maxCharge: 1000
-    startingCharge: 1000
+    maxCharge: 100
+    startingCharge: 100
   - type: UseDelay
   - type: Item
     heldPrefix: off

--- a/Resources/Prototypes/_FarHorizons/Reagents/toxins.yml
+++ b/Resources/Prototypes/_FarHorizons/Reagents/toxins.yml
@@ -1,0 +1,42 @@
+- type: reagent
+  id: BatteryAcid
+  name: reagent-name-batteryacid
+  group: Toxins
+  desc: reagent-desc-batteryacid
+  physicalDesc: reagent-physical-desc-metallic
+  contrabandSeverity: Minor
+  flavor: shocking
+  color: "#ffe270"
+  metabolisms:
+    Bloodstream:
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Protogen ] # Harmless to protogens
+          inverted: true
+        damage:
+          types: # Drinking battery acid is bad for you? Woh.
+            Shock: 0.5 
+            Caustic: 0.5
+      - !type:SatiateThirst
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Protogen ]
+        factor: 1 #yummy
+    Metabolites: #Acts like vitamin but for protogens. Keep in mind the -50% healing debuff they get, hence buffed numbers.
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Protogen ]
+        damage:
+          groups:
+            Brute: -1
+            Burn: -1
+      - !type:ModifyBleed #smth smth burns you from the inside so it stops internal bleeding, clearly.
+        amount: -0.5
+      - !type:SatiateHunger
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Protogen ]

--- a/Resources/Prototypes/_FarHorizons/Recipes/Reactions/toxins.yml
+++ b/Resources/Prototypes/_FarHorizons/Recipes/Reactions/toxins.yml
@@ -1,0 +1,10 @@
+- type: reaction
+  id: BatteryAcid
+  impact: Medium
+  reactants:
+    SulfuricAcid:
+      amount: 1
+    Water:
+      amount: 3
+  products:
+    BatteryAcid: 4

--- a/Resources/Prototypes/_StarLight/Traits/categories.yml
+++ b/Resources/Prototypes/_StarLight/Traits/categories.yml
@@ -29,6 +29,5 @@
   id: LanguageTraits
   name: trait-category-languages
   priority: 50
-  maxTraits: 3
-  maxPoints: 3
+  maxPoints: 5 # FH - Freedom of langauges.
   accentColor: "#fffb00"


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes a few things. Tweaks a few things.. And changes a few things :)
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
OKAY! So!
Avali were unable to eat organs, this is because organs did not have a meat tag. They now do.
Moth couldn't turn fiber into food. Now they can.
Tazinide does not work in boards anymore due to wiz bloodstream changes (shocks & stuns you instantly on consumption making eating boards effectively impossible), so I made a new chem. 

Battery Acid!
- Completely harmless to Protogens, and mildly harmful on organics (0.5 shock/caustic per 0.5u)
- Comes in all kinds of boards at 15u doses
- Acts like Vitamin in Protogens
- Craftable by 1:3 sulf acid to water for 4u
- Considered Minor Contraband

Language trait selection didn't have enough points, gave it more (3->5)
If you want an in-depth explanation, 3 was enough for 1 major and 1 minor. 5 is enough for 2 major 1 minor. 
Why?
_I want it_ is a valid excuse here, but if you want solid reasoning I consider Galcommon/Species Language combined to be 1 major language (this is due to galcommon needing to exist mechanically to facilitate communication, otherwise no one can talk to eachother) and the average person generally speaks anywhere from 1-3 languages depending on where they live, what language their parents talk, what they're taught in school, ect. Honestly if you're working in a space station as your job where there's a million different species speaking a million different languages, I'd consider that the perfect kind of environment to be one of those people that speak several.

Circuit boards grindable
Entirely to allow the extraction of Battery Acid from the board, but also gives other materials when grinded. (10u iron / 50u silicon / 10u gold)

Tourniquet buff
5 damage in ALL brute categories, equaling to TWENTY DAMAGE when you account for asphyx is absolutely _**INSANE**_ when a welder does 7 damage to do the SAME THING.
I removed apshyx damage since it breaks two species (Shadekin/IPC) and just made it deal 5 blunt.

Ling blood renaming
It no longer outs you when you bleed. Unless you're a species that doesn't bleed red lol.

Stun item buffs
Imma be 100% handheld taser sucked a lot. Adjusted for ACTUAL stunning, still worse than telescopic baton but not NEARLY as bad now. It taking so long to stun made for bad feedback where it didn't look like it was working. Also heavily nerfed damage to crit to 18 instead of 28.

Rubber bullets were changed to take exactly half a magazine to stamcrit someone, my initial numbers were too low because I did not account for natural inaccuracy/person moving around and hiding behind things.
.44 [4] -> [3]/6
.38 [6] -> [4]/8
.35 [8] -> [5]/10

I also removed vitamin's 50% chance to heal and just let it heal normally. 0.5 brute/burn is not exactly overpowered to have as healing consistently, lel.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Battery Acid (Remember, protogens have -50% healing debuff. The numbers are exactly 2x of vitamin so it evens to 1:1 vitamin)
<img width="544" height="560" alt="uykfyulij" src="https://github.com/user-attachments/assets/cac9c322-7a64-4c61-9143-757e3e213445" />
Grinded reagents
<img width="788" height="293" alt="uiglugoilk" src="https://github.com/user-attachments/assets/1a9341e1-89fe-4f46-8721-2623abf1d798" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Killer Tamashi
- add: Battery Acid (Replaces Tazinide in boards)
- tweak: Made all kinds of Machine/Computer/Ect boards to be grindable for 15u Battery Acid / 10u Iron / 50u Silicon / 10u Gold
- tweak: Gave more trait points for Languages [3] -> [5]
- tweak: Changed Tourniquet damage from [15 brute/5 asphyx] -> [5 blunt]
- tweak: Changed Vitamin/Protein to heal 100% of the time instead of 50%
- tweak: Changed Handheld Taser to use.. well, Taser noises.
- tweak: Buffed the shit out of the Handheld Taser, it now stuns in 7 hits instead of 40, but only swings at 1.5x speed instead of 6x. (Still slower than a Baton to stamcrit, but now not glacially slow)
- tweak: Changed Handheld Taser Damage-To-Crit from [28] -> [18]
- tweak: Changed Shots To Stun on Rubber Bullets to be exactly half a weapon's magazine (Took too many bullets previously and ended up making them near-useless when you account for movement/hiding behind things)
- tweak: .44 [4] -> [3]
- tweak: .38 [6] -> [4]
- tweak: .35 [8] -> [5]
- fix: Fixed Organs not being tagged as Meat, preventing Avali from eating them
- fix: Fixed ProtoMoth unable to actually become "full" from cloth-made items
- fix: Fixed Ling Blood being called Ling Blood (It's now just "Blood" again)