### PR TITLE
RETURN THE DAMN TOOLS

### DIFF
--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -155,11 +155,11 @@
   extraModuleCount: 3
   moduleWhitelist:
     tags:
-    - BorgModuleTool # Far Horizons - we love our cyborgs actually
     - BorgModuleGeneric
     - BorgModuleMedical
 
   defaultModules:
+  - BorgModuleTool # Far Horizons - we love our cyborgs actually
   - BorgModuleChemical
   - BorgModuleTopicals
 

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -126,6 +126,7 @@
     - BorgModuleJanitor
 
   defaultModules:
+  - BorgModuleTool # Far Horizons - we love our cyborgs actually
   - BorgModuleCleaning
   - BorgModuleCustodial
 
@@ -154,6 +155,7 @@
   extraModuleCount: 3
   moduleWhitelist:
     tags:
+    - BorgModuleTool # Far Horizons - we love our cyborgs actually
     - BorgModuleGeneric
     - BorgModuleMedical
 
@@ -210,6 +212,7 @@
     - BorgModuleService
 
   defaultModules:
+  - BorgModuleTool # Far Horizons - we love our cyborgs actually
   - BorgModuleMusique
   # Starlight start 
   - BorgModuleBartending


### PR DESCRIPTION
For fuck's sake wizden

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Returns basic tools to all the roundstart NT borgs.

## Why we need to add this
Because fuck you wizden, we like our cyborgs around here. Tools are practically necessary for every cyborg, if only to heal their buddies.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: R3v3l4t1on
- add: All borg subtypes get basic tools once again. Cause we love our borgs. Unlike Wizden.
