### PR TITLE
Port SL 3890

### DIFF
--- a/Content.Shared/Silicons/Borgs/Components/BorgChassisComponent.cs
+++ b/Content.Shared/Silicons/Borgs/Components/BorgChassisComponent.cs
@@ -23,6 +23,7 @@ public sealed partial class BorgChassisComponent : Component
     /// <summary>
     /// Is this borg currently activated?
     /// If activated the borg
+    /// - has door access, // Starlight
     /// - can use modules and
     /// - has full movement speed.
     /// To be activated the borg

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.API.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.API.cs
@@ -50,6 +50,7 @@ public abstract partial class SharedBorgSystem
     /// <summary>
     /// Activates or deactivates a borg.
     /// If active the borg
+    /// - has door access, // Starlight
     /// - can use modules and
     /// - has full movement speed.
     /// </summary>
@@ -65,7 +66,7 @@ public abstract partial class SharedBorgSystem
             InstallAllModules(chassis.AsNullable());
         else
             DisableAllModules(chassis.AsNullable());
-
+        _access.SetAccessEnabled(chassis.Owner, active); // Needs a player so that scientists can't drag around an empty borg for free AA. // Starlight
         _powerCell.SetDrawEnabled(chassis.Owner, active);
         _movementSpeedModifier.RefreshMovementSpeedModifiers(chassis);
 

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
@@ -236,7 +236,6 @@ public abstract partial class SharedBorgSystem : EntitySystem
 
         TryActivate(chassis);
 
-        _access.SetAccessEnabled(chassis.Owner, true); // Needs a player so that scientists can't drag around an empty borg for free AA.
         _appearance.SetData(chassis.Owner, BorgVisuals.HasPlayer, true);
     }
 
@@ -250,7 +249,6 @@ public abstract partial class SharedBorgSystem : EntitySystem
         if (TryComp<HandheldLightComponent>(chassis.Owner, out var light))
             _handheldLight.TurnOff((chassis.Owner, light), makeNoise: false); // Already plays a sound when toggling the borg off.
 
-        _access.SetAccessEnabled(chassis.Owner, false); // Needs a player so that scientists can't drag around an empty borg for free AA.
         _appearance.SetData(chassis.Owner, BorgVisuals.HasPlayer, false);
     }
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Reverts wizden 41844

## Why we need to add this
Wizden made it so cyborgs without power retain AA so long as they had a mind. Over on SL we have SELF which can lead to freed borgs which can't be brigged cause always AA. Over here... corrupt asked and I agreed.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: R3v3l4t1on
- remove: Borgs no longer get any access if they lose power.
