### PR TITLE
Fixes and guns

### DIFF
--- a/.github/workflows/fh-test-results.yml
+++ b/.github/workflows/fh-test-results.yml
@@ -1,0 +1,31 @@
+name: Test Results
+
+on:
+  workflow_run:
+    workflows: ["Test"]
+    types:
+      - completed
+permissions: {}
+
+jobs:
+  test-results:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'
+    permissions:
+      checks: write
+      pull-requests: write
+      actions: read
+
+    steps:
+      - uses: dawidd6/action-download-artifact@v19
+        with:
+           run_id: ${{ github.event.workflow_run.id }}
+           path: artifacts
+
+      - uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "**/results.trx"
+          check_name: Integration Tests

--- a/.github/workflows/fh-test.yml
+++ b/.github/workflows/fh-test.yml
@@ -53,11 +53,17 @@ jobs:
       - run: dotnet test --no-build -c DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj --settings .farhorizons/.integrationtests --logger "trx;LogFileName=results.trx"
         env:
           DOTNET_gcServer: "1"
-      - uses: EnricoMi/publish-unit-test-result-action@v2
-        if: (!cancelled())
+      - if: (!cancelled())
+        uses: actions/upload-artifact@v6
         with:
-          files: "**/results.trx"
-          check_name: Integration Tests
+          name: Event File
+          path: ${{ github.event_path }}
+      - if: (!cancelled())
+        uses: actions/upload-artifact@v6
+        with:
+          name: unit-test-results
+          path: "**/results.trx"
+          retention-days: 1
   
   build-release:
     if: "!contains(github.event.pull_request.labels.*.name, 'automated pr') && github.actor != 'github-actions[bot]' && github.event.pull_request.draft == false"

--- a/Content.Client/_FarHorizons/Silicons/IPC/IPCMenu.xaml.cs
+++ b/Content.Client/_FarHorizons/Silicons/IPC/IPCMenu.xaml.cs
@@ -49,7 +49,7 @@ public sealed partial class IPCMenu : FancyWindow
     public string FullText = "";
     public float CharsPerSecond = 150;
 
-    private int _shownCharacters = 0;
+    private int _shownCharacters;
 
     // CCVar.
     private readonly int _maxNameLength;
@@ -58,52 +58,41 @@ public sealed partial class IPCMenu : FancyWindow
 
     private float _bloodLevel;
 
-    private DamageableComponent? _damage = null;
     public DamageableComponent? Damage
     {
-        get => _damage ?? TryGetAssignComp(_entity, Entity, ref _damage);
-        set => _damage = value;
-    }
+        get => field ?? TryGetAssignComp(_entity, Entity, ref field);
+        set;
+    } = null;
 
-    private BlindableComponent? _blind = null;
     public BlindableComponent? Blind
     {
-        get => _blind ?? TryGetAssignComp(_entity, Entity, ref _blind);
-        set => _blind = value;
-    }
+        get => field ?? TryGetAssignComp(_entity, Entity, ref field);
+        set;
+    } = null;
 
-    private MobStateComponent? _state = null;
     public MobStateComponent? State
     {
-        get => _state ?? TryGetAssignComp(_entity, Entity, ref _state);
-        set => _state = value;
-    }
+        get => field ?? TryGetAssignComp(_entity, Entity, ref field);
+        set;
+    } = null;
 
-    private IPCBrainHolderComponent? _brain = null;
     public IPCBrainHolderComponent? Brain
     {
-        get => _brain ?? TryGetAssignComp(_entity, Entity, ref _brain);
-        set => _brain = value;
-    }
-    
-    private IPCThermalRegulationComponent? _thermals = null;
+        get => field ?? TryGetAssignComp(_entity, Entity, ref field);
+        set;
+    } = null;
+
     public IPCThermalRegulationComponent? Thermals
     {
-        get => _thermals ?? TryGetAssignComp(_entity, Entity, ref _thermals);
-        set => _thermals = value;
-    }
+        get => field ?? TryGetAssignComp(_entity, Entity, ref field);
+        set;
+    } = null;
 
-    private IPCBatteryComponent? _battery = null;
     public IPCBatteryComponent? Battery
     {
-        get => _battery ?? TryGetAssignComp(_entity, Entity, ref _battery);
-        set => _battery = value;
-    }
-
-    public bool LastKnownBattery = false;
-    public float LastKnownCharge = 0;
-
-    public MobState LastKnownState = MobState.Dead;
+        get => field ?? TryGetAssignComp(_entity, Entity, ref field);
+        set;
+    } = null;
 
     public IPCMenu()
     {
@@ -183,12 +172,12 @@ public sealed partial class IPCMenu : FancyWindow
         if (Thermals != null)
         {
             temp = Thermals.CurrentTemp;
-            fanMode = Thermals.FansCurrentlyOff || Thermals.CurrentMode == null ? 
-                        Thermals.FansOffDiagnosticsText : 
-                        Thermals.CurrentMode.DiagnosticsText;
-            fansEfficiency = Thermals.FansCurrentlyOff || Thermals.CurrentMode == null ?
-                                Loc.GetString("ipc-ui-console-fans-efficiency-none") :
-                                (Thermals.CurrentEfficiency * 100).ToString("F2") + "%";
+            fanMode = Thermals.FansCurrentlyOff || Thermals.CurrentMode == null
+                ? Thermals.FansOffDiagnosticsText
+                : Thermals.CurrentMode.DiagnosticsText;
+            fansEfficiency = Thermals.FansCurrentlyOff || Thermals.CurrentMode == null
+                ? Loc.GetString("ipc-ui-console-fans-efficiency-none")
+                : (Thermals.CurrentEfficiency * 100).ToString("F2") + "%";
         }
 
         var batteryInserted = false;
@@ -199,7 +188,11 @@ public sealed partial class IPCMenu : FancyWindow
             batteryCharge = _batterySystem.GetChargeLevel((checkedBattery.Owner, checkedBattery.Comp));
         }
 
-        FullText = PrintConsole(LastKnownState.ToString(), batteryInserted, batteryCharge, eyeDamage, _bloodLevel, temp, fanMode, fansEfficiency, Brain, damage);
+        var state = MobState.Dead;
+        if (State != null)
+            state = State.CurrentState;
+
+        FullText = PrintConsole(state.ToString(), batteryInserted, batteryCharge, eyeDamage, _bloodLevel, temp, fanMode, fansEfficiency, Brain, damage);
         UpdateBrainButton(Brain);
         EjectBatteryButton.Disabled = !batteryInserted;
         ChargeBar.Value = batteryCharge;

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -1,3 +1,4 @@
+using Content.Shared._FarHorizons.VisualPickupable;
 using Content.Shared.Armor;
 using Content.Shared.Atmos;
 using Content.Shared.Chat;
@@ -88,6 +89,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, TryDetectItem>(RefRelayInventoryEvent); // Starlight
         SubscribeLocalEvent<InventoryComponent, KnockDownAttemptEvent>(RefRelayInventoryEvent); // Starlight
         SubscribeLocalEvent<InventoryComponent, RadiateHeatAttemptEvent>(RefRelayInventoryEvent); // Starlight
+        SubscribeLocalEvent<InventoryComponent, PickupableArmorSpeedRelayEvent>(RefRelayInventoryEvent); // Far Horizons
 
         // Eye/vision events
         SubscribeLocalEvent<InventoryComponent, CanSeeAttemptEvent>(RelayInventoryEvent);

--- a/Content.Shared/_FarHorizons/VisualPickupable/PickupableSpeedRelayComponent.cs
+++ b/Content.Shared/_FarHorizons/VisualPickupable/PickupableSpeedRelayComponent.cs
@@ -1,4 +1,13 @@
+using Content.Shared.Inventory;
+
 namespace Content.Shared._FarHorizons.VisualPickupable;
 
 [RegisterComponent]
 public sealed partial class PickupableSpeedRelayComponent : Component;
+
+[ByRefEvent]
+public record struct PickupableArmorSpeedRelayEvent(float WalkSpeedModifier, float SprintSpeedModifier)
+    : IInventoryRelayEvent
+{
+    SlotFlags IInventoryRelayEvent.TargetSlots => SlotFlags.OUTERCLOTHING;
+}

--- a/Content.Shared/_FarHorizons/VisualPickupable/PickupableSpeedRelaySystem.cs
+++ b/Content.Shared/_FarHorizons/VisualPickupable/PickupableSpeedRelaySystem.cs
@@ -1,4 +1,6 @@
+using Content.Shared.Clothing;
 using Content.Shared.Hands;
+using Content.Shared.Inventory;
 using Content.Shared.Movement.Systems;
 
 namespace Content.Shared._FarHorizons.VisualPickupable;
@@ -12,15 +14,22 @@ public sealed class PickupableSpeedRelaySystem : EntitySystem
         SubscribeLocalEvent<PickupableSpeedRelayComponent, GotEquippedHandEvent>(OnGotPickedUp);
         SubscribeLocalEvent<PickupableSpeedRelayComponent, GotUnequippedHandEvent>(OnGotDropped);
         SubscribeLocalEvent<PickupableSpeedRelayComponent, HeldRelayedEvent<RefreshMovementSpeedModifiersEvent>>(OnRelaySpeed);
+        SubscribeLocalEvent<ClothingSpeedModifierComponent, InventoryRelayedEvent<PickupableArmorSpeedRelayEvent>>(HandleRelayedSpeed);
+    }
+
+    private void HandleRelayedSpeed(Entity<ClothingSpeedModifierComponent> ent, ref InventoryRelayedEvent<PickupableArmorSpeedRelayEvent> args)
+    {
+        args.Args.WalkSpeedModifier = ent.Comp.WalkModifier;
+        args.Args.SprintSpeedModifier = ent.Comp.SprintModifier;
     }
 
     private void OnRelaySpeed(Entity<PickupableSpeedRelayComponent> ent, ref HeldRelayedEvent<RefreshMovementSpeedModifiersEvent> args)
     {
-        var ev = new RefreshMovementSpeedModifiersEvent();
-        RaiseLocalEvent(ent.Owner, ev);
-
         var sprintModifier = 1f;
         var walkModifier = 1f;
+
+        var ev = new PickupableArmorSpeedRelayEvent(walkModifier, sprintModifier);
+        RaiseLocalEvent(ent.Owner, ref ev);
 
         if (ev.SprintSpeedModifier < 1)
             sprintModifier = (ev.SprintSpeedModifier + 1) / 2;

--- a/Resources/Maps/_FarHorizons/Shuttles/suggestedone9-NT-99-Asteroid-Cracker.yml
+++ b/Resources/Maps/_FarHorizons/Shuttles/suggestedone9-NT-99-Asteroid-Cracker.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 267.3.0
+  engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 12/03/2025 18:32:21
+  time: 03/25/2026 21:49:12
   entityCount: 198
 maps: []
 grids:
@@ -210,6 +210,10 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+    - type: TileHistory
+      chunkHistory: {}
+    - type: NavMap
+    - type: ExplosionAirtightGrid
 - proto: AirCanister
   entities:
   - uid: 100
@@ -232,20 +236,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-3.5
-      parent: 2
-- proto: AirlockGlassShuttle
-  entities:
-  - uid: 66
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-4.5
-      parent: 2
-  - uid: 67
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-3.5
       parent: 2
 - proto: AirlockMiningGlassLocked
   entities:
@@ -779,20 +769,26 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 1.5,-7.5
       parent: 2
-- proto: ComputerRadar
-  entities:
-  - uid: 125
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-1.5
-      parent: 2
 - proto: ComputerShuttle
   entities:
   - uid: 124
     components:
     - type: Transform
       pos: 1.5,-0.5
+      parent: 2
+- proto: FHAirlockGlassShuttle
+  entities:
+  - uid: 66
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 67
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-3.5
       parent: 2
 - proto: GasPassiveVent
   entities:
@@ -985,24 +981,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 24
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: MiningWindowDiagonal
   entities:
   - uid: 3
@@ -1010,23 +1000,17 @@ entities:
     - type: Transform
       pos: -0.5,-0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 4
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 5
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: OreBox
   entities:
   - uid: 120
@@ -1132,6 +1116,22 @@ entities:
       rot: 3.141592653589793 rad
       pos: 8.5,-0.5
       parent: 2
+- proto: ShuttleGunneryConsole
+  entities:
+  - uid: 125
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        68:
+        - - GunneryConsoleTurretControl
+          - Trigger
+        69:
+        - - GunneryConsoleTurretControl
+          - Trigger
 - proto: SignalButton
   entities:
   - uid: 123

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -235,6 +235,9 @@
   - type: HideLayerClothing
     slots:
     - Tail
+  - type: Tag # Far Horizons
+    tags:
+      - IPCExternalCooling # Robots can be ninjas too
 
 - type: entity
   parent: ClothingOuterBase

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -216,21 +216,21 @@
     - SimpleHostile
   - type: Sprite
     drawdepth: SmallMobs
-    sprite: _Starlight/Mobs/Animals/rat.rsi # Starlight
+    sprite: Mobs/Animals/rat.rsi
     layers:
     - map: ["enum.DamageStateVisualLayers.Base", "movement"]
-      state: smallrat #Starlight - They didn't comment this.
+      state: rat
     - map: [ "enum.DamageStateVisualLayers.BaseUnshaded"]
-      state: smallrat_eyes #Starlight - They didn't comment this.
+      state: eyes
       shader: unshaded
 
-  # - type: SpriteMovement // Starlight - Disabled
-  #   movementLayers:
-  #     movement:
-  #       state: rat-moving
-  #   noMovementLayers:
-  #     movement:
-  #       state: rat
+  - type: SpriteMovement
+    movementLayers:
+      movement:
+        state: rat-moving
+    noMovementLayers:
+      movement:
+        state: rat
 
   - type: Physics
     bodyType: KinematicController

--- a/Resources/Textures/_FarHorizons/Shaders/glitching_effect.swsl
+++ b/Resources/Textures/_FarHorizons/Shaders/glitching_effect.swsl
@@ -18,6 +18,11 @@ highp float get_luminance(highp vec3 color) {
 }
 
 void fragment() {
+    if (maxSteps == 0)
+    {
+        return;
+    }
+
     highp vec2 uv = FRAGCOORD.xy * SCREEN_PIXEL_SIZE.xy;
     
     // Glitch / psudo-pixel sorting


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Bunch of fixes and 1 addition.

Reverted rat sprites because (1) they are missing death state and error on death. (2) rat king wasn't using the sprites so style was clashing hard. (3) PR that added them didn't even list them in changelog

## Why we need to add this


## Media (Video/Screenshots)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- add: Gunnery console for mining shuttle. Rock and stone, brothers.
- fix: IPC UI will no longer always proclaim IPC dead (although if you think about it...)
- fix: Ninja suit will now protect IPC from overheating in space
- fix: Reverted broken rat sprites
- fix: You will now only receive movement speed penalty when carrying someone in heavy armor. No more slowdown from a person being hungry or hurt.
