### PR TITLE
IPC passive cooling adjustment

### DIFF
--- a/Content.Server/_FarHorizons/Silicons/IPC/IPCSystem.ThermalRegulation.cs
+++ b/Content.Server/_FarHorizons/Silicons/IPC/IPCSystem.ThermalRegulation.cs
@@ -27,16 +27,11 @@ public sealed partial class IPCSystem
     {
         if (!Resolve(ent, ref ent.Comp2) ||
             ExternalCooling(ent, ent.Comp2) ||
-            _atmos.GetContainingMixture(ent.Owner) is not GasMixture gas)
+            _atmos.GetContainingMixture(ent.Owner) is not { } gas)
             return;
 
-        var passiveHeat = 0f;
-        if (ent.Comp2.CurrentTemperature > gas.Temperature)
-            passiveHeat -= ent.Comp1.RadiateHeat;
-        if (!_state.IsDead(ent))
-            passiveHeat += ent.Comp1.ProduceHeat;
+        RadiateHeat(ent, ent.Comp2, gas.Temperature, _state.IsDead(ent) ? 0 : ent.Comp1.ProduceHeat);
         
-        _tempSys.ChangeHeat(ent, passiveHeat, ignoreHeatResistance: true, ent);
         ent.Comp1.FansCurrentlyOff = FanShutOff(ent, gas);
 
         ent.Comp1.CurrentTemp = ent.Comp2.CurrentTemperature;
@@ -72,6 +67,16 @@ public sealed partial class IPCSystem
         UpdateThermalsAlert(ent);
         Dirty(ent);
         return true;
+    }
+
+    private void RadiateHeat(Entity<IPCThermalRegulationComponent> ent, TemperatureComponent temp, float externalTemp, float produceHeat = 0)
+    {
+        var tempDelta = temp.CurrentTemperature - externalTemp;
+
+        if (tempDelta > 0)
+            _tempSys.ChangeHeat(ent, produceHeat - (tempDelta * ent.Comp.RadiateHeatEfficiency), ignoreHeatResistance: true, temp);
+        else if (produceHeat > 0)
+            _tempSys.ChangeHeat(ent, produceHeat, ignoreHeatResistance: true, temp);
     }
 
     private bool FanShutOff(Entity<IPCThermalRegulationComponent> ent, GasMixture gas) =>

--- a/Content.Shared/_FarHorizons/Silicons/IPC/Components/IPCThermalRegulationComponent.cs
+++ b/Content.Shared/_FarHorizons/Silicons/IPC/Components/IPCThermalRegulationComponent.cs
@@ -39,8 +39,7 @@ public sealed partial class IPCThermalRegulationComponent : Component
     [DataField(required: true)]
     public float ProduceHeat;
 
-    [DataField(required: true)]
-    public float RadiateHeat;
+    [DataField(required: true)] public float RadiateHeatEfficiency;
 
     [DataField(required: true)]
     public float MinEffectivePressure;

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
@@ -355,7 +355,7 @@
         Heat: 2.5 #per second, scales with temperature & other constants
   - type: IPCThermalRegulation
     produceHeat: 2000 # How much heat generated inside the body per second (only when on)
-    radiateHeat: 300 # Passive heat loss, even when dead and/or spaced
+    radiateHeatEfficiency: 2 # Proportional to temperature outside
     minEffectivePressure: 80
     maxEffectivePressure: 200 # Outside of optimal window fans become less effective
     minPressure: 10
@@ -402,6 +402,8 @@
         examineText: ipc-thermals-examine-extreme
         diagnosticsText: ipc-thermals-diagnostics-extreme
         modeAlert: IPCFansSpeedExtreme
+  - type: Flammable
+    firestackFade: -0.8 # Not much to burn + they take way too much damage even from a bit
 
 - type: entity
   parent: BaseMentalAction


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
adjusts how IPCs cool passively and for how long they burn

## Why we need to add this
IPC were ashing from a single inced shot

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/b301b906-d7a9-4ad9-9bb4-75cbf7ff8c91



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- tweak: dead IPC body will now cool down much faster if it reached high temperatures
- tweak: IPCs will burn for less time than organics