### PR TITLE
Removes implied psychic powers from CC items

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
@@ -212,7 +212,7 @@
 - type: entity
   parent: [ClothingNeckBase, BaseCentcommContraband]
   id: ClothingNeckCloakCEDMantle
-  name: Centeral Engineering Division mantle
+  name: Centeral Engineering Division Mantle #FH Typo
   description: A mantle for members of the CED. It comes in its typical green and gold colorscheme. #FH edit
   components:
   - type: Sprite
@@ -224,7 +224,7 @@
   parent: [ClothingNeckBase, BaseCentcommContraband]
   id: ClothingNeckCloakCCponcho
   name: Central Command poncho
-  description: a stylish poncho for a CC offical that prefers field-work to pushing papers.
+  description: A stylish poncho for a CC offical that prefers field-work to pushing papers. #FH Typo
   components:
   - type: Sprite
     sprite:  _Starlight/Clothing/Neck/Cloaks/CC_poncho.rsi
@@ -254,8 +254,8 @@
 
 - type: entity
   parent: [ ClothingNeckBase ]
-  id: ClothingNeckMantleERTLeader
-  name: ERT leader's mantle
+  id: ClothingNeckMantleERTLeader 
+  name: ERT Leader's Mantle #FH Typos
   description: Extraordinary decorative drape over the shoulders.
   components:
   - type: Sprite
@@ -532,8 +532,8 @@
 - type: entity
   parent: [ClothingNeckMantleRD, BaseCentcommContraband]
   id: ClothingNeckCloakCRDMantle
-  name: Central Researching Division Mantle
-  description: Rumors says that this is just an ordinary cloak to easily identify members for CRD. #FH edit
+  name: Central Researching Division Mantle #FH Capitalization
+  description: Rumors say that this is just an ordinary cloak to easily identify members for CRD. #FH edit
   components:
   - type: Sprite
     sprite:  _Starlight/Clothing/Neck/Cloaks/CRD_mantle.rsi

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
@@ -213,7 +213,7 @@
   parent: [ClothingNeckBase, BaseCentcommContraband]
   id: ClothingNeckCloakCEDMantle
   name: Centeral Engineering Division mantle
-  description: A mantle for members of the CED. It comes in its typical green and gold colorscheme.
+  description: A mantle for members of the CED. It comes in its typical green and gold colorscheme. #FH edit
   components:
   - type: Sprite
     sprite:  _Starlight/Clothing/Neck/Cloaks/CED_mantle.rsi
@@ -533,7 +533,7 @@
   parent: [ClothingNeckMantleRD, BaseCentcommContraband]
   id: ClothingNeckCloakCRDMantle
   name: Central Researching Division Mantle
-  description: Rumors says that this is just an ordinary cloak to easily identify members for CRD.
+  description: Rumors says that this is just an ordinary cloak to easily identify members for CRD. #FH edit
   components:
   - type: Sprite
     sprite:  _Starlight/Clothing/Neck/Cloaks/CRD_mantle.rsi

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
@@ -224,7 +224,7 @@
   parent: [ClothingNeckBase, BaseCentcommContraband]
   id: ClothingNeckCloakCCponcho
   name: Central Command poncho
-  description: A stylish poncho for a CC offical that prefers field-work to pushing papers. #FH Typo
+  description: A stylish poncho for a CC Offical that prefers field-work to pushing papers. #FH Typo
   components:
   - type: Sprite
     sprite:  _Starlight/Clothing/Neck/Cloaks/CC_poncho.rsi

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
@@ -224,7 +224,7 @@
   parent: [ClothingNeckBase, BaseCentcommContraband]
   id: ClothingNeckCloakCCponcho
   name: Central Command poncho
-  description: A stylish poncho for a CC Offical that prefers field-work to pushing papers. #FH Typo
+  description: A stylish poncho for a CC Official that prefers field-work to pushing papers. #FH Typo
   components:
   - type: Sprite
     sprite:  _Starlight/Clothing/Neck/Cloaks/CC_poncho.rsi

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
@@ -212,7 +212,7 @@
 - type: entity
   parent: [ClothingNeckBase, BaseCentcommContraband]
   id: ClothingNeckCloakCEDMantle
-  name: Centeral Engineering Division Mantle #FH Typo
+  name: Central Engineering Division Mantle #FH Typo
   description: A mantle for members of the CED. It comes in its typical green and gold colorscheme. #FH edit
   components:
   - type: Sprite

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
@@ -213,7 +213,7 @@
   parent: [ClothingNeckBase, BaseCentcommContraband]
   id: ClothingNeckCloakCEDMantle
   name: Centeral Engineering Division mantle
-  description: Supermatters, Teslas and TEGs all tremble in fear from anyone wearing this mantle.
+  description: A mantle for members of the CED. It comes in its typical green and gold colorscheme.
   components:
   - type: Sprite
     sprite:  _Starlight/Clothing/Neck/Cloaks/CED_mantle.rsi
@@ -533,7 +533,7 @@
   parent: [ClothingNeckMantleRD, BaseCentcommContraband]
   id: ClothingNeckCloakCRDMantle
   name: Central Researching Division Mantle
-  description: Rumors say that anomalies stabilize on their own and artifacts start behaving the moment this mantle shows up in the lab.
+  description: Rumors says that this is just an ordinary cloak to easily identify members for CRD.
   components:
   - type: Sprite
     sprite:  _Starlight/Clothing/Neck/Cloaks/CRD_mantle.rsi


### PR DESCRIPTION
I know its not wizden, thank you.

## Short description
This isn't Starlight. NT is not run by CSOD (demi)gods of Pantheon Subject Optimization (PSO for short). And thus item descriptions should represent such. These particular cloaks are a thorn in my eye since their implementation. Descriptions like this give false impressions to both players and staff alike and further helps with disparity between the two groups. 

I opt to change the description of the cloaks to not imply that anyone in CC has psychic superpowers. You are just a mortal. You are not special. You are not unique. Like the rest of us.

## Why we need to add this
The best way to get somebody immersed in a setting is by having decent item descriptions. Not good. Just decent. The previous item descriptions are a far cry from being great as they imply godhood onto admin characters, an entire OOC thing. 

## Media (Video/Screenshots)
n/A, bro it changes a description

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Irkalla
- remove: Removed things that annoy me personally. In this case some of the amount of self praise we inherited from SL. Point me at more bad flavor messages and descriptions please.
- fix: Fixed implied psychic powers on NT CC cloaks description. No. You aren't CSOD CAD CED CRD CID CBT John ‘Rouge’ Endbringer of the Void” who makes anomalies soil themself by just looking at them.
