### PR TITLE
fix(Hardsuits): Remove rescue pings from hardsuits that shouldnt have it

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1729,6 +1729,8 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSanta
+  - type: SpaceRescuePingSender # Far Horizons
+    hidden: true
 
 - type: entity
   parent: [ ClothingOuterBaseLarge, AllowSuitStorageClothing ]

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -142,6 +142,8 @@
       damageCoefficient: 0.75
     - type: ToggleableClothing
       clothingPrototype: ClothingHeadHelmetHardsuitMercenary
+    - type: SpaceRescuePingSender # Far Horizons
+      hidden: true
 
 #Space Hazard Suit
 - type: entity
@@ -251,6 +253,8 @@
             - PowerCell
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitInfiltration
+  - type: SpaceRescuePingSender # Far Horizons
+    hidden: true
 
 #USSP
 - type: entity
@@ -302,6 +306,8 @@
     - IPCExternalCooling # Far Horizons
   - type: Item
     size: Huge
+  - type: SpaceRescuePingSender # Far Horizons
+    hidden: true
 
 #QM's Luxury Maxim Hardsuit
 - type: entity
@@ -554,6 +560,8 @@
         variation: 0.025
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitNTSF
+  - type: SpaceRescuePingSender # Far Horizons
+    hidden: true
 
 - type: entity
   parent: [ BaseCentcommContraband, ClothingOuterHardsuitBase ]
@@ -603,6 +611,8 @@
         variation: 0.025
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitDecimus
+  - type: SpaceRescuePingSender # Far Horizons
+    hidden: true
 
 #Thanatos (Starlight version of Deathsquad with enhanced stats)
 - type: entity
@@ -646,5 +656,5 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitThanatos
-
-
+  - type: SpaceRescuePingSender # Far Horizons
+    hidden: true


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR removes rescue ping from hardsuits: SSF, Mercenary, Santa, Thantos, Decimus, NTSF, Infiltration hardsuit

## Why we need to add this
It was determined that most of these should not have this ping:
- SSF - it is not a crew aligned hardsuit, it should not inform the crew about itself
- Mercenary - currently only admeme
- Santa - santa should not be easy to find
- Thanatos, Decimus - Deathsquad hardsuit is not pinged, so i have added it as well
- NTSF - they are not located by the crew.
- Infiltration Hardsuit - Antag hardsuit that ironically is for stealth, was not hidden.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/cae4c65c-85a5-489c-8f21-404e993f5d42

https://github.com/user-attachments/assets/8a12f852-9c0f-4cb7-afcb-522ac8c10d12

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- fix: Fixed SSF, Mercenary, Santa, Thantos, Decimus, NTSF, Infiltration hardsuits incorrectly showing on rescue pings. 
