### PR TITLE
Porting 3 things, Fixing some bugs, Improving cyborg lights, Allowing Syndi Cyborgs to use Hailer, etc.

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -767,6 +767,22 @@ namespace Content.Server.GameTicking
             return true;
         }
 
+        // Moffstation - Start - SetCountdown Command
+        public bool SetCountdown(TimeSpan time)
+        {
+            if (_runLevel != GameRunLevel.PreRoundLobby) // must be in preround
+                return false;
+
+            _roundStartTime = _gameTiming.CurTime + time;
+            RaiseNetworkEvent(new TickerLobbyCountdownEvent(_roundStartTime, Paused));
+            _chatManager.DispatchServerAnnouncement(
+                Loc.GetString("game-ticker-set-countdown", ("seconds", time.TotalSeconds))
+            );
+
+            return true;
+        }
+        // Moffstation - End
+
         private void UpdateRoundFlow(float frameTime)
         {
             if (RunLevel == GameRunLevel.InRound)

--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
@@ -151,11 +151,8 @@ public sealed partial class RevenantSystem
         }
 
         // Starlight start
-        if (TryComp(target, out SSDIndicatorComponent? SSDComp) && HasComp<SleepingComponent>(target))
-        {
-            if (SSDComp!.IsSSD)
-                return;
-        }
+        if (TryComp(target, out SSDIndicatorComponent? SSDComp) && HasComp<SleepingComponent>(target) && SSDComp!.IsSSD)
+            return;
         // Starlight end
 
         if (_physics.GetEntitiesIntersectingBody(uid, (int)CollisionGroup.Impassable).Count > 0)

--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
@@ -31,6 +31,7 @@ using Robust.Shared.Utility;
 using Robust.Shared.Map.Components;
 using Content.Shared.Whitelist;
 using Robust.Shared.Prototypes;
+using Content.Shared.SSDIndicator;
 
 namespace Content.Server.Revenant.EntitySystems;
 
@@ -149,7 +150,15 @@ public sealed partial class RevenantSystem
             return;
         }
 
-        if(_physics.GetEntitiesIntersectingBody(uid, (int) CollisionGroup.Impassable).Count > 0)
+        // Starlight start
+        if (TryComp(target, out SSDIndicatorComponent? SSDComp) && HasComp<SleepingComponent>(target))
+        {
+            if (SSDComp!.IsSSD)
+                return;
+        }
+        // Starlight end
+
+        if (_physics.GetEntitiesIntersectingBody(uid, (int)CollisionGroup.Impassable).Count > 0)
         {
             _popup.PopupEntity(Loc.GetString("revenant-in-solid"), uid, uid);
             return;

--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
@@ -31,7 +31,7 @@ using Robust.Shared.Utility;
 using Robust.Shared.Map.Components;
 using Content.Shared.Whitelist;
 using Robust.Shared.Prototypes;
-using Content.Shared.SSDIndicator;
+using Content.Shared.SSDIndicator; // Starlight-edit
 
 namespace Content.Server.Revenant.EntitySystems;
 

--- a/Content.Server/_Moffstation/GameTicking/Commands/SetCountdownCommand.cs
+++ b/Content.Server/_Moffstation/GameTicking/Commands/SetCountdownCommand.cs
@@ -1,0 +1,35 @@
+﻿using Content.Server.Administration;
+using Content.Server.GameTicking;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server._Moffstation.GameTicking.Commands;
+
+[AdminCommand(AdminFlags.Round)]
+public sealed class SetCountdownCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+
+    public override string Command => "setcountdown";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (_gameTicker.RunLevel != GameRunLevel.PreRoundLobby)
+        {
+            shell.WriteLine(Loc.GetString("shell-can-only-run-from-pre-round-lobby"));
+            return;
+        }
+
+        if (!uint.TryParse(args[0], out var seconds) || seconds == 0)
+        {
+            shell.WriteLine(Loc.GetString("cmd-setcountdown-invalid-seconds", ("value", args[0])));
+            return;
+        }
+
+        var time = TimeSpan.FromSeconds(seconds);
+        if (!_gameTicker.SetCountdown(time))
+        {
+            shell.WriteLine(Loc.GetString("cmd-setcountdown-too-late"));
+        }
+    }
+}

--- a/Content.Server/_Starlight/Commands/SSDIndicatorCommand.cs
+++ b/Content.Server/_Starlight/Commands/SSDIndicatorCommand.cs
@@ -45,7 +45,7 @@ public sealed class SSDIndicatorCommand : IConsoleCommand
             return;
         }
 
-        if (indicatorComponent.IsSSD is true)
+        if (indicatorComponent.IsSSD)
         {
             shell.WriteLine(Loc.GetString("ssd-indicator-command-denied"));
             return;

--- a/Content.Server/_Starlight/Commands/SSDIndicatorCommand.cs
+++ b/Content.Server/_Starlight/Commands/SSDIndicatorCommand.cs
@@ -1,0 +1,58 @@
+using Content.Server.GameTicking;
+using Content.Shared.Administration;
+using Content.Shared.GameTicking;
+using Robust.Shared.Console;
+
+namespace Content.Shared.SSDIndicator;
+
+[AnyCommand]
+public sealed class SSDIndicatorCommand : IConsoleCommand
+{
+    [Dependency] private readonly IEntityManager _entities = default!;
+
+    public string Command => "ssd";
+    public string Description => Loc.GetString("ssd-indicator-command-description");
+    public string Help => Loc.GetString("ssd-indicator-command-help-text");
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var player = shell.Player;
+
+        if (player == null)
+        {
+            shell.WriteLine(Loc.GetString("ssd-indicator-command-no-character"));
+            return;
+        }
+
+        var gameTicker = _entities.System<GameTicker>();
+        if (!gameTicker.PlayerGameStatuses.TryGetValue(player.UserId, out var playerStatus) ||
+            playerStatus != PlayerGameStatus.JoinedGame)
+        {
+            shell.WriteLine(Loc.GetString("ssd-indicator-command-no-character"));
+            return;
+        }
+
+        if (player.AttachedEntity is { Valid: true } frozen &&
+            _entities.HasComponent<AdminFrozenComponent>(frozen))
+        {
+            shell.WriteLine(Loc.GetString("ssd-indicator-command-denied"));
+            return;
+        }
+
+        if (!_entities.TryGetComponent(player.AttachedEntity, out SSDIndicatorComponent? indicatorComponent))
+        {
+            shell.WriteLine(Loc.GetString("ssd-indicator-command-no-character"));
+            return;
+        }
+
+        if (indicatorComponent.IsSSD is true)
+        {
+            shell.WriteLine(Loc.GetString("ssd-indicator-command-denied"));
+            return;
+        }
+        if (!_entities.System<SSDIndicatorSystem>().TrySSD((EntityUid)player.AttachedEntity!, indicatorComponent))
+        {
+            shell.WriteLine(Loc.GetString("ssd-indicator-command-denied"));
+        }
+    }
+}

--- a/Content.Server/_Starlight/Commands/SSDIndicatorCommand.cs
+++ b/Content.Server/_Starlight/Commands/SSDIndicatorCommand.cs
@@ -4,7 +4,7 @@ using Content.Shared.GameTicking;
 using Robust.Shared.Console;
 using Content.Shared.Starlight.CryoTeleportation;
 
-namespace Content.Shared.SSDIndicator;
+namespace Content.Shared._Starlight.SSDIndicator;
 
 [AnyCommand]
 public sealed class SSDIndicatorCommand : IConsoleCommand

--- a/Content.Server/_Starlight/Commands/SSDIndicatorCommand.cs
+++ b/Content.Server/_Starlight/Commands/SSDIndicatorCommand.cs
@@ -1,10 +1,11 @@
 using Content.Server.GameTicking;
 using Content.Shared.Administration;
 using Content.Shared.GameTicking;
+using Content.Shared.SSDIndicator;
 using Robust.Shared.Console;
 using Content.Shared.Starlight.CryoTeleportation;
 
-namespace Content.Shared._Starlight.SSDIndicator;
+namespace Content.Shared._Starlight.Commands.SSDIndicator;
 
 [AnyCommand]
 public sealed class SSDIndicatorCommand : IConsoleCommand

--- a/Content.Server/_Starlight/Commands/SSDIndicatorCommand.cs
+++ b/Content.Server/_Starlight/Commands/SSDIndicatorCommand.cs
@@ -2,6 +2,7 @@ using Content.Server.GameTicking;
 using Content.Shared.Administration;
 using Content.Shared.GameTicking;
 using Robust.Shared.Console;
+using Content.Shared.Starlight.CryoTeleportation;
 
 namespace Content.Shared.SSDIndicator;
 
@@ -53,6 +54,10 @@ public sealed class SSDIndicatorCommand : IConsoleCommand
         if (!_entities.System<SSDIndicatorSystem>().TrySSD((EntityUid)player.AttachedEntity!, indicatorComponent))
         {
             shell.WriteLine(Loc.GetString("ssd-indicator-command-denied"));
+            return;
         }
+
+        if (_entities.TryGetComponent(player.AttachedEntity, out TargetCryoTeleportationComponent? cryoTeleport))
+            cryoTeleport.TimeDelay = TimeSpan.FromMinutes(10); // Delay cryo teleportation for 10 minutes.
     }
 }

--- a/Content.Server/_Starlight/CryoTeleportation/CryoTeleportationSystem.cs
+++ b/Content.Server/_Starlight/CryoTeleportation/CryoTeleportationSystem.cs
@@ -65,7 +65,7 @@ public sealed class CryoTeleportationSystem : EntitySystem
                 || HasComp<BorgChassisComponent>(uid)
                 || mobStateComponent.CurrentState != MobState.Alive
                 || comp.ExitTime == null
-                || _timing.CurTime - comp.ExitTime < stationComp.TransferDelay 
+                || _timing.CurTime - comp.ExitTime - comp.TimeDelay < stationComp.TransferDelay 
                 || HasComp<CryostorageContainedComponent>(uid)
                 || HasComp<UncryoableComponent>(uid))
                 continue;

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -20,7 +20,7 @@ using Content.Shared.Slippery;
 using Content.Shared.Sound;
 using Content.Shared.Sound.Components;
 using Content.Shared.Speech;
-using Content.Shared.SSDIndicator;
+using Content.Shared.SSDIndicator; // Starlight-edit
 using Content.Shared.StatusEffectNew;
 using Content.Shared.Stunnable;
 using Content.Shared.Traits.Assorted;

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -351,7 +351,7 @@ public sealed partial class SleepingSystem : EntitySystem
 
         /// Starlight
         /// Ensures that people who are SSD cannot be woken up by others.
-        if (TryComp(ent, out SSDIndicatorComponent? SSDComp))
+        if (TryComp(ent.Owner, out SSDIndicatorComponent? SSDComp))
         {
             if (SSDComp.IsSSD)
                 return false;

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -351,11 +351,8 @@ public sealed partial class SleepingSystem : EntitySystem
 
         /// Starlight
         /// Ensures that people who are SSD cannot be woken up by others.
-        if (TryComp(ent.Owner, out SSDIndicatorComponent? SSDComp))
-        {
-            if (SSDComp.IsSSD)
-                return false;
-        }
+        if (TryComp(ent.Owner, out SSDIndicatorComponent? SSDComp) && SSDComp.IsSSD)
+            return false;
 
         Wake((ent, ent.Comp));
         return true;

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -354,8 +354,7 @@ public sealed partial class SleepingSystem : EntitySystem
         if (TryComp(ent.Owner, out SSDIndicatorComponent? SSDComp) && SSDComp.IsSSD)
             return false;
 
-        Wake((ent, ent.Comp));
-        return true;
+        return RemComp<SleepingComponent>(ent);
     }
 
     /// <summary>

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -20,6 +20,7 @@ using Content.Shared.Slippery;
 using Content.Shared.Sound;
 using Content.Shared.Sound.Components;
 using Content.Shared.Speech;
+using Content.Shared.SSDIndicator;
 using Content.Shared.StatusEffectNew;
 using Content.Shared.Stunnable;
 using Content.Shared.Traits.Assorted;
@@ -348,7 +349,16 @@ public sealed partial class SleepingSystem : EntitySystem
             _popupSystem.PopupClient(Loc.GetString("wake-other-success", ("target", Identity.Entity(ent, EntityManager))), ent, user);
         }
 
-        return RemComp<SleepingComponent>(ent);
+        /// Starlight
+        /// Ensures that people who are SSD cannot be woken up by others.
+        if (TryComp(ent, out SSDIndicatorComponent? SSDComp))
+        {
+            if (SSDComp.IsSSD)
+                return false;
+        }
+
+        Wake((ent, ent.Comp));
+        return true;
     }
 
     /// <summary>

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -131,10 +131,11 @@ public sealed class SSDIndicatorSystem : EntitySystem
     /// <returns>True if succesful</returns>
     public bool TryRemoveSSD(EntityUid uid, SSDIndicatorComponent? comp)
     {
-        bool success = false;
-
         if (comp == null)
-            return success;
+            return false;
+
+        if (!comp.IsSSD)
+            return false;
 
         comp.IsSSD = false;
 
@@ -142,11 +143,10 @@ public sealed class SSDIndicatorSystem : EntitySystem
         {
             comp.FallAsleepTime = TimeSpan.Zero;
             _statusEffects.TryRemoveStatusEffect(uid, StatusEffectSSDSleeping);
-            success = true;
         }
 
         Dirty(uid, comp);
-        return success;
+        return true;
     }
     
     #endregion

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -105,23 +105,21 @@ public sealed class SSDIndicatorSystem : EntitySystem
     /// <returns>True if succesful</returns>
     public bool TrySSD(EntityUid uid, SSDIndicatorComponent? comp)
     {
-        bool success = false;
-
         if (comp == null)
-            return success;
+            return false;
+
+        if (comp.IsSSD)
+            return false;
 
         comp.IsSSD = true;
 
-        // Sets the time when the entity should fall asleep
         if (_icSsdSleep)
-        {
             comp.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
-            success = true;
-        }
 
         _sleep.TrySleeping(uid);
+
         Dirty(uid, comp);
-        return success;
+        return true;
     }
 
     /// <summary>

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -36,26 +36,14 @@ public sealed class SSDIndicatorSystem : EntitySystem
         _cfg.OnValueChanged(CCVars.ICSSDSleepTime, obj => _icSsdSleepTime = obj, true);
     }
 
-    private void OnPlayerAttached(EntityUid uid, SSDIndicatorComponent component, PlayerAttachedEvent args)
-    {
-        TryRemoveSSD(uid, component); // Starlight
-    }
-
-    private void OnPlayerDetached(EntityUid uid, SSDIndicatorComponent component, PlayerDetachedEvent args)
-    {
-        TrySSD(uid, component); // Starlight
-    }
-
     // Starlight start
-    private void OnMoveInput(EntityUid uid, SSDIndicatorComponent comp, MoveInputEvent args)
-    {
-        TryRemoveSSD(uid, comp);
-    }
+    private void OnPlayerAttached(EntityUid uid, SSDIndicatorComponent component, PlayerAttachedEvent args) => TryRemoveSSD(uid, component);
 
-    private void OnWakeAction(EntityUid uid, SSDIndicatorComponent comp, WakeActionEvent args)
-    {
-        TryRemoveSSD(uid, comp);
-    }
+    private void OnPlayerDetached(EntityUid uid, SSDIndicatorComponent component, PlayerDetachedEvent args) => TrySSD(uid, component);
+
+    private void OnMoveInput(EntityUid uid, SSDIndicatorComponent comp, MoveInputEvent args) => TryRemoveSSD(uid, comp);
+
+    private void OnWakeAction(EntityUid uid, SSDIndicatorComponent comp, WakeActionEvent args) => TryRemoveSSD(uid, comp);
     // Starlight end (for now :P)
 
     // Prevents mapped mobs to go to sleep immediately
@@ -94,7 +82,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
         }
     }
 
-     #region Starlight
+    #region Starlight
 
     /// <summary>
     /// STARLIGHT

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -1,6 +1,6 @@
-using Content.Shared.Bed.Sleep;
+using Content.Shared.Bed.Sleep; // Starlight-edit
 using Content.Shared.CCVar;
-using Content.Shared.Movement.Events;
+using Content.Shared.Movement.Events; // Starlight-edit
 using Content.Shared.StatusEffectNew;
 using Robust.Shared.Configuration;
 using Robust.Shared.Player;
@@ -94,6 +94,8 @@ public sealed class SSDIndicatorSystem : EntitySystem
         }
     }
 
+     #region Starlight
+
     /// <summary>
     /// STARLIGHT
     /// Attempts to set the entity as SSD.
@@ -148,4 +150,6 @@ public sealed class SSDIndicatorSystem : EntitySystem
         Dirty(uid, comp);
         return success;
     }
+    
+    #endregion
 }

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -1,4 +1,6 @@
+using Content.Shared.Bed.Sleep;
 using Content.Shared.CCVar;
+using Content.Shared.Movement.Events;
 using Content.Shared.StatusEffectNew;
 using Robust.Shared.Configuration;
 using Robust.Shared.Player;
@@ -17,6 +19,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
+    [Dependency] private readonly SleepingSystem _sleep = default!; // Starlight
 
     private bool _icSsdSleep;
     private float _icSsdSleepTime;
@@ -26,6 +29,8 @@ public sealed class SSDIndicatorSystem : EntitySystem
         SubscribeLocalEvent<SSDIndicatorComponent, PlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<SSDIndicatorComponent, PlayerDetachedEvent>(OnPlayerDetached);
         SubscribeLocalEvent<SSDIndicatorComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<SSDIndicatorComponent, MoveInputEvent>(OnMoveInput); // Starlight
+        SubscribeLocalEvent<SSDIndicatorComponent, WakeActionEvent>(OnWakeAction); // Starlight
 
         _cfg.OnValueChanged(CCVars.ICSSDSleep, obj => _icSsdSleep = obj, true);
         _cfg.OnValueChanged(CCVars.ICSSDSleepTime, obj => _icSsdSleepTime = obj, true);
@@ -33,30 +38,25 @@ public sealed class SSDIndicatorSystem : EntitySystem
 
     private void OnPlayerAttached(EntityUid uid, SSDIndicatorComponent component, PlayerAttachedEvent args)
     {
-        component.IsSSD = false;
-
-        // Removes force sleep and resets the time to zero
-        if (_icSsdSleep)
-        {
-            component.FallAsleepTime = TimeSpan.Zero;
-            _statusEffects.TryRemoveStatusEffect(uid, StatusEffectSSDSleeping);
-        }
-
-        Dirty(uid, component);
+        TryRemoveSSD(uid, component); // Starlight
     }
 
     private void OnPlayerDetached(EntityUid uid, SSDIndicatorComponent component, PlayerDetachedEvent args)
     {
-        component.IsSSD = true;
-
-        // Sets the time when the entity should fall asleep
-        if (_icSsdSleep)
-        {
-            component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
-        }
-
-        Dirty(uid, component);
+        TrySSD(uid, component); // Starlight
     }
+
+    // Starlight start
+    private void OnMoveInput(EntityUid uid, SSDIndicatorComponent comp, MoveInputEvent args)
+    {
+        TryRemoveSSD(uid, comp);
+    }
+
+    private void OnWakeAction(EntityUid uid, SSDIndicatorComponent comp, WakeActionEvent args)
+    {
+        TryRemoveSSD(uid, comp);
+    }
+    // Starlight end (for now :P)
 
     // Prevents mapped mobs to go to sleep immediately
     private void OnMapInit(EntityUid uid, SSDIndicatorComponent component, MapInitEvent args)
@@ -92,5 +92,60 @@ public sealed class SSDIndicatorSystem : EntitySystem
             ssd.NextUpdate += ssd.UpdateInterval;
             Dirty(uid, ssd);
         }
+    }
+
+    /// <summary>
+    /// STARLIGHT
+    /// Attempts to set the entity as SSD.
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <param name="comp"></param>
+    /// <returns>True if succesful</returns>
+    public bool TrySSD(EntityUid uid, SSDIndicatorComponent? comp)
+    {
+        bool success = false;
+
+        if (comp == null)
+            return success;
+
+        comp.IsSSD = true;
+
+        // Sets the time when the entity should fall asleep
+        if (_icSsdSleep)
+        {
+            comp.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
+            success = true;
+        }
+
+        _sleep.TrySleeping(uid);
+        Dirty(uid, comp);
+        return success;
+    }
+
+    /// <summary>
+    /// STARLIGHT
+    /// Attempts to remove the SSD condition from the entity.
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <param name="comp"></param>
+    /// <returns>True if succesful</returns>
+    public bool TryRemoveSSD(EntityUid uid, SSDIndicatorComponent? comp)
+    {
+        bool success = false;
+
+        if (comp == null)
+            return success;
+
+        comp.IsSSD = false;
+
+        if (_icSsdSleep)
+        {
+            comp.FallAsleepTime = TimeSpan.Zero;
+            _statusEffects.TryRemoveStatusEffect(uid, StatusEffectSSDSleeping);
+            success = true;
+        }
+
+        Dirty(uid, comp);
+        return success;
     }
 }

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -96,8 +96,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
     /// <summary>
     /// Attempts to set the entity as SSD.
     /// </summary>
-    /// <param name="uid"></param>
-    /// <param name="comp"></param>
+    /// <param name="force">bypasses doAfter.</param>
     /// <returns>True if succesful</returns>
     public bool TrySSD(EntityUid uid, SSDIndicatorComponent? comp, bool force = false)
     {
@@ -135,8 +134,6 @@ public sealed class SSDIndicatorSystem : EntitySystem
     /// <summary>
     /// Attempts to remove the SSD condition from the entity.
     /// </summary>
-    /// <param name="uid"></param>
-    /// <param name="comp"></param>
     /// <returns>True if succesful</returns>
     public bool TryRemoveSSD(EntityUid uid, SSDIndicatorComponent? comp)
     {

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Bed.Sleep;
 using Content.Shared._Starlight.SSDIndicator.Events;
 using Content.Shared.DoAfter;
 using Content.Shared.Movement.Events;
+using Content.Shared.Starlight.CryoTeleportation;
 // Starlight-end
 
 namespace Content.Shared.SSDIndicator;
@@ -149,6 +150,9 @@ public sealed class SSDIndicatorSystem : EntitySystem
             comp.FallAsleepTime = TimeSpan.Zero;
             _statusEffects.TryRemoveStatusEffect(uid, StatusEffectSSDSleeping);
         }
+
+        if (TryComp<TargetCryoTeleportationComponent>(uid, out var cryoTeleport) && cryoTeleport.TimeDelay > TimeSpan.FromSeconds(0))
+            cryoTeleport.TimeDelay = TimeSpan.FromSeconds(0); // Reset time delay to 0.
 
         Dirty(uid, comp);
         return true;

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -102,7 +102,8 @@ public sealed class SSDIndicatorSystem : EntitySystem
     public bool TrySSD(EntityUid uid, SSDIndicatorComponent? comp, bool force = false)
     {
         if (comp == null 
-            || comp.IsSSD)
+            || comp.IsSSD 
+            || TerminatingOrDeleted(uid))
             return false;
 
         if (!force)
@@ -140,7 +141,8 @@ public sealed class SSDIndicatorSystem : EntitySystem
     public bool TryRemoveSSD(EntityUid uid, SSDIndicatorComponent? comp)
     {
         if (comp == null 
-            || !comp.IsSSD)
+            || !comp.IsSSD 
+            || TerminatingOrDeleted(uid))
             return false;
 
         comp.IsSSD = false;

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -101,7 +101,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
     /// <returns>True if succesful</returns>
     public bool TrySSD(EntityUid uid, SSDIndicatorComponent? comp, bool force = false)
     {
-        if (comp == null 
+        if (!Resolve(uid, ref comp) 
             || comp.IsSSD 
             || TerminatingOrDeleted(uid))
             return false;
@@ -138,7 +138,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
     /// <returns>True if succesful</returns>
     public bool TryRemoveSSD(EntityUid uid, SSDIndicatorComponent? comp)
     {
-        if (comp == null 
+        if (!Resolve(uid, ref comp)
             || !comp.IsSSD 
             || TerminatingOrDeleted(uid))
             return false;

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -93,10 +93,8 @@ public sealed class SSDIndicatorSystem : EntitySystem
     /// <returns>True if succesful</returns>
     public bool TrySSD(EntityUid uid, SSDIndicatorComponent? comp)
     {
-        if (comp == null)
-            return false;
-
-        if (comp.IsSSD)
+        if (comp == null 
+            || comp.IsSSD)
             return false;
 
         comp.IsSSD = true;
@@ -119,10 +117,8 @@ public sealed class SSDIndicatorSystem : EntitySystem
     /// <returns>True if succesful</returns>
     public bool TryRemoveSSD(EntityUid uid, SSDIndicatorComponent? comp)
     {
-        if (comp == null)
-            return false;
-
-        if (!comp.IsSSD)
+        if (comp == null 
+            || !comp.IsSSD)
             return false;
 
         comp.IsSSD = false;

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -1,11 +1,16 @@
-using Content.Shared.Bed.Sleep; // Starlight-edit
 using Content.Shared.CCVar;
-using Content.Shared.Movement.Events; // Starlight-edit
 using Content.Shared.StatusEffectNew;
 using Robust.Shared.Configuration;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+
+// Starlight-start
+using Content.Shared.Bed.Sleep;
+using Content.Shared._Starlight.SSDIndicator.Events;
+using Content.Shared.DoAfter;
+using Content.Shared.Movement.Events;
+// Starlight-end
 
 namespace Content.Shared.SSDIndicator;
 
@@ -20,6 +25,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
     [Dependency] private readonly SleepingSystem _sleep = default!; // Starlight
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!; // Starlight
 
     private bool _icSsdSleep;
     private float _icSsdSleepTime;
@@ -31,6 +37,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
         SubscribeLocalEvent<SSDIndicatorComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<SSDIndicatorComponent, MoveInputEvent>(OnMoveInput); // Starlight
         SubscribeLocalEvent<SSDIndicatorComponent, WakeActionEvent>(OnWakeAction); // Starlight
+        SubscribeLocalEvent<SSDIndicatorComponent, SSDTryDoAfterEvent>(OnSSDTry); // Starlight
 
         _cfg.OnValueChanged(CCVars.ICSSDSleep, obj => _icSsdSleep = obj, true);
         _cfg.OnValueChanged(CCVars.ICSSDSleepTime, obj => _icSsdSleepTime = obj, true);
@@ -39,7 +46,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
     // Starlight start
     private void OnPlayerAttached(EntityUid uid, SSDIndicatorComponent component, PlayerAttachedEvent args) => TryRemoveSSD(uid, component);
 
-    private void OnPlayerDetached(EntityUid uid, SSDIndicatorComponent component, PlayerDetachedEvent args) => TrySSD(uid, component);
+    private void OnPlayerDetached(EntityUid uid, SSDIndicatorComponent component, PlayerDetachedEvent args) => TrySSD(uid, component, force: true);
 
     private void OnMoveInput(EntityUid uid, SSDIndicatorComponent comp, MoveInputEvent args) => TryRemoveSSD(uid, comp);
 
@@ -84,32 +91,47 @@ public sealed class SSDIndicatorSystem : EntitySystem
 
     #region Starlight
 
+    private void OnSSDTry(EntityUid uid, SSDIndicatorComponent component, SSDTryDoAfterEvent args) => SSD(uid, component);
+
     /// <summary>
-    /// STARLIGHT
     /// Attempts to set the entity as SSD.
     /// </summary>
     /// <param name="uid"></param>
     /// <param name="comp"></param>
     /// <returns>True if succesful</returns>
-    public bool TrySSD(EntityUid uid, SSDIndicatorComponent? comp)
+    public bool TrySSD(EntityUid uid, SSDIndicatorComponent? comp, bool force = false)
     {
         if (comp == null 
             || comp.IsSSD)
             return false;
 
-        comp.IsSSD = true;
+        if (!force)
+        {
+            var doAfter = new DoAfterArgs(EntityManager, uid, TimeSpan.FromSeconds(10), new SSDTryDoAfterEvent(), uid)
+            {
+                BreakOnMove = true,
+            };
+            _doAfter.TryStartDoAfter(doAfter);
+        }
+        else
+            SSD(uid, comp);
 
-        if (_icSsdSleep)
-            comp.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
-
-        _sleep.TrySleeping(uid);
-
-        Dirty(uid, comp);
         return true;
     }
 
+    private void SSD(EntityUid uid, SSDIndicatorComponent component)
+    {
+        component.IsSSD = true;
+
+        if (_icSsdSleep)
+            component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
+
+        _sleep.TrySleeping(uid);
+
+        Dirty(uid, component);
+    }
+
     /// <summary>
-    /// STARLIGHT
     /// Attempts to remove the SSD condition from the entity.
     /// </summary>
     /// <param name="uid"></param>

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -25,7 +25,6 @@ public sealed class SSDIndicatorSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
-    [Dependency] private readonly SleepingSystem _sleep = default!; // Starlight
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!; // Starlight
 
     private bool _icSsdSleep;
@@ -126,7 +125,6 @@ public sealed class SSDIndicatorSystem : EntitySystem
 
         if (_icSsdSleep)
             component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
-
 
         Dirty(uid, component);
     }

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -127,7 +127,6 @@ public sealed class SSDIndicatorSystem : EntitySystem
         if (_icSsdSleep)
             component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
 
-        _sleep.TrySleeping(uid);
 
         Dirty(uid, component);
     }

--- a/Content.Shared/_Starlight/CryoTeleportation/TargetCryoTeleportationComponent.cs
+++ b/Content.Shared/_Starlight/CryoTeleportation/TargetCryoTeleportationComponent.cs
@@ -5,12 +5,24 @@ namespace Content.Shared.Starlight.CryoTeleportation;
 [RegisterComponent]
 public sealed partial class TargetCryoTeleportationComponent : Component
 {
+    /// <summary>
+    /// Station uid where entity will be cryo teleported.
+    /// </summary>
     [DataField]
     public EntityUid? Station;
 
+    /// <summary>
+    /// Time when player detached from entity.
+    /// </summary>
     [DataField]
     public TimeSpan? ExitTime;
     
     [DataField]
     public NetUserId? UserId;
+
+    /// <summary>
+    /// Determines how much extra time we need to wait for cryo teleportation.
+    /// </summary>
+    [DataField]
+    public TimeSpan TimeDelay = TimeSpan.FromSeconds(0);
 }

--- a/Content.Shared/_Starlight/SSDIndicator/Events/SSDTryDoAfterEvent.cs
+++ b/Content.Shared/_Starlight/SSDIndicator/Events/SSDTryDoAfterEvent.cs
@@ -1,0 +1,9 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Starlight.SSDIndicator.Events;
+
+[Serializable, NetSerializable]
+public sealed partial class SSDTryDoAfterEvent : SimpleDoAfterEvent
+{
+}

--- a/Resources/Locale/en-US/_FarHorizons/robotics/borg_modules.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/robotics/borg_modules.ftl
@@ -1,3 +1,6 @@
-borg-slot-handcuffs-empty = Handcuffs
+borg-slot-handcuffs-empty = Empty Handcuffs
 
-borg-slot-cleanergrenade-empty = Cleannade
+borg-slot-cleanergrenade-empty = Empty Cleannade
+
+borg-slot-mouth-swab-box-empty = Empty Mouth Swab Box
+borg-slot-mouth-swab-empty = Empty Mouth Swab

--- a/Resources/Locale/en-US/_Moffstation/collective-mind/collective-mind.ftl
+++ b/Resources/Locale/en-US/_Moffstation/collective-mind/collective-mind.ftl
@@ -1,0 +1,1 @@
+collective-mind-xeno = Xeno

--- a/Resources/Locale/en-US/_Moffstation/commands/setcountdown-command.ftl
+++ b/Resources/Locale/en-US/_Moffstation/commands/setcountdown-command.ftl
@@ -1,0 +1,3 @@
+cmd-setcountdown-desc = Sets the countdown until the next round starts to the given value in seconds.
+cmd-setcountdown-too-late = Countdown could not be set in time!
+cmd-setcountdown-invalid-seconds = Given value "{$value}" isn't a valid number of seconds. Value must be a positive integer.

--- a/Resources/Locale/en-US/_Moffstation/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/_Moffstation/game-ticking/game-ticker.ftl
@@ -1,0 +1,1 @@
+game-ticker-set-countdown = Round will begin in {$seconds} seconds.

--- a/Resources/Locale/en-US/_Starlight/chat/commands/ssd-indicator-command.ftl
+++ b/Resources/Locale/en-US/_Starlight/chat/commands/ssd-indicator-command.ftl
@@ -1,0 +1,5 @@
+ssd-indicator-command-description = Mark yourself as SSD.
+ssd-indicator-command-help-text = The SSD command triggers the SSD indicator without needing to close the game.
+                                  Please note that being in this state will automatically cryo your character after some time, removing you from the game.
+ssd-indicator-command-denied = You cannot SSD right now.
+ssd-indicator-command-no-character = You cannot SSD without being actively in control of a character.

--- a/Resources/Prototypes/Body/Species/slime.yml
+++ b/Resources/Prototypes/Body/Species/slime.yml
@@ -171,6 +171,7 @@
     groups:
       Flammable: [ Touch ]
       Extinguish: [ Touch ]
+      Acidic: [Touch, Ingestion] #Far Horizons
     reactions:
     - reagents: [ Water, SpaceCleaner ]
       methods: [ Touch ]

--- a/Resources/Prototypes/Entities/Markers/Spawners/Mobs/xenos.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Mobs/xenos.yml
@@ -2,7 +2,7 @@
   parent: MarkerBase
   id: SpawnMobXenoBurrower
   name: Xeno Spawner
-  suffix: Burrower
+  suffix: Burrower, XenoAlien #Far Horizons
   components:
   - type: Sprite
     layers:
@@ -18,7 +18,7 @@
   parent: MarkerBase
   id: SpawnMobXenoDrone
   name: Xeno Spawner
-  suffix: Drone
+  suffix: Drone, XenoAlien #Far Horizons
   components:
   - type: Sprite
     layers:
@@ -34,7 +34,7 @@
   parent: MarkerBase
   id: SpawnMobXenoPraetorian
   name: Xeno Spawner
-  suffix: Praetorian
+  suffix: Praetorian, XenoAlien #Far Horizons
   components:
   - type: Sprite
     layers:
@@ -50,7 +50,7 @@
   parent: MarkerBase
   id: SpawnMobXenoQueen
   name: Xeno Spawner
-  suffix: Queen
+  suffix: Queen, XenoAlien #Far Horizons
   components:
   - type: Sprite
     layers:
@@ -66,7 +66,7 @@
   parent: MarkerBase
   id: SpawnMobXenoRavager
   name: Xeno Spawner
-  suffix: Ravager
+  suffix: Ravager, XenoAlien #Far Horizons
   components:
   - type: Sprite
     layers:
@@ -82,7 +82,7 @@
   parent: MarkerBase
   id: SpawnMobXenoRunner
   name: Xeno Spawner
-  suffix: Runner
+  suffix: Runner, XenoAlien #Far Horizons
   components:
   - type: Sprite
     layers:
@@ -98,7 +98,7 @@
   parent: MarkerBase
   id: SpawnMobXenoSpitter
   name: Xeno Spawner
-  suffix: Spitter
+  suffix: Spitter, XenoAlien #Far Horizons
   components:
   - type: Sprite
     layers:
@@ -114,7 +114,7 @@
   parent: MarkerBase
   id: SpawnMobXenoLonePraetorian
   name: Xeno Spawner
-  suffix: Lone Praetorian, Exo Station
+  suffix: Lone Praetorian, Exo Station, XenoAlien #Far Horizons
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Mobs/xenos.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Mobs/xenos.yml
@@ -2,7 +2,7 @@
   parent: MarkerBase
   id: SpawnMobXenoEasy
   name: Xeno Spawner
-  suffix: Easy, Random
+  suffix: Easy, Random, XenoAlien #Far Horizons
   components:
   - type: Sprite
     layers:
@@ -20,7 +20,7 @@
   parent: MarkerBase
   id: SpawnMobXenoHard
   name: Xeno Spawner
-  suffix: Hard, Random
+  suffix: Hard, Random, XenoAlien #Far Horizons
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: [BaseMob, StripableInventoryBase, BaseSiliconLanguages] #Starlight Languages
   id: BaseBorgChassisNotIonStormable
-  name: cyborg
+  name: Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A man-machine hybrid that assists in station activity. They love being asked to state their laws over and over.
   save: false
   abstract: true
@@ -225,7 +225,8 @@
     enabled: false
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true
-    radius: 4
+    radius: 8 #Far Horizons
+    energy: 2 #Far Horizons
     netsync: false
   - type: Pullable
   - type: Puller
@@ -395,6 +396,8 @@
     energy: 6
   - type: BypassLock
     bypassDelay: 15 # We don't want people to easily be able to remove syndieborg brains.
+  - type: Loadout #Far Horizons
+    prototypes: [ SyndicateBorgDeathTie ]
 
 - type: entity
   id: BaseBorgChassisDerelict
@@ -460,7 +463,7 @@
 - type: entity
   parent: BaseBorgChassisNotIonStormable
   id: BaseXenoborgChassis
-  name: xenoborg
+  name: Xenoborg #Far Horizons - The Great Capitalization Crusade
   description: A man-machine hybrid that aims to replicate itself. They love extracting brains to insert into fresh Xenoborg chassis to grow their army.
   save: false
   abstract: true

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -46,7 +46,7 @@
 - type: entity
   id: BorgChassisGeneric
   parent: BorgChassisSelectable
-  Name: Generic Cyborg #Far Horizons - The Great Capitalization Crusade
+  name: Generic Cyborg #Far Horizons - The Great Capitalization Crusade
   suffix: type picked
   components:
   - type: BorgSwitchableType
@@ -55,7 +55,7 @@
 - type: entity
   id: BorgChassisMining
   parent: BorgChassisSelectable
-  Name: Salvage Cyborg #Far Horizons - The Great Capitalization Crusade
+  name: Salvage Cyborg #Far Horizons - The Great Capitalization Crusade
   components:
   - type: BorgSwitchableType
     selectedBorgType: mining
@@ -63,7 +63,7 @@
 - type: entity
   id: BorgChassisEngineer
   parent: BorgChassisSelectable
-  Name: Engineer Cyborg #Far Horizons - The Great Capitalization Crusade
+  name: Engineer Cyborg #Far Horizons - The Great Capitalization Crusade
   components:
   - type: BorgSwitchableType
     selectedBorgType: engineering
@@ -71,7 +71,7 @@
 - type: entity
   id: BorgChassisJanitor
   parent: BorgChassisSelectable
-  Name: Janitor Cyborg #Far Horizons - The Great Capitalization Crusade
+  name: Janitor Cyborg #Far Horizons - The Great Capitalization Crusade
   components:
   - type: BorgSwitchableType
     selectedBorgType: janitor
@@ -79,7 +79,7 @@
 - type: entity
   id: BorgChassisMedical
   parent: BorgChassisSelectable
-  Name: Medical Cyborg #Far Horizons - The Great Capitalization Crusade
+  name: Medical Cyborg #Far Horizons - The Great Capitalization Crusade
   components:
   - type: BorgSwitchableType
     selectedBorgType: medical
@@ -87,7 +87,7 @@
 - type: entity
   id: BorgChassisService
   parent: BorgChassisSelectable
-  Name: Service Cyborg #Far Horizons - The Great Capitalization Crusade
+  name: Service Cyborg #Far Horizons - The Great Capitalization Crusade
   components:
   - type: BorgSwitchableType
     selectedBorgType: service
@@ -95,7 +95,7 @@
 - type: entity
   id: BorgChassisSyndicateAssault
   parent: BaseBorgChassisSyndicate
-  Name: Syndicate Assault Cyborg #Far Horizons - The Great Capitalization Crusade
+  name: Syndicate Assault Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A lean, mean killing machine with access to a variety of deadly modules.
   components:
     - type: TextToSpeech
@@ -129,7 +129,7 @@
 - type: entity
   id: BorgChassisSyndicateMedical
   parent: [ BaseBorgChassisSyndicate, ShowMedicalIcons ]
-  Name: Syndicate Medical Cyborg #Far Horizons - The Great Capitalization Crusade
+  name: Syndicate Medical Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A combat medical cyborg. Has limited offensive potential, but makes more than up for it with its support capabilities.
   components:
     - type: TextToSpeech
@@ -170,7 +170,7 @@
 - type: entity
   id: BorgChassisSyndicateSaboteur
   parent: BaseBorgChassisSyndicate
-  Name: Syndicate Saboteur Cyborg #Far Horizons - The Great Capitalization Crusade
+  name: Syndicate Saboteur Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A streamlined engineering cyborg, equipped with covert modules. Its chameleon projector lets it disguise itself as a Nanotrasen cyborg.
   components:
     - type: TextToSpeech
@@ -208,7 +208,7 @@
 - type: entity
   id: BorgChassisDerelict
   parent: BaseBorgChassisDerelict
-  Name: Derelict Cyborg #Far Horizons - The Great Capitalization Crusade
+  name: Derelict Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A man-machine hybrid that assists in station activity. This one is in a state of great disrepair.
   components:
   - type: Sprite
@@ -241,7 +241,7 @@
 - type: entity
   parent: BaseBorgChassisDerelict
   id: EngineeringBorgChassisDerelict
-  Name: Derelict Engineer Cyborg #Far Horizons - The Great Capitalization Crusade
+  name: Derelict Engineer Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A man-machine hybrid that assists the engineering department. This one seems to have chunks of strange crystals pockmarking its surface.
   components:
   - type: Sprite
@@ -275,7 +275,7 @@
 - type: entity
   parent: BaseBorgChassisDerelict
   id: JanitorBorgChassisDerelict
-  Name: Derelict Janitor Cyborg #Far Horizons - The Great Capitalization Crusade
+  name: Derelict Janitor Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A man-machine hybrid that assists the service department. It's a bigger mess than anything it can clean up.
   components:
   - type: Sprite
@@ -311,7 +311,7 @@
 - type: entity
   parent: BaseBorgChassisDerelict
   id: MedicalBorgChassisDerelict
-  Name: Derelict Medical Cyborg #Far Horizons - The Great Capitalization Crusade
+  name: Derelict Medical Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A man-machine hybrid that assists the medical department. This one's needles don't look very sanitary.
   components:
   - type: Sprite
@@ -354,7 +354,7 @@
 - type: entity
   parent: BaseBorgChassisDerelict
   id: MiningBorgChassisDerelict
-  Name: Derelict Salvage Cyborg #Far Horizons - The Great Capitalization Crusade
+  name: Derelict Salvage Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A man-machine hybrid that assists the cargo department. This one has seen the wrong side of a gibtonite chunk.
   components:
   - type: Sprite
@@ -390,7 +390,7 @@
 - type: entity
   parent: BaseBorgChassisSyndicateDerelict
   id: SyndicateAssaultBorgChassisDerelict
-  Name: Derelict Syndicate Assault Cyborg #Far Horizons - The Great Capitalization Crusade
+  name: Derelict Syndicate Assault Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A lean, mean killing machine with access to a variety of deadly modules. This one is more rust-orange than blood-red.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -46,7 +46,7 @@
 - type: entity
   id: BorgChassisGeneric
   parent: BorgChassisSelectable
-  name: generic cyborg
+  Name: Generic Cyborg #Far Horizons - The Great Capitalization Crusade
   suffix: type picked
   components:
   - type: BorgSwitchableType
@@ -55,7 +55,7 @@
 - type: entity
   id: BorgChassisMining
   parent: BorgChassisSelectable
-  name: salvage cyborg
+  Name: Salvage Cyborg #Far Horizons - The Great Capitalization Crusade
   components:
   - type: BorgSwitchableType
     selectedBorgType: mining
@@ -63,7 +63,7 @@
 - type: entity
   id: BorgChassisEngineer
   parent: BorgChassisSelectable
-  name: engineer cyborg
+  Name: Engineer Cyborg #Far Horizons - The Great Capitalization Crusade
   components:
   - type: BorgSwitchableType
     selectedBorgType: engineering
@@ -71,7 +71,7 @@
 - type: entity
   id: BorgChassisJanitor
   parent: BorgChassisSelectable
-  name: janitor cyborg
+  Name: Janitor Cyborg #Far Horizons - The Great Capitalization Crusade
   components:
   - type: BorgSwitchableType
     selectedBorgType: janitor
@@ -79,7 +79,7 @@
 - type: entity
   id: BorgChassisMedical
   parent: BorgChassisSelectable
-  name: medical cyborg
+  Name: Medical Cyborg #Far Horizons - The Great Capitalization Crusade
   components:
   - type: BorgSwitchableType
     selectedBorgType: medical
@@ -87,7 +87,7 @@
 - type: entity
   id: BorgChassisService
   parent: BorgChassisSelectable
-  name: service cyborg
+  Name: Service Cyborg #Far Horizons - The Great Capitalization Crusade
   components:
   - type: BorgSwitchableType
     selectedBorgType: service
@@ -95,7 +95,7 @@
 - type: entity
   id: BorgChassisSyndicateAssault
   parent: BaseBorgChassisSyndicate
-  name: syndicate assault cyborg
+  Name: Syndicate Assault Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A lean, mean killing machine with access to a variety of deadly modules.
   components:
     - type: TextToSpeech
@@ -129,7 +129,7 @@
 - type: entity
   id: BorgChassisSyndicateMedical
   parent: [ BaseBorgChassisSyndicate, ShowMedicalIcons ]
-  name: syndicate medical cyborg
+  Name: Syndicate Medical Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A combat medical cyborg. Has limited offensive potential, but makes more than up for it with its support capabilities.
   components:
     - type: TextToSpeech
@@ -170,7 +170,7 @@
 - type: entity
   id: BorgChassisSyndicateSaboteur
   parent: BaseBorgChassisSyndicate
-  name: syndicate saboteur cyborg
+  Name: Syndicate Saboteur Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A streamlined engineering cyborg, equipped with covert modules. Its chameleon projector lets it disguise itself as a Nanotrasen cyborg.
   components:
     - type: TextToSpeech
@@ -208,7 +208,7 @@
 - type: entity
   id: BorgChassisDerelict
   parent: BaseBorgChassisDerelict
-  name: derelict cyborg
+  Name: Derelict Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A man-machine hybrid that assists in station activity. This one is in a state of great disrepair.
   components:
   - type: Sprite
@@ -241,7 +241,7 @@
 - type: entity
   parent: BaseBorgChassisDerelict
   id: EngineeringBorgChassisDerelict
-  name: derelict engineer cyborg
+  Name: Derelict Engineer Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A man-machine hybrid that assists the engineering department. This one seems to have chunks of strange crystals pockmarking its surface.
   components:
   - type: Sprite
@@ -275,7 +275,7 @@
 - type: entity
   parent: BaseBorgChassisDerelict
   id: JanitorBorgChassisDerelict
-  name: derelict janitor cyborg
+  Name: Derelict Janitor Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A man-machine hybrid that assists the service department. It's a bigger mess than anything it can clean up.
   components:
   - type: Sprite
@@ -311,7 +311,7 @@
 - type: entity
   parent: BaseBorgChassisDerelict
   id: MedicalBorgChassisDerelict
-  name: derelict medical cyborg
+  Name: Derelict Medical Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A man-machine hybrid that assists the medical department. This one's needles don't look very sanitary.
   components:
   - type: Sprite
@@ -354,7 +354,7 @@
 - type: entity
   parent: BaseBorgChassisDerelict
   id: MiningBorgChassisDerelict
-  name: derelict salvage cyborg
+  Name: Derelict Salvage Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A man-machine hybrid that assists the cargo department. This one has seen the wrong side of a gibtonite chunk.
   components:
   - type: Sprite
@@ -390,7 +390,7 @@
 - type: entity
   parent: BaseBorgChassisSyndicateDerelict
   id: SyndicateAssaultBorgChassisDerelict
-  name: derelict syndicate assault cyborg
+  Name: Derelict Syndicate Assault Cyborg #Far Horizons - The Great Capitalization Crusade
   description: A lean, mean killing machine with access to a variety of deadly modules. This one is more rust-orange than blood-red.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -3,7 +3,7 @@
   name: burrower
   id: MobXeno
   parent: SimpleSpaceMobBase
-  description: They mostly come at night. Mostly.
+  description: A small Xeno which uses its claws to break things and force open doors. # Moffstation - (Xeno Buffs)
   components:
   # Starlight-start: Languages
   - type: LanguageSpeaker
@@ -33,7 +33,7 @@
   - type: Prying
     pryPowered: true
     force: true
-    speedModifier: 1.5
+    speedModifier: 4 # Moffstation - (Xeno Buffs)
     useSound:
       path: /Audio/Items/crowbar.ogg
   - type: Reactive
@@ -66,14 +66,16 @@
     allowedStates:
     - Alive
     - Dead
-  # Moffstation - Begin (Xeno Buffs)
+  # Moffstation - Begin (Xeno Buffs) - NOTE: there are a few extra SlowOnDamage and MovementSpeedModifier components which already inherit everything from their parent in the xenos.
   - type: MobThresholds
     thresholds:
       0: Alive
+      #50: Dead
       150: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
-      75: 0.7
+      #25: 0.5
+      90: 0.7
       120: 0.5
   - type: Stamina
     baseCritThreshold: 200
@@ -89,10 +91,13 @@
      collection: AlienClaw
     animation: WeaponArcBite
     damage:
+      #groups:
+        #Brute: 6
       types:
-        blunt: 10
-  - type: MovementSpeedModifier
-    baseSprintSpeed: 4.0 # Slightly slower than a person
+        Blunt: 2
+        Slash: 10
+        Structural: 40
+  - type: NightVision
   # Moffstation - End
   - type: DamageStateVisuals
     states:
@@ -134,6 +139,7 @@
       - CannotSuicide
       - DoorBumpOpener
       - FootstepSound
+      - Xeno # Moffstation - (Xeno Buffs)
   - type: NoSlip
   - type: Perishable #Ummmm the acid kills a lot of the bacteria or something
     molsPerSecondPerUnitMass: 0.0005
@@ -144,6 +150,7 @@
   name: praetorian
   parent: MobXeno
   id: MobXenoPraetorian
+  description: A large Xeno which can soak up a huge amount of damage. # Moffstation - (Xeno Buffs)
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -156,21 +163,22 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      400: Dead
+      #100: Dead
+      300: Dead
   - type: Stamina
     baseCritThreshold: 300
   - type: SlowOnDamage
     speedModifierThresholds:
-      200: 0.7
-      320: 0.5
+      #50: 0.7
+      180: 0.7
+      240: 0.5
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 13
-        Piercing: 7
-    bluntStaminaDamageFactor: 1.0
-  - type: MovementSpeedModifier
-    baseSprintSpeed: 3.0 # Mining suit can barely outrun them
+        Blunt: 10
+        Slash: 15
+  - type: Prying
+    speedModifier: 2
   # Moffstation - End
   - type: Fixtures
     fixtures:
@@ -188,6 +196,7 @@
   name: drone
   parent: MobXeno
   id: MobXenoDrone
+  description: A small xeno which carries things around for the hive. # Moffstation - (Xeno Buffs)
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -200,19 +209,22 @@
   - type: MobThresholds
     thresholds:
       0: Alive
+      #80: Dead
       100: Dead
   - type: SlowOnDamage
-    speedModifierThresholds:
-      50: 0.7
-      75: 0.5
+    #speedModifierThresholds:
+      #40: 0.7
   - type: MeleeWeapon
     damage:
+      #groups:
+        #Brute: 6
       types:
-        Blunt: 8
-        Piercing: 4
-    bluntStaminaDamageFactor: 1.0
-  - type: MovementSpeedModifier
-    baseSprintSpeed: 5.0
+        Blunt: 10
+        Slash: 5
+  #- type: MovementSpeedModifier
+    #baseSprintSpeed: 4
+  - type: Prying
+    speedModifier: 2
   # Moffstation - End
   - type: Fixtures
     fixtures:
@@ -230,6 +242,7 @@
   name: queen
   parent: MobXeno
   id: MobXenoQueen
+  description: A massive Xeno who leads the hive. # Moffstation - (Xeno Buffs)
   components:
   # Starlight-start: Languages
   - type: LanguageSpeaker
@@ -252,19 +265,24 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      500: Dead # Dragon health
+      #300: Dead
+      600: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
-      250: 0.7
-      400: 0.5
-  - type: MovementSpeedModifier
-    baseSprintSpeed: 3.0 # Mining suit can barely outrun them
+      #150: 0.7
+      360: 0.7
+      480: 0.5
+  #- type: MovementSpeedModifier
   - type: MeleeWeapon
     damage:
-     types:
-       Blunt: 25
-       Piercing: 10
-    bluntStaminaDamageFactor: 1.0
+      #groups:
+        #Brute: 12
+      types:
+        Blunt: 10
+        Slash: 25
+        Structural: 40
+  - type: Prying
+    speedModifier: 2
   # Moffstation - End
   - type: Fixtures
     fixtures:
@@ -285,6 +303,7 @@
   name: ravager
   parent: MobXeno
   id: MobXenoRavager
+  description: A large Xeno which uses its massive claws to hunt prey. # Moffstation - (Xeno Buffs)
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -294,21 +313,25 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
   # Moffstation - Begin (Xeno Buffs)
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      200: Dead
-  - type: MovementSpeedModifier
-    baseSprintSpeed: 4.5
+  #- type: MobThresholds
+    #thresholds:
+      #0: Alive
+      #100: Dead
+  #- type: MovementSpeedModifier
+    #baseSprintSpeed: 4
   - type: MeleeWeapon
+    attackRate: 1.5
     damage:
+      #groups:
+        #Brute: 10
      types:
        Slash: 20
-       Piercing: 10
+       Structural: 20
   - type: SlowOnDamage
-    speedModifierThresholds:
-      100: 0.7
-      160: 0.5
+    #speedModifierThresholds:
+      #50: 0.7
+  - type: Prying
+    speedModifier: 2
   # Moffstation - End
   - type: Fixtures
     fixtures:
@@ -326,6 +349,7 @@
   name: runner
   parent: MobXeno
   id: MobXenoRunner
+  description: A small, extremely fast Xeno. # Moffstation - (Xeno Buffs)
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -334,14 +358,19 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
-  # Moffstation - Begin (Xeno Buffs)
   - type: MovementSpeedModifier
-    baseSprintSpeed: 10.0 # Scary fast
+    baseSprintSpeed: 6.0
+  # Moffstation - Begin (Xeno Buffs)
   - type: MeleeWeapon
+    attackRate: 2
     damage:
-     types:
-       Slash: 10
-       Piercing: 5
+      #groups:
+        #Brute: 5
+      types:
+        Blunt: 3
+        Slash: 7
+  - type: Prying
+    speedModifier: 2
   # Moffstation - End
   - type: Fixtures
     fixtures:
@@ -374,6 +403,7 @@
   name: spitter
   parent: MobXeno
   id: MobXenoSpitter
+  description: A large Xeno which can spit acid at long distances. # Moffstation - (Xeno Buffs)
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -383,14 +413,20 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
   # Moffstation - Begin (Xeno Buffs)
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      100: Dead
+  #- type: MobThresholds
+    #thresholds:
+      #0: Alive
+      #50: Dead
   - type: SlowOnDamage
-    speedModifierThresholds:
-      50: 0.7
-      80: 0.5
+    #speedModifierThresholds:
+      #25: 0.7
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 7
+        Slash: 3
+  - type: Prying
+    speedModifier: 2
   # Moffstation - End
   - type: HTN
     rootTask:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -108,6 +108,7 @@
       Dead:
         Base: dead
   - type: Puller
+    needsHands: false # Moffstation - even more Xeno buffs
   - type: Butcherable
     butcheringType: Spike
     spawned:
@@ -121,7 +122,7 @@
     description: ghost-role-information-xeno-description
     rules: ghost-role-information-xeno-rules
     raffle:
-      settings: default
+      settings: short # Moffstation - even more Xeno buffs
     # Starlight start
     mindRoles:
     - MindRoleGhostRoleXeno

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -1,6 +1,7 @@
 # Hacky for the stress test so don't even consider adding to this
 - type: entity
-  name: burrower
+  name: Burrower #Far Horizons - The Great Capitalization Crusade
+  suffix: XenoAlien #Far Horizons
   id: MobXeno
   parent: SimpleSpaceMobBase
   description: A small Xeno which uses its claws to break things and force open doors. # Moffstation - (Xeno Buffs)
@@ -148,7 +149,8 @@
     speechVerb: LargeMob
 
 - type: entity
-  name: praetorian
+  name: Praetorian #Far Horizons - The Great Capitalization Crusade
+  suffix: XenoAlien #Far Horizons
   parent: MobXeno
   id: MobXenoPraetorian
   description: A large Xeno which can soak up a huge amount of damage. # Moffstation - (Xeno Buffs)
@@ -194,7 +196,8 @@
         - MobLayer
 
 - type: entity
-  name: drone
+  name: Drone #Far Horizons - The Great Capitalization Crusade
+  suffix: XenoAlien #Far Horizons
   parent: MobXeno
   id: MobXenoDrone
   description: A small xeno which carries things around for the hive. # Moffstation - (Xeno Buffs)
@@ -240,7 +243,8 @@
         - MobLayer
 
 - type: entity
-  name: queen
+  name: Queen #Far Horizons - The Great Capitalization Crusade
+  suffix: XenoAlien #Far Horizons
   parent: MobXeno
   id: MobXenoQueen
   description: A massive Xeno who leads the hive. # Moffstation - (Xeno Buffs)
@@ -268,6 +272,46 @@
       0: Alive
       #300: Dead
       600: Dead
+  #Far Horizons - Start - Changing destructible in the middle of the Moff sandwich
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Blunt
+        damage: 800
+      behaviors:
+      - !type:GibBehavior { }
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Heat
+        damage: 1500
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawnInContainer: true
+        spawn:
+          Ash:
+            min: 1
+            max: 1
+      - !type:BurnBodyBehavior
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MeatLaserImpact
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Radiation
+        damage: 15
+      behaviors:
+      - !type:PopupBehavior
+        popup: mouth-taste-metal
+        popupType: LargeCaution
+        targetOnly: true
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Radiation
+        damage: 40
+      behaviors:
+      - !type:VomitBehavior
+  # Far Horizons - End
   - type: SlowOnDamage
     speedModifierThresholds:
       #150: 0.7
@@ -301,7 +345,8 @@
     - CannotSuicide
 
 - type: entity
-  name: ravager
+  name: Ravager #Far Horizons #Far Horizons - The Great Capitalization Crusade
+  suffix: XenoAlien #Far Horizons
   parent: MobXeno
   id: MobXenoRavager
   description: A large Xeno which uses its massive claws to hunt prey. # Moffstation - (Xeno Buffs)
@@ -347,7 +392,8 @@
         - MobLayer
 
 - type: entity
-  name: runner
+  name: Runner #Far Horizons #Far Horizons - The Great Capitalization Crusade
+  suffix: XenoAlien #Far Horizons
   parent: MobXeno
   id: MobXenoRunner
   description: A small, extremely fast Xeno. # Moffstation - (Xeno Buffs)
@@ -386,7 +432,8 @@
         - MobLayer
 
 - type: entity
-  name: rouny
+  name: Rouny #Far Horizons - The Great Capitalization Crusade
+  suffix: Meme, XenoAlien #Far Horizons
   parent: MobXenoRunner
   id: MobXenoRouny
   components:
@@ -401,7 +448,8 @@
       amount: 3
 
 - type: entity
-  name: spitter
+  name: Spitter #Far Horizons - The Great Capitalization Crusade
+  suffix: XenoAlien #Far Horizons
   parent: MobXeno
   id: MobXenoSpitter
   description: A large Xeno which can spit acid at long distances. # Moffstation - (Xeno Buffs)
@@ -414,10 +462,10 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
   # Moffstation - Begin (Xeno Buffs)
-  #- type: MobThresholds
-    #thresholds:
-      #0: Alive
-      #50: Dead
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      75: Dead
   - type: SlowOnDamage
     #speedModifierThresholds:
       #25: 0.7
@@ -458,7 +506,7 @@
         - MobLayer
 
 - type: entity
-  name: space adder
+  name: Space Adder #Far Horizons
   parent: SimpleSpaceMobBase
   id: MobPurpleSnake
   description: A menacing purple snake from Kepler-283c.
@@ -528,7 +576,7 @@
     - FootstepSound
 
 - type: entity
-  name: space adder
+  name: Space Adder #Far Horizons
   parent: MobPurpleSnake
   id: MobSmallPurpleSnake
   suffix: small
@@ -559,6 +607,7 @@
 
 - type: entity
   name: '"Dale"'
+  suffix: XenoAlien #Far Horizons
   description: A praetorian left over from the station's initial security sweep. Has a pair of bloodied dog tags engraved with the name "Pvt. Dale" stuck in its maw.
   parent: SimpleSpaceMobBase
   id: MobXenoLonePraetorianNoGhost

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -66,13 +66,15 @@
     allowedStates:
     - Alive
     - Dead
+  # Moffstation - Begin (Xeno Buffs)
   - type: MobThresholds
     thresholds:
       0: Alive
-      50: Dead
+      150: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
-      25: 0.5
+      75: 0.7
+      120: 0.5
   - type: Stamina
     baseCritThreshold: 200
   - type: Bloodstream
@@ -88,7 +90,10 @@
     animation: WeaponArcBite
     damage:
       types:
-        Piercing: 6
+        blunt: 10
+  - type: MovementSpeedModifier
+    baseSprintSpeed: 4.0 # Slightly slower than a person
+  # Moffstation - End
   - type: DamageStateVisuals
     states:
       Alive:
@@ -147,15 +152,26 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
+  # Moffstation - Begin (Xeno Buffs)
   - type: MobThresholds
     thresholds:
       0: Alive
-      100: Dead
+      400: Dead
   - type: Stamina
     baseCritThreshold: 300
   - type: SlowOnDamage
     speedModifierThresholds:
-      50: 0.7
+      200: 0.7
+      320: 0.5
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 13
+        Piercing: 7
+    bluntStaminaDamageFactor: 1.0
+  - type: MovementSpeedModifier
+    baseSprintSpeed: 3.0 # Mining suit can barely outrun them
+  # Moffstation - End
   - type: Fixtures
     fixtures:
       fix1:
@@ -180,19 +196,24 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
+  # Moffstation - Begin (Xeno Buffs)
   - type: MobThresholds
     thresholds:
       0: Alive
-      80: Dead
+      100: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
-      40: 0.7
+      50: 0.7
+      75: 0.5
   - type: MeleeWeapon
     damage:
       types:
-        Slash: 6
+        Blunt: 8
+        Piercing: 4
+    bluntStaminaDamageFactor: 1.0
   - type: MovementSpeedModifier
-    baseSprintSpeed: 4
+    baseSprintSpeed: 5.0
+  # Moffstation - End
   - type: Fixtures
     fixtures:
       fix1:
@@ -227,18 +248,24 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
+  # Moffstation - Begin (Xeno Buffs)
   - type: MobThresholds
     thresholds:
       0: Alive
-      300: Dead
+      500: Dead # Dragon health
   - type: SlowOnDamage
     speedModifierThresholds:
-      150: 0.7
+      250: 0.7
+      400: 0.5
   - type: MovementSpeedModifier
+    baseSprintSpeed: 3.0 # Mining suit can barely outrun them
   - type: MeleeWeapon
     damage:
-      types:
-        Slash: 12
+     types:
+       Blunt: 25
+       Piercing: 10
+    bluntStaminaDamageFactor: 1.0
+  # Moffstation - End
   - type: Fixtures
     fixtures:
       fix1:
@@ -266,19 +293,23 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
+  # Moffstation - Begin (Xeno Buffs)
   - type: MobThresholds
     thresholds:
       0: Alive
-      100: Dead
+      200: Dead
   - type: MovementSpeedModifier
-    baseSprintSpeed: 4
+    baseSprintSpeed: 4.5
   - type: MeleeWeapon
     damage:
-      types:
-        Slash: 10
+     types:
+       Slash: 20
+       Piercing: 10
   - type: SlowOnDamage
     speedModifierThresholds:
-      50: 0.7
+      100: 0.7
+      160: 0.5
+  # Moffstation - End
   - type: Fixtures
     fixtures:
       fix1:
@@ -303,12 +334,15 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
+  # Moffstation - Begin (Xeno Buffs)
   - type: MovementSpeedModifier
-    baseSprintSpeed: 6.0
+    baseSprintSpeed: 10.0 # Scary fast
   - type: MeleeWeapon
     damage:
-      types:
-        Slash: 5
+     types:
+       Slash: 10
+       Piercing: 5
+  # Moffstation - End
   - type: Fixtures
     fixtures:
       fix1:
@@ -348,13 +382,16 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
+  # Moffstation - Begin (Xeno Buffs)
   - type: MobThresholds
     thresholds:
       0: Alive
-      50: Dead
+      100: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
-      25: 0.7
+      50: 0.7
+      80: 0.5
+  # Moffstation - End
   - type: HTN
     rootTask:
       task: SimpleRangedHostileCompound

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -980,7 +980,7 @@
     - state: icon-chemist
   - type: ItemBorgModule
     hands:
-    - item: HandLabeler
+    #- item: HandLabeler #Far Horizons - This is doubled up for some reason.
     - item: Syringe
       hand: #Starlight start
         emptyLabel: borg-slot-syringe-empty
@@ -1016,6 +1016,21 @@
           tags:
           - ChemDispensable
     - item: HandLabeler
+    - item: BoxMouthSwab #Far Horizons
+      hand:
+        emptyLabel: borg-slot-mouth-swab-box-empty
+        emptyRepresentative: BoxMouthSwab
+        whitelist:
+          tags:
+          - BoxMouthSwab
+    - item: DiseaseSwab #Far Horizons
+      hand:
+        emptyLabel: borg-slot-mouth-swab-empty
+        emptyRepresentative: DiseaseSwab
+        whitelist:
+          tags:
+          - DiseaseSwab
+
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: chem-module }
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -991,7 +991,7 @@
     - type: Projectile
       damage:
         types:
-          Caustic: 15 #Caustic : 5 Moffstation - (Xeno Buffs)
+          Caustic: 10 #Caustic : 5 Moffstation - (Xeno Buffs) #Far Horizons - Nerfed to 10, for balance.
     - type: Sprite
       sprite: Objects/Weapons/Guns/Projectiles/xeno_toxic.rsi
       layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -991,7 +991,7 @@
     - type: Projectile
       damage:
         types:
-          Caustic: 25 # Moffstation - Xeno Buffs
+          Caustic: 15 #Caustic : 5 Moffstation - (Xeno Buffs)
     - type: Sprite
       sprite: Objects/Weapons/Guns/Projectiles/xeno_toxic.rsi
       layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -991,7 +991,7 @@
     - type: Projectile
       damage:
         types:
-          Caustic: 5
+          Caustic: 25 # Moffstation - Xeno Buffs
     - type: Sprite
       sprite: Objects/Weapons/Guns/Projectiles/xeno_toxic.rsi
       layers:

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Neck/ties.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Neck/ties.yml
@@ -25,3 +25,32 @@
     sprite: Clothing/Neck/Ties/dettie.rsi
   - type: Clothing
     sprite: Clothing/Neck/Ties/dettie.rsi
+
+# Syndicate Cyborg Tie for Hailer purposes. Don't question my methods.
+- type: entity
+  parent: ClothingNeckBase
+  id: ClothingNeckTieRedSyndicateBorg
+  name: Red-Tie
+  description: A neosilk clip-on red tie with a tiny speaker on it.
+  components:
+  - type: Sprite
+    sprite: Clothing/Neck/Ties/redtie.rsi
+  - type: Clothing
+    sprite: Clothing/Neck/Ties/redtie.rsi
+  - type: Item
+    storedSprite:
+      state: storage
+      sprite: Clothing/Neck/Ties/redtie.rsi
+  - type: Hailer 
+    hailMessage: "Death to NanoTrasen!!"
+    hailSound:
+      path: /Audio/_Starlight/Effects/nano_death.ogg
+      params:
+        variation: 0.09
+    cooldownDuration: 30
+  - type: Tag
+    tags:
+    - HamsterWearable
+    - WhitelistChameleon
+    - ClothMade
+    - Recyclable

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
@@ -543,6 +543,7 @@
     groups:
       Flammable: [ Touch ]
       Extinguish: [ Touch ]
+      Acidic: [Touch, Ingestion]
     reactions:
     - reagents: [ Water, SpaceCleaner ]
       methods: [ Touch ]
@@ -739,6 +740,7 @@
       groups:
         Flammable: [Touch]
         Extinguish: [Touch]
+        Acidic: [Touch, Ingestion]
       reactions:
         - reagents: [Water, SpaceCleaner]
           methods: [Touch]
@@ -1449,6 +1451,7 @@
     groups:
       Flammable: [ Touch ]
       Extinguish: [ Touch ]
+      Acidic: [Touch, Ingestion]
     reactions:
     - reagents: [ Water, SpaceCleaner ]
       methods: [ Touch ]

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Medical/disease.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Medical/disease.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: BaseItem
   id: DiseaseSwab
-  name: sterile swab
+  name: Sterile Swab
   description: Used for taking and transferring samples. Sterile until open. Single use only.
   components:
   - type: Item
@@ -14,6 +14,7 @@
     tags:
     - Recyclable
     - Trash
+    - DiseaseSwab
   - type: BotanySwab
   - type: GuideHelp
     guides:
@@ -24,7 +25,7 @@
 - type: entity
   parent: BaseAmmoProvider # this is for cycling swabs out and not spawning 30 entities, trust
   id: BoxMouthSwab
-  name: sterile swab dispenser
+  name: Sterile Swab Dispenser
   description: Dispenses 30 sterile swabs, extremely useful for botany.
   components:
   - type: Sprite
@@ -37,6 +38,9 @@
       - BotanySwab
     proto: DiseaseSwab
     capacity: 30
+  - type: Tag
+    tags:
+    - BoxMouthSwab
   - type: GuideHelp
     guides:
   # - Virology (when it will be written)
@@ -46,7 +50,7 @@
 - type: entity
   parent: BaseItem
   id: Vaccine
-  name: vaccine
+  name: Vaccine
   description: Prevents people who DON'T already have a disease from catching it.
   components:
   - type: Item

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -30,7 +30,7 @@
 - type: entity
   parent: [BaseBorgModuleSecurity,BaseProviderBorgModule,BaseSecurityContraband]
   id: BorgModuleBaton
-  name: Baton Cyborg module
+  name: Baton Cyborg Module
   description: Now even cyborgs can enjoy harm batong.
   components:
   - type: Sprite
@@ -56,7 +56,7 @@
 - type: entity
   parent: [BaseBorgModuleSecurity,BaseProviderBorgModule,BaseSecurityContraband]
   id: BorgModuleDominator
-  name: Dominator Cyborg module
+  name: Dominator Cyborg Module
   description: Module with a dominator specifically designed for cyborgs.
   components:
   - type: Sprite
@@ -73,7 +73,7 @@
 - type: entity
   parent: [BaseBorgModuleSecurity,BaseProviderBorgModule,BaseSecurityContraband]
   id: BorgModuleLaserCarbine
-  name: Laser Carbine Cyborg module
+  name: Laser Carbine Cyborg Module
   description: Module with a Laser Carbine specifically designed for cyborgs.
   components:
   - type: Sprite
@@ -119,7 +119,7 @@
 - type: entity
   parent: [BaseBorgModuleCentcomm,BaseProviderBorgModule,BaseCentcommContraband]
   id: CentcommLaserModule
-  name: CentComm cyborg laser module
+  name: CentComm Cyborg Laser Module
   description: Module with a standard issue HAW laser.
   components:
   - type: Sprite
@@ -151,7 +151,7 @@
 - type: entity
   id: CentcommBulwarkModule
   parent: [ BaseBorgModuleCentcomm, BaseProviderBorgModule, BaseCentcommContraband ]
-  name: CentComm bulwark module
+  name: CentComm Bulwark Module
   description: A module that comes with an energy chainsword and shield.
   components:
     - type: Sprite
@@ -168,7 +168,7 @@
 - type: entity
   parent: [ BaseBorgModuleCentcomm, BaseProviderBorgModule, BaseCentcommContraband ]
   id: CentcommModuleSpaceMovement
-  name: CentComm space movement module
+  name: CentComm Space Movement Module
   description: After seeing the success of the thruster module, CentComm decided to develop a proper jetpack for their most valued cyborgs.
   components:
   - type: Sprite
@@ -188,7 +188,7 @@
 - type: entity
   parent: [ BaseBorgModuleCentcomm, BaseProviderBorgModule, BaseCentcommContraband ]
   id: CentcommModuleChameleonProjector
-  name: CentComm chameleon projector module
+  name: CentComm Chameleon Projector Module
   description: Module with a chameleon projector.
   components:
   - type: Sprite
@@ -204,7 +204,7 @@
 - type: entity
   parent: [ BaseBorgModuleCentcomm, BaseProviderBorgModule, BaseCentcommContraband ]
   id: CentcommModuleCloakDevice
-  name: CentComm cloaking device module
+  name: CentComm Cloaking Device Module
   description: A state of the art module with a device that allows cyborgs to become invisible for some time.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_FarHorizons/Factions/Loadouts/syndie_loadouts.yml
+++ b/Resources/Prototypes/_FarHorizons/Factions/Loadouts/syndie_loadouts.yml
@@ -273,6 +273,12 @@
 
 #region Neck
 
+# This exists to allow syndicate borgs to scream out their dislike of NanoTrasen
+- type: loadout
+  id: SyndiBorgTie
+  equipment:
+    neck: ClothingNeckTieRedSyndicateBorg
+
 - type: loadout
   id: ScarfStripedSyndieGreen
   equipment:

--- a/Resources/Prototypes/_FarHorizons/Factions/Loadouts/syndie_startingGear.yml
+++ b/Resources/Prototypes/_FarHorizons/Factions/Loadouts/syndie_startingGear.yml
@@ -293,3 +293,12 @@
     back:
     - Flash
     - ClothingMaskGasBSO
+
+#region Silicon
+
+#This exists to allow Syndicate Borgs (antag ones) to shout death to nanotrasen.
+
+- type: startingGear
+  id: SyndicateBorgDeathTie
+  equipment:
+    neck: ClothingNeckTieRedSyndicateBorg

--- a/Resources/Prototypes/_FarHorizons/tags.yml
+++ b/Resources/Prototypes/_FarHorizons/tags.yml
@@ -25,6 +25,9 @@
   id: BoxFolderHoPClipboard
 
 - type: Tag
+  id: BoxMouthSwab
+  
+- type: Tag
   id: BulletproofArmor
 
 - type: Tag
@@ -49,10 +52,13 @@
   id: Cyclorite
 
 - type: Tag
-  id: Drozd
+  id: DiseaseSwab
 
 - type: Tag
   id: Dominator
+
+- type: Tag
+  id: Drozd
 
 - type: Tag
   id: Enforcer

--- a/Resources/Prototypes/_Moffstation/CollectiveMinds/collective_mind.yml
+++ b/Resources/Prototypes/_Moffstation/CollectiveMinds/collective_mind.yml
@@ -1,0 +1,7 @@
+- type: collectiveMind
+  id: Xeno
+  name: collective-mind-xeno
+  keycode: 'x'
+  color: "#578a87"
+  requiredTags:
+  - Xeno

--- a/Resources/Prototypes/_Moffstation/tags.yml
+++ b/Resources/Prototypes/_Moffstation/tags.yml
@@ -1,0 +1,57 @@
+- type: Tag
+  id: DockEmergencyPod
+
+- type: Tag
+  id: SurvivalBoxInsertable
+
+- type: Tag
+  id: PowerCellBigIron
+
+- type: Tag
+  id: Pirate
+
+# Pirate bounty objectives
+
+- type: Tag
+  id: Nuke
+
+- type: Tag
+  id: Chefware
+
+- type: Tag
+  id: Magboots
+
+- type: Tag
+  id: Recharger
+
+- type: Tag
+  id: BorgModulePirate
+
+- type: Tag
+  id: PlushieSharkPirate
+
+- type: Tag
+  id: MetalRod
+
+- type: Tag
+  id: BarGold
+
+- type: Tag
+  id: BarSilver
+
+- type: Tag
+  id: WeaponShotgunPepperbox
+
+#Revert machine parts
+- type: Tag
+  id: CapacitorStockPart
+
+- type: Tag
+  id: SunglassesCheap
+
+- type: Tag
+  id: MesonGoggles
+
+# Xeno Buffs
+- type: Tag
+  id: Xeno

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
@@ -64,6 +64,7 @@
     groups:
       Flammable: [ Touch ]
       Extinguish: [ Touch ]
+      Acidic: [Touch, Ingestion] #Far Horizons
     reactions:
     - reagents: [ Water, SpaceCleaner ]
       methods: [ Touch ]

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/shadekin.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/shadekin.yml
@@ -53,6 +53,7 @@
       groups:
         Flammable: [Touch]
         Extinguish: [Touch]
+        Acidic: [Touch, Ingestion] #Far Horizons
       reactions:
         - reagents: [Water, SpaceCleaner]
           methods: [Touch]


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Porting 3 PRs (groups):
Make Xenos Scary - Buffs to Xenos which make them scarier to fight.
https://github.com/moff-station/moff-station-14/pull/198
https://github.com/moff-station/moff-station-14/pull/475
https://github.com/moff-station/moff-station-14/pull/948
Further edited so spitters could take two hits with PK Shotgun but they deal less damage in return. Queen should also gib AFTER they die, not before.
Also made it easier for Admin spawning by giving them the XenoAlien suffix.

SSD Command - People can now use the /ssd command which puts them into a much clearer form of SSD.
https://github.com/ss14Starlight/space-station-14/pull/1406

Admin Command - SetCountdown - Admins can now use SetCountdown command to set the exact time to start instead of trying to add up without going overboard and not being able to subtract.
https://github.com/moff-station/moff-station-14/pull/965

-------------

Laspi, Felinoids, Shades, and their Proto versions have been updated to once again be able to take acid damage, because oops.

All station side Cyborg Lights have been improved so they're not travelling in the absolute dark. They will still dim/disappear as power drains out but it's at least tolerable now when at full charge.

Syndicate Cyborgs can now shout out their disdain of NanoTrasen. DEATH TO NANOTRASEN!

Medical Cyborg had duplicate hand labeler removed from Chemical Module. It was replaced with a box of mouth swabs and an empty hand for mouth swabs. They too can now check people for diseases.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Porting I started before some of them screwed me up. Some bug fixes that were required. Slight additions to my silicon breathren.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
### Xenos - I aint giving media. It was tested by Gurchi and I want them to be a bit of a surprise.

### SSD Command

https://github.com/user-attachments/assets/07ff0f74-7600-447a-81e4-06517ad7129d


https://github.com/user-attachments/assets/97324098-8e9c-4e6e-9ea2-c5f0a4dacb5f


### Admin SetCountdown

https://github.com/user-attachments/assets/6ca83c4f-4a72-48ec-a158-1b6c0cc38f8f

### Three species now have the acidic proto that all other species have, kind of hard to show.

### Cyborg Lights
<img width="622" height="692" alt="image" src="https://github.com/user-attachments/assets/1fd573f7-870d-42fc-bf35-6faecbab4834" />

### Syndicate Cyborgs now have a Red Tie that allows them to use Hailer.

https://github.com/user-attachments/assets/2b809965-eece-46c5-bc90-c75a4688467c

### Medical Borg Chemical Module - Duplicate removed and added Swaps/Box.

https://github.com/user-attachments/assets/27f9f5f0-b483-45d0-8986-b6feb7463177


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Nox38, Nyxilath, RH Svenson, Katzenminer, CorruptOmega
- add: Ported Make Xenos Scary - Three PR's from MoffStation by Nox38 and Nyxilath (# 198, # 475, # 948)
- add: Ported SSD command - PR from Starlight by RHSvenson (# 1406) - Type /ssd into chat to take a nap for a while.
- add: Ported Add a SetCountdown Command - PR from Moffstation by Katzenminer (# 965)
- fix: Laspi, Felinoids, Shadekin and their Proto counterparts now will properly take Acidic damage again like the rest of the species. 
- tweak: Station Cyborg Lights have been improved. No more fumbling in the dark, at least till the battery runs out.
- add: Syndicate Cyborgs now start with a fancy red tie that allows them to shout out their disdain for NanoTrasen. They also happen to look about 100% cooler.
- remove: Medical Cyborg Chemical Module had duplicate Hand Labeler removed. They don't need to be dual wielding labelers.
- add: Medical Cyborg Chemical Module now includes a box of mouth swabs, and a hand to use them with also! They can now figure out which virus Hanz has outside of greed.