### PR TITLE
Removes implied Psychic Powers from CMD mantle description

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
@@ -543,7 +543,7 @@
   parent: [ClothingNeckMantleCMO, BaseCentcommContraband]
   id: ClothingNeckCloakCMDMantle
   name: Central Medical Division Mantle
-  description: No ailment or wound can hide from the gaze of the one draped in this mantle.
+  description: A mantle worn by somebody in CMD. Made to be easily identifyable.
   components:
   - type: Sprite
     sprite:  _Starlight/Clothing/Neck/Cloaks/CMD_mantle.rsi


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Seems like I don't have psychic powers either. I missed a mantle with a flavortext implying psychic powers on CC officials.

## Why we need to add this
Removing bad flavortexts that may confuse new players into thinking this mantle gives them superpowers.

## Media (Video/Screenshots)
n/A, it changes a description. 

## Checks


- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Irkalla
- remove: Removed things that annoy me personally. In this case a mantle that implies the wearer has superpowers IC and tricks new players into thinking this is that weird clothing anime from 2013 or something where clothing gives you superpowers.
- fix: Psychic powers are not in the clothing. Please wear an amplifier like Yuri did in RA2. 
