### PR TITLE
Shadekin Lore Compliance PR #001: Eye color limitation removal

### DIFF
--- a/Resources/Prototypes/_StarLight/Species/shadekin.yml
+++ b/Resources/Prototypes/_StarLight/Species/shadekin.yml
@@ -6,7 +6,6 @@
   dollPrototype: AppearanceShadekin
   defaultSkinTone: "#ffffff"
   skinColoration: Hues
-  eyeColoration: Shadekin
   maleFirstNames: names_shadekin
   femaleFirstNames: names_shadekin
   naming: First

--- a/Resources/Prototypes/_StarLight/Species/shadekin.yml
+++ b/Resources/Prototypes/_StarLight/Species/shadekin.yml
@@ -7,7 +7,7 @@
   defaultSkinTone: "#ffffff"
   skinColoration: Hues
   maleFirstNames: names_shadekin
-  femaleFirstNames: names_shadekin #
+  femaleFirstNames: names_shadekin 
   naming: First
   minAge: 18
   maxAge: 300

--- a/Resources/Prototypes/_StarLight/Species/shadekin.yml
+++ b/Resources/Prototypes/_StarLight/Species/shadekin.yml
@@ -7,7 +7,7 @@
   defaultSkinTone: "#ffffff"
   skinColoration: Hues
   maleFirstNames: names_shadekin
-  femaleFirstNames: names_shadekin 
+  femaleFirstNames: names_shadekin
   naming: First
   minAge: 18
   maxAge: 300

--- a/Resources/Prototypes/_StarLight/Species/shadekin.yml
+++ b/Resources/Prototypes/_StarLight/Species/shadekin.yml
@@ -7,7 +7,7 @@
   defaultSkinTone: "#ffffff"
   skinColoration: Hues
   maleFirstNames: names_shadekin
-  femaleFirstNames: names_shadekin
+  femaleFirstNames: names_shadekin #
   naming: First
   minAge: 18
   maxAge: 300


### PR DESCRIPTION

## Short description
This PR removes the mandatory component that returns Shadekin eye color back  to blackeye value. 

We have different lore here that so far explicitly states that Shadekin in realspace loose their ability to phase over long distances shortly after being in realspace as our reality asserts itself over them in that there is imply not enough Dark Energy to power their organic phasecoils/core. They can only phase for a short period after leaving The Dark. Upon reentering The Dark in lore they regain their ability to phase as their core is repowered proper unless they are blackeyed which is so far only an in-lore thing for players to flavor their character about.

I am certain 90% of the players will go "Oh cool they can finally have bright eyes" which is fine. Thats what this intends to do.


## Why we need to add this
Lore compliance with Shadekin. Crew Shadekin can now finally pick pretty bright eye colors. Those who want to play a blackeye still can.

## "Irkalla but its not 100% true to the original source from 2016/2017/2018"

And? What happened with "Yes and"?

## Media (Video/Screenshots)
<img width="1181" height="435" alt="image" src="https://github.com/user-attachments/assets/9309dc43-fd64-422a-939c-bab9de5bb808" />

<img width="1190" height="698" alt="image" src="https://github.com/user-attachments/assets/ea0f8991-0567-485f-a728-46ce0f150ea6" />

<img width="484" height="529" alt="image" src="https://github.com/user-attachments/assets/2947b00b-9bab-4c96-94c5-11e5ecea8794" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**

:cl: Irkalla
- tweak: Changed nothing important. Really. Just makes Shadekin eyes able to be bright to be compliant with upcoming lore changes.
