### PR TITLE
make ling limbs ungibbabe

### DIFF
--- a/Content.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Server/Changeling/ChangelingSystem.cs
@@ -65,6 +65,7 @@ using Content.Shared.Body.Components;
 using Content.Shared.Chemistry.Reagent;
 // Starlight edit end
 using Content.Shared.Zombies;
+using Content.Shared._FarHorizons.LimbDamage;
 
 namespace Content.Server.Changeling;
 
@@ -108,6 +109,7 @@ public sealed partial class ChangelingSystem : EntitySystem
     [Dependency] private readonly NpcFactionSystem _factionSystem = default!;
     [Dependency] private readonly MovementModStatusSystem _movementMod = default!;
     [Dependency] private readonly VisualBodySystem _visualBody = default!;
+    [Dependency] private readonly LimbDamageSystem _limbDamage = default!; // Far Horizons
 
     public EntProtoId FakeArmbladePrototype = "FakeArmBladeChangeling";
 
@@ -560,6 +562,7 @@ public sealed partial class ChangelingSystem : EntitySystem
             QueueDel(equip);
 
         PlayMeatySound(target, comp);
+        _limbDamage.SetChangelingLimbs(target, false); // Far Horizons
     }
 
     #endregion
@@ -592,6 +595,7 @@ public sealed partial class ChangelingSystem : EntitySystem
             _blood.ChangeBloodReagents(uid, new Solution([new ReagentQuantity("BloodChangeling", originalBlood.Volume)]));
         }
         // Starlight edit end
+        _limbDamage.SetChangelingLimbs(uid, true); // Far Horizons
     }
 
     private void OnMobStateChange(EntityUid uid, ChangelingComponent comp, ref MobStateChangedEvent args)

--- a/Content.Shared/_FarHorizons/LimbDamage/Components/ChangelingLimbComponent.cs
+++ b/Content.Shared/_FarHorizons/LimbDamage/Components/ChangelingLimbComponent.cs
@@ -1,0 +1,10 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._FarHorizons.LimbDamage.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ChangelingLimbComponent : Component
+{
+    [DataField] public FixedPoint2 DamageCap = 100;
+}

--- a/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.API.cs
+++ b/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.API.cs
@@ -217,7 +217,7 @@ public partial class LimbDamageSystem
 
     public void SetChangelingLimbs(Entity<LimbDamageableComponent?> target, bool state)
     {
-        if (!Resolve(target, ref target.Comp)) return;
+        if (!Resolve(target, ref target.Comp, false)) return;
 
         foreach (var limb in GetAllDamageable(target))
         {

--- a/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.API.cs
+++ b/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.API.cs
@@ -214,4 +214,17 @@ public partial class LimbDamageSystem
                 RemCompDeferred<GodmodeComponent>(limb);
         }
     }
+
+    public void SetChangelingLimbs(Entity<LimbDamageableComponent?> target, bool state)
+    {
+        if (!Resolve(target, ref target.Comp)) return;
+
+        foreach (var limb in GetAllDamageable(target))
+        {
+            if (state)
+                EnsureComp<ChangelingLimbComponent>(limb);
+            else
+                RemCompDeferred<ChangelingLimbComponent>(limb);
+        }
+    }
 }

--- a/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.Damage.cs
+++ b/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.Damage.cs
@@ -1,6 +1,7 @@
 using Content.Shared._FarHorizons.LimbDamage.Components;
 using Content.Shared.Body;
 using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Systems;
 using Content.Shared.Rejuvenate;
 using Content.Shared.Weapons.Hitscan.Components;
 using Content.Shared.Weapons.Hitscan.Events;
@@ -17,6 +18,7 @@ public partial class LimbDamageSystem
         SubscribeLocalEvent<DamageableLimbComponent, OrganGotInsertedEvent>(OnDamageableLimbInserted);
         SubscribeLocalEvent<DamageableLimbComponent, RejuvenateEvent>(OnRejuvenate);
         SubscribeLocalEvent<DamageableLimbComponent, BodyRelayedEvent<RejuvenateEvent>>(OnRejuvenateBody);
+        SubscribeLocalEvent<ChangelingLimbComponent, DamageChangedEvent>(OnChangelingLimbDamaged);
     }
 
     private void OnRejuvenate(Entity<DamageableLimbComponent> ent, ref RejuvenateEvent args) => 
@@ -53,5 +55,15 @@ public partial class LimbDamageSystem
         if (!TryComp<DamageableComponent>(args.Target, out var bodyDamageable)) return;
         var damageable = EnsureComp<DamageableComponent>(ent);
         _damageable.SetDamageModifierSetId((ent, damageable), bodyDamageable.DamageModifierSetId);
+    }
+    
+    private void OnChangelingLimbDamaged(Entity<ChangelingLimbComponent> ent, ref DamageChangedEvent args)
+    {
+        if (!args.DamageIncreased)
+            return;
+
+        var allDamage = _damageable.GetPositiveDamage((ent, args.Damageable));
+        allDamage.ClampMax(ent.Comp.DamageCap);
+        _damageable.SetDamage((ent, args.Damageable), allDamage);
     }
 }

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -115,11 +115,11 @@
       - mask
       - ears
   - type: DamageableLimb
-    bodyDamageFactor: 1.0 # Note: Making it >100% was a bad idea
+    bodyDamageFactor: 0.4 # Non vital variant is used for diona and slime, same 40% as legs/arms
     missChance: 0.35 # 35% chance to miss
     redirectChance: 0.2 # 20% chance to hit torso
-    scatterHitChance: 0.05
-    aimedTowardsScatterHitChance: 0.05 # Have to aim directly at them for headshots, bud
+    scatterHitChance: 0 # Disable chance to miss head without aiming
+    aimedTowardsScatterHitChance: 0
   - type: LimbDamageEffect
     effects:
       - effect: !type:LimbEffectDetach
@@ -145,6 +145,8 @@
   abstract: true
   components:
   - type: VitalOrgan
+  - type: DamageableLimb
+    bodyDamageFactor: 1.0 # 100% damage transfer for vital heads
   # Far Horizons end
 
 - type: entity


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
fix for limb damage to prevent easy RR of lings

## Why we need to add this
bugfix

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- tweak: You can no longer hit anyone's head with indirect attack
- tweak: Slimes and dionas (as well as their protogen variants) have no organs in their heads. Therefore attacking their heads is no different from attacking their arms or legs
- fix: Ling limbs can't be gibbed to match how their bodies work