### PR TITLE
Security Module Description Quickfix

### DIFF
--- a/Resources/Locale/en-US/_FarHorizons/silicones/borg-module.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/silicones/borg-module.ftl
@@ -1,0 +1,1 @@
+borg-type-security = [color= #337dd6]Security Cyborgs[/color]

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -8,6 +8,9 @@
     - BorgModuleSecurity
   - type: Sprite
     sprite: _FarHorizons/Objects/Specific/Robotics/borgmodule.rsi
+  - type: BorgModule
+    borgFitTypes:
+    - borg-type-security
   - type: Item
     inhandVisuals: # todo fix these
       left:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adjusts the description of security borg modules to correctly state the frame they can be slotted in.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The description of the security borg modules incorrectly state that they fit into any frame
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Before
<img width="400" height="174" alt="Content Client_7qHxZ01iqA" src="https://github.com/user-attachments/assets/ccad43e9-f873-4c91-ad97-bb46dde016c4" />
After
<img width="392" height="169" alt="image" src="https://github.com/user-attachments/assets/af487157-3a01-417a-ad3d-d4b0947a74e9" />
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: KarusKardin
- fix: Fixed Security Borg Modules description incorrectly stating they can be fit into any frame.
