### PR TITLE
Fixes regarding collision checks with the new prediction system.

### DIFF
--- a/Content.Shared/_FarHorizons/Vehicles/SharedVehicleSystem.cs
+++ b/Content.Shared/_FarHorizons/Vehicles/SharedVehicleSystem.cs
@@ -356,7 +356,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
         if (args.OurFixture.Hard && args.OtherFixture.Hard)
         {
             if (_gameTiming.IsFirstTimePredicted)
-                _audio.PlayPvs(ent.Comp.SoundHit, ent.Owner, AudioParams.Default.WithVariation(0.125f).WithVolume(-0.125f));
+                _audio.PlayPredicted(ent.Comp.SoundHit, ent.Owner, null, AudioParams.Default.WithVariation(0.125f).WithVolume(-0.125f));
                 
             if(TryComp<VehicleBuckleComponent>(ent.Owner, out var vbComp) && TryComp<BuckleComponent>(rider, out var buckleComp))
             {
@@ -383,7 +383,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
             if(!HasComp<DamageableComponent>(args.OtherEntity) || HasComp<PacifiedComponent>(ent.Owner)) return; 
 
             if (_gameTiming.IsFirstTimePredicted)
-                _audio.PlayPvs(ent.Comp.SoundHit, ent.Owner, AudioParams.Default.WithVariation(0.125f).WithVolume(-0.125f));
+                _audio.PlayPredicted(ent.Comp.SoundHit, ent.Owner, null, AudioParams.Default.WithVariation(0.125f).WithVolume(-0.125f));
 
             DamageTypePrototype? _blunt = _prototypes.Index<DamageTypePrototype>(_bluntname);
             DamageSpecifier? _damage = new(_blunt, Math.Clamp(10 * (1 + (0.5 * speed / crashingSpeed)), 10, 20));
@@ -430,6 +430,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
 
     private void OnToggleTrunk(Entity<VehicleComponent> ent, ref ToggleTrunkActionEvent args)
     {
+        if (!_gameTiming.IsFirstTimePredicted) return;
         if(args.Handled) return;
         if(!TryComp<LockComponent>(ent.Owner, out var lockComp)) return;
         _adminLogger.Add(Database.LogType.Action, Database.LogImpact.Low, $"{ToPrettyString(args.Performer)} toggled the trunk from {ToPrettyString(ent.Owner)}");
@@ -438,12 +439,12 @@ public abstract partial class SharedVehicleSystem : EntitySystem
         if(!_lock.IsLocked(ent.Owner))
         {
             _popup.PopupPredicted(Loc.GetString("vehicle-toggle-trunk-open"), ent.Owner, null, PopupType.Small);
-            _audio.PlayPvs(lockComp.UnlockSound, ent.Owner);
+            _audio.PlayPredicted(lockComp.UnlockSound, ent.Owner, null);
         }
         else
         {
             _popup.PopupPredicted(Loc.GetString("vehicle-toggle-trunk-close"), ent.Owner, null, PopupType.Small);
-            _audio.PlayPvs(lockComp.LockSound, ent.Owner);
+            _audio.PlayPredicted(lockComp.LockSound, ent.Owner, null);
         }
         args.Handled = true;
     }
@@ -508,11 +509,14 @@ public abstract partial class SharedVehicleSystem : EntitySystem
     {
         args.CanDrop = !ent.Comp.isBroken;
         args.Handled = true;
-    }
+    } 
 
     public void TryUpdateVisualState(Entity<VehicleComponent?> entity)
     {
         if (!Resolve(entity.Owner, ref entity.Comp))
+            return;
+
+        if (_gameTiming.ApplyingState)
             return;
 
         var finalState = VehicleVisualState.Normal;
@@ -564,10 +568,11 @@ public abstract partial class SharedVehicleSystem : EntitySystem
     
     private void OnHornActionEvent(Entity<VehicleComponent> ent, ref HornActionEvent args)
     {
+        if (!_gameTiming.IsFirstTimePredicted) return;
         if (args.Handled || ent.Comp.HornSound == null)
             return;
         if(ent.Comp.Rider == null) return;
-        _audio.PlayPvs(ent.Comp.HornSound, ent.Owner);
+        _audio.PlayPredicted(ent.Comp.HornSound, ent.Owner, null);
         args.Handled = true;
     }
 

--- a/Content.Shared/_FarHorizons/Vehicles/SharedVehicleSystem.cs
+++ b/Content.Shared/_FarHorizons/Vehicles/SharedVehicleSystem.cs
@@ -333,6 +333,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
 
     private void HandleCollide(Entity<VehicleComponent> ent, ref StartCollideEvent args)
     {
+        if(!_gameTiming.IsFirstTimePredicted) return;
         if(ent.Comp.Rider == null) return;
         var rider = ent.Comp.Rider.Value;
         
@@ -450,6 +451,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
     private void OnDamageChanged(EntityUid ent, VehicleComponent component, DamageChangedEvent args)
     {
         if(!args.DamageIncreased || args.DamageDelta == null) return;
+        if(args.Origin == ent) return;
         if (TryComp<VehicleContainerComponent>(ent, out var vcComp)
             && vcComp.PassengerSlot.ContainedEntities.Count != 0)
         {


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Basically fixes an issue where the vehicle was considered the damaged party added a check against it. Also found a bug where if I didnt request the system to verify it was the first time it predicted the setting of the speed after a collision it could cause a bug where client speed would be 4000 but server speed would be normal aka a desync.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Fixes

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: AthenaAI
- fix: A bug relating to client and server desync movement speed.
- fix: A bug with vehicles trying to damage themselves after running over someone.
