### PR TITLE
Make people fall asleep instead of being weirdly awake with SSD Command

### DIFF
--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -11,7 +11,6 @@ using Content.Shared._Starlight.SSDIndicator.Events;
 using Content.Shared.DoAfter;
 using Content.Shared.Movement.Events;
 using Content.Shared.Starlight.CryoTeleportation;
-using System.Runtime; /// Far Horizons
 // Starlight-end
 
 namespace Content.Shared.SSDIndicator;
@@ -92,7 +91,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
 
     #region Starlight
 
-    private void OnSSDTry(EntityUid uid, SSDIndicatorComponent component, SSDTryDoAfterEvent args) => SSD(uid, component);
+    private void OnSSDTry(EntityUid uid, SSDIndicatorComponent component, SSDTryDoAfterEvent args) => SSD(uid, component, true);
 
     /// <summary>
     /// Attempts to set the entity as SSD.
@@ -120,14 +119,16 @@ public sealed class SSDIndicatorSystem : EntitySystem
         return true;
     }
 
-    private void SSD(EntityUid uid, SSDIndicatorComponent component)
+    // Far Horizons
+    private void SSD(EntityUid uid, SSDIndicatorComponent component, bool sleepNow = false)
     {
         component.IsSSD = true;
 
         if (_icSsdSleep)
             component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
 
-        component.FallAsleepTime = _timing.CurTime; /// Far Horizons
+        if (sleepNow)
+          component.FallAsleepTime = _timing.CurTime; // Far Horizons
         
         Dirty(uid, component);
     }

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -127,7 +127,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
         if (_icSsdSleep)
             component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
 
-        component.FallAsleepTime = _timing.CurTime;
+        component.FallAsleepTime = _timing.CurTime; /// Far Horizons
         
         Dirty(uid, component);
     }

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -11,7 +11,7 @@ using Content.Shared._Starlight.SSDIndicator.Events;
 using Content.Shared.DoAfter;
 using Content.Shared.Movement.Events;
 using Content.Shared.Starlight.CryoTeleportation;
-using System.Runtime;
+using System.Runtime; /// Far Horizons
 // Starlight-end
 
 namespace Content.Shared.SSDIndicator;

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -91,7 +91,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
 
     #region Starlight
 
-    private void OnSSDTry(EntityUid uid, SSDIndicatorComponent component, SSDTryDoAfterEvent args) => SSD(uid, component, true);
+    private void OnSSDTry(EntityUid uid, SSDIndicatorComponent component, SSDTryDoAfterEvent args) => SSD(uid, component, true); // Far Horizons
 
     /// <summary>
     /// Attempts to set the entity as SSD.

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared._Starlight.SSDIndicator.Events;
 using Content.Shared.DoAfter;
 using Content.Shared.Movement.Events;
 using Content.Shared.Starlight.CryoTeleportation;
+using System.Runtime;
 // Starlight-end
 
 namespace Content.Shared.SSDIndicator;
@@ -126,6 +127,8 @@ public sealed class SSDIndicatorSystem : EntitySystem
         if (_icSsdSleep)
             component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
 
+        component.FallAsleepTime = _timing.CurTime;
+        
         Dirty(uid, component);
     }
 

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -91,7 +91,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
 
     #region Starlight
 
-    private void OnSSDTry(EntityUid uid, SSDIndicatorComponent component, SSDTryDoAfterEvent args) => SSD(uid, component, true); // Far Horizons
+    private void OnSSDTry(EntityUid uid, SSDIndicatorComponent component, SSDTryDoAfterEvent args) => SSD(uid, component, true); /// Far Horizons
 
     /// <summary>
     /// Attempts to set the entity as SSD.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
SSD command actually makes you go to sleep.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Tests were upset with Starlight sleep command, so a line was removed. Well it made people weirdly awake but with ssd zzz's.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/ef71808a-dd80-47a5-966f-86bb71fff361


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi and their minion CorruptOmega
- tweak: Put people using the /ssd command actually to sleep.
