### PR TITLE
fix limb targetting shader in compatibility renderer mode

### DIFF
--- a/Resources/Textures/_FarHorizons/Shaders/limb_targetting.swsl
+++ b/Resources/Textures/_FarHorizons/Shaders/limb_targetting.swsl
@@ -8,25 +8,25 @@ uniform highp float lineFreq;
 uniform highp float colorFactor;
 
 void fragment() {
-	vec2 size = TEXTURE_PIXEL_SIZE * width;
-	float alpha = texture(TEXTURE, UV).a;
+	highp vec2 size = TEXTURE_PIXEL_SIZE * width;
+	highp float alpha = texture(TEXTURE, UV).a;
 
 	if (alpha == 0.0) {
 		discard;
 	}
 
-	float a_up = texture(TEXTURE, UV + vec2(0.0, -size.y)).a;
-	float a_down = texture(TEXTURE, UV + vec2(0.0, size.y)).a;
-	float a_left = texture(TEXTURE, UV + vec2(-size.x, 0.0)).a;
-	float a_right = texture(TEXTURE, UV + vec2(size.x, 0.0)).a;
-	float min_neighbor_alpha = min(min(a_up, a_down), min(a_left, a_right));
+	highp float a_up = texture(TEXTURE, UV + vec2(0.0, -size.y)).a;
+	highp float a_down = texture(TEXTURE, UV + vec2(0.0, size.y)).a;
+	highp float a_left = texture(TEXTURE, UV + vec2(-size.x, 0.0)).a;
+	highp float a_right = texture(TEXTURE, UV + vec2(size.x, 0.0)).a;
+	highp float min_neighbor_alpha = min(min(a_up, a_down), min(a_left, a_right));
 
 	if (min_neighbor_alpha < 1.0) {
 		COLOR = vec4(outerColor, 1.0);
 	} else {
 		if (innerFill) {
-			float scanline = sin((UV.y * lineFreq) - (TIME * lineSpeed));
-			vec3 final_color = innerColor;
+			highp float scanline = sin((UV.y * lineFreq) - (TIME * lineSpeed));
+			highp vec3 final_color = innerColor;
 			if (scanline < 0.0) {
 				final_color *= colorFactor;
 			}


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
apparently there is an option to run game with older GLSL versions that some people use, and my new shader broke it. No functionality afftected otherwise.

## Why we need to add this
fix

## Media (Video/Screenshots)
<img width="1266" height="753" alt="image" src="https://github.com/user-attachments/assets/30b8732a-ef82-4a19-982c-0a98b859c61d" />
People play like this?

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- fix: Fixed limb targeting shader being unable to compile on old GLSL versions (compatibility renderer mode)