### PR TITLE
Small tweaks - CMO medical door remote, Detective Wawa shoulder holster

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -317,6 +317,7 @@
     - id: AutoMenderBurnFilled #Starlight
     - id: AutoMenderBruteFilled #Starlight
     - id: CMOLicense #STARLIGHT
+    - id: DoorRemoteMedical #Far Horizons
     - id: PrintedDocumentGreenshiftAlert #SL
       conditions: #SL
       - !type:GamemodeCondition #SL

--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: BaseItem
   id: DoorRemoteDefault
-  name: door remote
+  name: Door Remote #Far Horizons - The Great Capitalization Crusade
   description: A gadget which can open and bolt doors remotely.
   abstract: true
   components:
@@ -62,7 +62,7 @@
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]
   id: DoorRemoteCommand
-  name: command door remote
+  name: Command Door Remote #Far Horizons - The Great Capitalization Crusade
   components:
   - type: Sprite
     layers:
@@ -79,7 +79,7 @@
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]
   id: DoorRemoteCustom
-  name: custom door remote
+  name: Custom Door Remote #Far Horizons - The Great Capitalization Crusade
   description: A gadget which can open and bolt doors remotely. This advanced variant does not have built-in access, instead inheriting the ID access of the user.
   components:
   - type: Sprite
@@ -96,7 +96,7 @@
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]
   id: DoorRemoteSecurity
-  name: security door remote
+  name: Security Door Remote #Far Horizons - The Great Capitalization Crusade
   components:
   - type: Sprite
     layers:
@@ -112,7 +112,7 @@
 - type: entity
   parent: [DoorRemoteDefault, BaseSecurityCommandContraband]
   id: DoorRemoteArmory
-  name: armory door remote
+  name: Armory Door Remote #Far Horizons - The Great Capitalization Crusade
   components:
   - type: Sprite
     layers:
@@ -128,7 +128,7 @@
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]
   id: DoorRemoteService
-  name: service door remote
+  name: Service Door Remote #Far Horizons - The Great Capitalization Crusade
   components:
   - type: Sprite
     layers:
@@ -144,7 +144,7 @@
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]
   id: DoorRemoteResearch
-  name: research door remote
+  name: Research Door Remote #Far Horizons - The Great Capitalization Crusade
   components:
   - type: Sprite
     layers:
@@ -160,7 +160,7 @@
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]
   id: DoorRemoteCargo
-  name: cargo door remote
+  name: Cargo Door Remote #Far Horizons - The Great Capitalization Crusade
   components:
   - type: Sprite
     layers:
@@ -176,7 +176,7 @@
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]
   id: DoorRemoteMedical
-  name: medical door remote
+  name: Medical Door Remote #Far Horizons - The Great Capitalization Crusade
   components:
   - type: Sprite
     layers:
@@ -192,7 +192,7 @@
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]
   id: DoorRemoteEngineering
-  name: engineering door remote
+  name: Engineering Door Remote #Far Horizons - The Great Capitalization Crusade
   components:
   - type: Sprite
     layers:
@@ -208,7 +208,7 @@
 - type: entity
   parent: [DoorRemoteCanEletrifyDoors, BaseCommandContraband]
   id: DoorRemoteAll
-  name: super door remote
+  name: Super Door Remote #Far Horizons - The Great Capitalization Crusade
   description: A gadget which can open and bolt doors remotely. This one works even on wooden doors!
   suffix: Admeme
   components:
@@ -236,7 +236,7 @@
 - type: entity
   parent: [DoorRemoteCanEletrifyDoors, BaseXenoborgContraband]
   id: DoorRemoteXenoborg
-  name: xenoborg door remote
+  name: Xenoborg Door Remote #Far Horizons - The Great Capitalization Crusade
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Rig/webbings.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Rig/webbings.yml
@@ -68,6 +68,7 @@
   - type: Tag
     tags: 
     - Webbing
+    - ShoulderHolster #So Detective Wawa can have this.
 
 - type: entity
   parent: ClothingBeltWebbingBase

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/NPCs/scurret.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/NPCs/scurret.yml
@@ -82,6 +82,9 @@
       - ScurretSign
       - Sign
       - GalacticCommon
+    - type: Inventory
+      speciesId: scurret
+      templateId: detectivewawa
     - type: Loadout
       prototypes: [ DetectiveScurretGear ]
     - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/_FarHorizons/InventoryTemplates/smart_scurret_inventory_template.yml
+++ b/Resources/Prototypes/_FarHorizons/InventoryTemplates/smart_scurret_inventory_template.yml
@@ -72,14 +72,11 @@
     slotGroup: MainHotbar
     stripTime: 3
     uiWindowPos: 2,4
-    strippingWindowPos: 1,6
+    strippingWindowPos: 2,6
     dependsOn: outerClothing
     dependsOnComponents:
     - type: AllowSuitStorage
     displayName: Tank Storage
-    whitelist:
-      tags:
-      - GasTank
   - name: belt
     slotTexture: belt
     fullTextureName: template_small
@@ -89,6 +86,106 @@
     uiWindowPos: 3,2
     strippingWindowPos: 0,5
     displayName: Belt
+  - name: outerClothing
+    slotTexture: suit
+    slotFlags: OUTERCLOTHING
+    stripTime: 6
+    uiWindowPos: 0,3
+    strippingWindowPos: 1,3
+    displayName: Suit
+
+#region Detective Wawa
+- type: inventoryTemplate
+  id: detectivewawa
+  slots:
+  - name: ears
+    slotTexture: ears
+    slotFlags: EARS
+    stripTime: 3
+    uiWindowPos: 0,2
+    strippingWindowPos: 1,2
+    displayName: Ears
+  - name: gloves
+    slotTexture: gloves
+    slotFlags: GLOVES
+    uiWindowPos: 0,1
+    strippingWindowPos: 2,2
+    displayName: Gloves
+  - name: eyes
+    slotTexture: glasses
+    slotFlags: EYES
+    stripTime: 3
+    uiWindowPos: 0,3
+    strippingWindowPos: 1,0
+    displayName: Eyes
+  - name: head
+    slotTexture: head
+    slotFlags: HEAD
+    uiWindowPos: 1,3
+    strippingWindowPos: 0,0
+    displayName: Head
+  - name: mask
+    slotTexture: mask
+    slotFlags: MASK
+    uiWindowPos: 1,2
+    strippingWindowPos: 1,1
+    displayName: Mask
+  - name: neck
+    slotTexture: neck
+    slotFlags: NECK
+    uiWindowPos: 1,1
+    strippingWindowPos: 0,1
+    displayName: Neck
+  - name: jumpsuit
+    slotTexture: uniform
+    slotFlags: INNERCLOTHING
+    stripTime: 6
+    uiWindowPos: 1,0
+    strippingWindowPos: 0,2
+    displayName: Jumpsuit
+  - name: id
+    slotTexture: id
+    fullTextureName: template_small
+    slotFlags: IDCARD
+    slotGroup: SecondHotbar
+    stripTime: 6
+    uiWindowPos: 2,1
+    strippingWindowPos: 2,4
+    displayName: ID
+  - name: suitstorage
+    slotTexture: suit_storage
+    slotFlags:   SUITSTORAGE
+    slotGroup: MainHotbar
+    stripTime: 3
+    uiWindowPos: 2,0
+    strippingWindowPos: 2,5
+    dependsOn: outerClothing
+    dependsOnComponents:
+    - type: AllowSuitStorage
+    displayName: Suit Storage
+  - name: suitstorage2
+    slotTexture: tank
+    slotFlags:   SUITSTORAGE
+    slotGroup: MainHotbar
+    stripTime: 3
+    uiWindowPos: 2,4
+    strippingWindowPos: 2,6
+    dependsOn: outerClothing
+    dependsOnComponents:
+    - type: AllowSuitStorage
+    displayName: Tank Storage
+  - name: rig
+    slotTexture: rig
+    fullTextureName: template_small
+    slotFlags: RIG
+    slotGroup: SecondHotbar
+    stripTime: 6
+    uiWindowPos: 3,1
+    strippingWindowPos: 1,5
+    displayName: Chest Rig
+    whitelist:
+      tags:
+      - ShoulderHolster
   - name: outerClothing
     slotTexture: suit
     slotFlags: OUTERCLOTHING

--- a/Resources/Prototypes/_FarHorizons/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/_FarHorizons/Roles/Jobs/Fun/misc_startinggear.yml
@@ -9,6 +9,6 @@
     jumpsuit: ClothingUniformJumpsuitDetective
     outerClothing: ClothingOuterVestDetective
     ears: ClothingHeadsetSecurity
-    belt: ClothingBeltHolsterScugFilled
+    rig: ClothingBeltHolsterScugFilled
     eyes: ClothingEyesGlassesSecurity
     gloves: ClothingHandsGlovesForensic

--- a/Resources/Prototypes/_FarHorizons/tags.yml
+++ b/Resources/Prototypes/_FarHorizons/tags.yml
@@ -277,6 +277,9 @@
   id: SegwayKeys
 
 - type: Tag
+  id: ShoulderHolster
+  
+- type: Tag
   id: SyndicateSegwayKeys
 
 - type: Tag


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adding Medical Door Remote to CMO's locker fill.

Changed Detective Wawa's stuff to have shoulder holster spawn in rig slot and be the only option for it. You can now place down the holster, or put it back on when removed. Made it so nothing else could go into this rig slot (no adding armor to det scurret).
Also made their gas tank slot actually show in the stripping window in the same location as other species.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Medical Door Remote - https://discord.com/channels/1407077238876147783/1489742882159071302
Shoulder Holster - https://discord.com/channels/1407077238876147783/1489942419221778522

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
### Medical Door Remote in Locker
<img width="662" height="676" alt="image" src="https://github.com/user-attachments/assets/bd95cda9-edfb-4974-9adb-23717d725492" />

### Detective Wawa Shoulder Holster

https://github.com/user-attachments/assets/7b64a7d7-d4c3-4616-9b47-0629370298dc

<img width="230" height="609" alt="image" src="https://github.com/user-attachments/assets/88239809-ed02-4be5-a4ab-5877b2829e42" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: CorruptOmega
- tweak: CMO now has a medical door remote in locker again. Apparently when they are handed the remote and told "Don't forget to bring this to station" they are more likely to not take it with them. NanoTrasen now supplies in locker instead.
- tweak: Detective Wawa kept getting tangled up with their shoulder holster where their belt was supposed to be. We have corrected their silly antics by attaching the holster to their torso instead. Silly little goober.
