### PR TITLE
Making some species not miserable to play.

### DIFF
--- a/Content.Shared/Rootable/RootableComponent.cs
+++ b/Content.Shared/Rootable/RootableComponent.cs
@@ -66,7 +66,7 @@ public sealed partial class RootableComponent : Component
     /// The movement speed modifier for when rooting is active.
     /// </summary>
     [DataField]
-    public float SpeedModifier = 0.8f;
+    public float SpeedModifier = 0.9f; //FH
 
     /// <summary>
     /// Sound that plays when rooting is toggled.

--- a/Resources/Prototypes/Body/Species/diona.yml
+++ b/Resources/Prototypes/Body/Species/diona.yml
@@ -176,9 +176,9 @@
   - type: BodyEmotes
     soundsId: DionaBodyEmotes
   - type: IgnoreKudzu
-  - type: IgniteOnHeatDamage
-    fireStacks: 1
-    threshold: 12
+#  - type: IgniteOnHeatDamage #FH it sucks so bad
+#    fireStacks: 1
+#    threshold: 12
   - type: GibAction
     actionPrototype: DionaGibAction
     allowedStates:

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -176,7 +176,7 @@
     Blunt: 0.6
     Slash: 1.2
     Piercing: 1.2
-    Cold: 1.5
+    Cold: 1.3 #FH
     Poison: 0.8
 
 - type: damageModifierSet
@@ -211,8 +211,8 @@
   coefficients:
     Blunt: 0.7
     Slash: 0.8
-    Heat: 1.5
-    Shock: 1.2
+    Heat: 1.3 #FH
+#    Shock: 1.2 #FH plants dont get fucked up by shock tho?.. who came up with this? they actually have a higher tolerance
 
 - type: damageModifierSet
   id: Moth # Slightly worse at everything but cold

--- a/Resources/Prototypes/_FarHorizons/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_FarHorizons/Damage/modifier_sets.yml
@@ -48,7 +48,7 @@
     Blunt: 0.7
     Slash: 1.2
     Piercing: 1.2
-    Cold: 1.4 # Metal's not exactly insulating, but better than nothing.
+    Cold: 1.3 # Metal's not exactly insulating, but better than nothing.
     Poison: 0.8
 
 - type: damageModifierSet
@@ -58,7 +58,7 @@
     Cold: 0.4
     Heat: 1.15
     Cellular: 0.25
-    Bloodloss: 1.35
+#    Bloodloss: 1.35
     Shock: 1.25
     Radiation: 1.3
     Blunt: 1.1
@@ -109,9 +109,9 @@
   coefficients:
     Blunt: 0.8
     Slash: 0.9
-    Heat: 1.5
+    Heat: 1.25
     Cold: 0.5
-    Shock: 1.25
+    Shock: 1.15 #Plants actually have a higher tolerance so im lowerin.
 
 - type: damageModifierSet
   id: ProtoCyclops
@@ -128,7 +128,7 @@
     Shock: 1.25
     Blunt: 1.1
     Cold: 0.3 # Two reasons- Literally cold blooded, as in, blood below freezing, and supreme insulation. 
-    Heat: 1.4
+    Heat: 1.2
 
 #region Vehicles
 

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Back/duffel.yml
@@ -12,7 +12,7 @@
 # Engi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: ClothingBackpackDuffel
   id: ClothingDuffelBagChiefEngineer
   name: Chief Engineer's Duffel Bag
   description: It's a backpack especially designed for use in a spacious environment.

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Back/satchel.yml
@@ -12,7 +12,7 @@
 # Engi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: ClothingBackpackSatchel
   id: ClothingSatchelChiefEngineer
   name: Chief Engineer's Satchel
   description: It's a backpack especially designed for use in a spacious environment.

--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -1,8 +1,8 @@
 - type: damageModifierSet
-  id: Avali # Not as good as thick fur like the vulps, but still rather insulating.
+  id: Avali # Not as good as thick fur like the vulps, but still rather insulating. - modified to actually be on par with vulps
   coefficients:
-    Cold: 0.6
-    Heat: 1.4
+    Cold: 0.8 #FH
+    Heat: 1.2 #FH
 
 - type: damageModifierSet
   id: TerrorSpider
@@ -25,7 +25,7 @@
     Cold: 0.75
     Heat: 1.2
     Cellular: 0.25
-    Bloodloss: 1.35
+#    Bloodloss: 1.35 #FH ok so, this caused them to actually take way more bloodloss than intended, they already take 100% more bloodloss even without this modifier.
     Shock: 1.25
     Radiation: 1.3
 

--- a/Resources/ServerInfo/Guidebook/Mobs/Avali.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Avali.xml
@@ -11,13 +11,13 @@
 
   ## Racial Features
 
-  - Receive [color=#ffa500]40% more fire damage[/color] and [color=#1e90ff]40% less cold damage[/color].
+  - Receive [color=#ffa500]20% more heat damage[/color] and [color=#1e90ff]20% less cold damage[/color]. <!-- FH edit -->
   - Can stand in tempatures of up to [color=#1e90ff]-50c before taking cold damage[/color].
   - Deal [color=red]6.25[/color] slashing damage with claws.
   - Can fly in Zero-G.
   - Slightly faster.
   - [color=#ffbc48]Nanite Technology![/color] Can encase themselves in a [color=#ffbc48]Nanite Shell[/color] to heal most common types of damage.
-  - Can talk over [color=#ffbc48]The Nexus with +N.[/color]
+  - Can talk over [color=#ffbc48]The Nexus with :x.[/color]  <!-- FH edit -->
   - 2x Hunger rate, stay fed!
   - Can only eat meat-related food items (including organs) and pills.
   - Heal airloss from Ammonia and Amoxla but..

--- a/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
@@ -5,14 +5,14 @@
     <GuideEntityEmbed Entity="MobDiona" Caption=""/>
   </Box>
 
-  They can't wear shoes, but are not slowed by Kudzu.
+  They can't wear shoes, instead, are able to become rooted to the ground for a slight slowdown. <!-- FH edit -->
+  They are not slowed by Kudzu. <!-- FH edit -->
   They get hungry and thirsty slower.
   Their "blood" is tree sap and can't be metabolised from Iron.
-  Being plants, Weed Killer poisons them, while Robust Harvest heals them (but not without risk when overused!)
+  Being plants, Weed Killer poisons them, while Robust Harvest heals them and allows them to regrow lost limbs. (but not without risk when overused!) <!-- FH edit -->
 
   They take [color=#1e90ff]30% less Blunt damage and 20% less Slash damage[/color];
-  but [color=#ffa500]50% more Heat damage, 20% more Shock damage, and they can easily
-  catch on fire when receiving enough Heat damage from *any* source.[/color]
+  but [color=#ffa500]30% more Heat damage. <!-- FH edit -->
 
   ## Make Like A Tree And Leave
   <Box>

--- a/Resources/ServerInfo/Guidebook/Mobs/Resomi.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Resomi.xml
@@ -16,7 +16,7 @@
   ## Nexus Technological Hivemind
   Due to a implant that all Resomi are given at birth, they have a neural connection to the Nexus.
   This allows them to communicate with others of their species over a technological network.
-  Use the [color=orange]+n[/color] prefix in chat to send a message to all Resomi anonymously.
+  Use the [color=orange]:x[/color] prefix in chat to send a message to all Resomi anonymously. <!-- FH edit -->
 
   ## Age and names
   Resomi are hatched from eggs, and enter eligibility for CC and NT employment at the age of [color=yellow]23[/color] standard galactic years.  

--- a/Resources/ServerInfo/Guidebook/Mobs/SlimePerson.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/SlimePerson.xml
@@ -14,12 +14,12 @@
   Laspii  have an [bold]internal 2x3 storage inventory[/bold] inside of their slime membrane. Anyone can see what's inside and take it out of you without asking, <!--Starlight-->
   so be careful.
 
-  Laspii have roughly [color=#1e90ff]double[/color] regeneration compared to other humanoids and can regenerate from far greater wounds up to [color=#1e90ff]triple[/color] compared to others.
+  Laspii have roughly [color=#1e90ff]double[/color] regeneration compared to other humanoids and can regenerate from far more severe wounds compared to others. [color=#1e90ff]Due to their anatomy they can even reattach any of their lost limbs.[/color]   <!-- FH edit -->
 
   Their slime "blood" can not be regenerated from Iron. Slime Blood is technically a source of
   moderately filling food for other species, although drinking the blood of your coworkers is usually frowned upon.
   They suffocate 80% slower, but take pressure damage 9% faster. This makes them by far the species most capable to survive in hard vacuum. For a while.
 
-  They take [color=#1e90ff]40% less Blunt damage[/color], but [color=#ffa500]50% more Cold damage, 20% more Slash damage and 20% more Piercing damage[/color].
+  They take [color=#1e90ff]40% less Blunt damage[/color], but [color=#ffa500]30% more Cold damage, 20% more Slash damage and 20% more Piercing damage[/color].  <!-- FH edit -->
 
 </Document>

--- a/Resources/ServerInfo/_FarHorizons/Guidebook/Mobs/SubMobs/ProtoAvali.xml
+++ b/Resources/ServerInfo/_FarHorizons/Guidebook/Mobs/SubMobs/ProtoAvali.xml
@@ -10,7 +10,7 @@
   ## Changes from the "Protogen" base species.
   Values listed replace "Protogen" values of that damage catagory, they do not stack ontop of them.
 
-  - Receive [color=#ffa500]40% more heat damage[/color] and [color=#1e90ff]70% less cold damage[/color].
+  - Receive [color=#ffa500]20% more heat damage[/color] and [color=#1e90ff]70% less cold damage[/color].
 
   With the advent of advanced cybernetics and with some help from their extensive body modifications, Proto-Avali have been able to get rid of their inability to properly process most foods and as such can enjoy and metabolise just about any food under the sun. 
   

--- a/Resources/ServerInfo/_FarHorizons/Guidebook/Mobs/SubMobs/ProtoDionae.xml
+++ b/Resources/ServerInfo/_FarHorizons/Guidebook/Mobs/SubMobs/ProtoDionae.xml
@@ -10,7 +10,7 @@
   ## Changes from the "Protogen" base species.
   Values listed replace "Protogen" values of that damage catagory, they do not stack ontop of them.
 
-  - Receive [color=#ffa500]50% more heat damage[/color], [color=#FF3636]20% less blunt damage[/color] and [color=#B9BF93]10% less slash damage[/color].
+  - Receive [color=#ffa500]25% more heat damage[/color], [color=#FF3636]20% less blunt damage[/color] and [color=#B9BF93]10% less slash damage[/color].
 
 [color=red]WARNING![/color] Splitting into nymphs as a Proto-Dionae will [color=red]turn you back into a normal Diona![/color] Choose carefully, is it really worth it to lose your cybernetics?
 </Document>

--- a/Resources/ServerInfo/_FarHorizons/Guidebook/Mobs/SubMobs/ProtoKin.xml
+++ b/Resources/ServerInfo/_FarHorizons/Guidebook/Mobs/SubMobs/ProtoKin.xml
@@ -17,5 +17,5 @@
 
   ## Racial Features
 
-  - Receive [color=#ffa500]15% more heat damage[/color], [color=#800000]35% more bloodloss damage[/color], [color=#BD5902]30% more radiation damage[/color], [color=#C8FF75]75% less genetic damage[/color] and [color=#1e90ff]60% less cold damage[/color].
+  - Receive [color=#ffa500]15% more heat damage[/color], [color=#800000]100% more bloodloss damage[/color], [color=#BD5902]30% more radiation damage[/color], [color=#C8FF75]75% less genetic damage[/color] and [color=#1e90ff]60% less cold damage[/color].
 </Document>

--- a/Resources/ServerInfo/_FarHorizons/Guidebook/Mobs/SubMobs/ProtoSlimePerson.xml
+++ b/Resources/ServerInfo/_FarHorizons/Guidebook/Mobs/SubMobs/ProtoSlimePerson.xml
@@ -10,7 +10,7 @@
   ## Changes from the "Protogen" base species.
   Values listed replace "Protogen" values of that damage catagory, they do not stack ontop of them.
 
-  - Receive [color=#592ed1]20% less poison damage[/color], [color=#ffa500]0% more heat damage[/color], [color=#FF3636]30% less blunt damage[/color], [color=#1e90ff]40% more cold damage[/color] and [color=#B9BF93]20% more slash/piercing damage[/color].
+  - Receive [color=#592ed1]20% less poison damage[/color], [color=#ffa500]0% more heat damage[/color], [color=#FF3636]30% less blunt damage[/color], [color=#1e90ff]30% more cold damage[/color] and [color=#B9BF93]20% more slash/piercing damage[/color].
 
   With the advent of advanced cybernetics and with some help from their extensive body modifications, Proto-Laspii have been able to get rid of their inability to properly breathe oxygen and as such can live in oxygen-rich enviroments without life support. 
 </Document>

--- a/Resources/ServerInfo/_StarLight/Guidebook/Mobs/Shadekin.xml
+++ b/Resources/ServerInfo/_StarLight/Guidebook/Mobs/Shadekin.xml
@@ -13,7 +13,7 @@
   ## Racial Features
 
   - Receive [color=#ffa500]20% more heat damage[/color] and [color=#1e90ff]25% less cold damage[/color] and [color=#1e90ff]75% less cellular damage[/color].
-  - Receive [color=#ffa500]170% more bloodloss damage (and heal bloodloss damage 75% slower)[/color] and [color=#ffa500]30% more radiation damage[/color] and [color=#ffa500]25% more shock damage[/color].
+  - Receive [color=#ffa500]100% more bloodloss damage (and heal bloodloss damage 75% slower)[/color] and [color=#ffa500]30% more radiation damage[/color] and [color=#ffa500]25% more shock damage[/color]. <!-- FH edit -->
   - They do not breathe and thus require no air.
   - Flashes stun time are doubled.
   - Deal [color=red]5[/color] slashing damage with claws.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Removes completely debilitating weaknesses from species that previously discouraged people from even trying them, you shouldnt be discouraged from playing a race because a practice laser sets you aflame, no more of that.

Also a couple of fixes.

## Why we need to add this
As explained above

The damage inspection in media is one laser shot for clarification.

## Media (Video/Screenshots)
<img width="693" height="780" alt="Screenshot 2026-04-04 161350" src="https://github.com/user-attachments/assets/d207839b-01d3-468f-8d51-c9264b71ee39" />
<img width="690" height="827" alt="Screenshot 2026-04-04 154604" src="https://github.com/user-attachments/assets/4b6c4b47-38dd-46d3-971b-88a890d8cb92" />
<img width="689" height="830" alt="Screenshot 2026-04-04 154618" src="https://github.com/user-attachments/assets/32658dba-dc20-4979-ac62-185c87d369d3" />
<img width="690" height="785" alt="Screenshot 2026-04-04 154646" src="https://github.com/user-attachments/assets/8a83ca02-92ee-430a-a771-80c625ede193" />
<img width="693" height="120" alt="Screenshot 2026-04-04 154736" src="https://github.com/user-attachments/assets/b1367d94-7148-44a2-818c-6a02a9733abc" />
<img width="693" height="807" alt="Screenshot 2026-04-04 154750" src="https://github.com/user-attachments/assets/dbe18dd6-ec55-4245-9aeb-1be789a94c77" />
<img width="404" height="354" alt="Screenshot 2026-04-04 154840" src="https://github.com/user-attachments/assets/b81d6254-b093-4941-b9ce-9c800a986808" />
<img width="515" height="359" alt="Screenshot 2026-04-04 154845" src="https://github.com/user-attachments/assets/fe165672-83d5-4935-91d4-7fd9ea8b9d41" />
<img width="430" height="485" alt="Screenshot 2026-04-04 155010" src="https://github.com/user-attachments/assets/353f3e9c-d74d-4d47-a2a3-9aa1e9c4b789" />
<img width="459" height="516" alt="Screenshot 2026-04-04 155023" src="https://github.com/user-attachments/assets/37d23cc6-bde8-459a-8772-31d7e6cdd3f6" />
<img width="451" height="528" alt="Screenshot 2026-04-04 155036" src="https://github.com/user-attachments/assets/b052ab43-e2ea-497a-9f76-0a0afe43e978" />
<img width="625" height="654" alt="Screenshot 2026-04-04 160805" src="https://github.com/user-attachments/assets/205ba8d8-1a7a-4cba-a020-38c967cc9c52" />
<img width="638" height="631" alt="Screenshot 2026-04-04 160812" src="https://github.com/user-attachments/assets/244ae5de-85d4-46cb-b1e4-37c0ac870b8c" />
<img width="632" height="634" alt="Screenshot 2026-04-04 160820" src="https://github.com/user-attachments/assets/3ce20d4b-d2e3-4f00-a909-e4adab6bbff3" />
<img width="684" height="148" alt="Screenshot 2026-04-04 160913" src="https://github.com/user-attachments/assets/0b751ff3-7af8-40e3-b1d0-55be4f13d608" />
<img width="1375" height="645" alt="Screenshot 2026-04-04 161518" src="https://github.com/user-attachments/assets/d5051ee5-903e-4e94-ac81-9db004713b18" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**

:cl: Roro
- add: Made Diona not horrific to play.
- remove: Removed Diona Flammability, it was needlessly debilitating and caused a literal practice laser to set you on fire, moths lost this aspect for a reason.
- remove: Removed Diona Shock Weakness.
- tweak: Diona Rooting Slowdown 20% -> 10%.
- tweak: Diona Heat Weakness 50% -> 30%.
- tweak: ProtoDiona Heat Weakness 50% -> 30%.
- tweak: ProtoDiona Shock Weakness 25% -> 15%.
- tweak: Avali Heat Weakness 40% -> 20% and Cold Resist 40% -> 20%.
- tweak: ProtoAvali Heat Weakness 40% -> 20%.
- tweak: Shadekin Bloodloss 270% -> 100% (you just take double bloodloss rather than over quintuple).
- tweak: ProtoKin Bloodloss 270% -> 100%.
- tweak: Laspii Cold Weakness 50% -> 30%.
- tweak: ProtoLaspii Cold Weakness 40% -> 30%.
- tweak: Edited Guidebook entries to reflect these changes.
- fix: Shadekin Guidebook formerly said they took 170% more bloodloss when in reality it was 270%, this has been fixed considering i changed their bloodloss level.
- fix: Fixed Chief Engineer Satchel and Duffel to have the correct storage amount.
- fix: Avali and Resomi Guidebook now gives the proper key for nexus.
