### PR TITLE
Topicals / limbs QoL

### DIFF
--- a/Content.Shared/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/Medical/Healing/HealingSystem.cs
@@ -112,7 +112,7 @@ public sealed class HealingSystem : EntitySystem
                 origin: args.Args.User);
         }
 
-        if (healed.Empty || !healingDoneToLimb)
+        if (!healingDoneToLimb)
             healingDone = _damageable.TryChangeDamage(target.Owner,
                 healing.Damage * _damageable.UniversalTopicalsHealModifier, out healed, true,
                 origin: args.Args.User);

--- a/Content.Shared/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/Medical/Healing/HealingSystem.cs
@@ -102,15 +102,22 @@ public sealed class HealingSystem : EntitySystem
 
         // Far Horizons start
         bool healingDone;
-        DamageSpecifier? healed;
-        if (args.TargettedLimb == null)
+        DamageSpecifier healed = new();
+
+        var healingDoneToLimb = false;
+        if (args.TargettedLimb != null)
+        {
+            healingDoneToLimb = _limbDamage.TryChangeLimbDamage(target.Owner, args.TargettedLimb.Value,
+                healing.Damage * _damageable.UniversalTopicalsHealModifier, out healed, true,
+                origin: args.Args.User);
+        }
+
+        if (healed.Empty || !healingDoneToLimb)
             healingDone = _damageable.TryChangeDamage(target.Owner,
                 healing.Damage * _damageable.UniversalTopicalsHealModifier, out healed, true,
                 origin: args.Args.User);
         else
-            healingDone = _limbDamage.TryChangeLimbDamage(target.Owner, args.TargettedLimb.Value,
-                healing.Damage * _damageable.UniversalTopicalsHealModifier, out healed, true,
-                origin: args.Args.User);
+            healingDone = healingDoneToLimb;
         // Far Horizons end
 
         if (!healingDone && healing.BloodlossModifier != 0)
@@ -194,7 +201,8 @@ public sealed class HealingSystem : EntitySystem
         if (origin != null)
         {
             var limbTarget = _limbDamage.GetCurrentValidTarget(target.Owner, origin.Value);
-            if (limbTarget != null) return _limbDamage.LimbHasDamage(target.Owner, limbTarget.Value, healing.Comp);
+            if (limbTarget != null && _limbDamage.LimbHasDamage(target.Owner, limbTarget.Value, healing.Comp))
+                return true;
         }
         // Far Horizons end
 

--- a/Content.Shared/Repairable/RepairableSystem.cs
+++ b/Content.Shared/Repairable/RepairableSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Shared._FarHorizons.LimbDamage;
+using Content.Shared._FarHorizons.LimbDamage.Components;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Body;
 using Content.Shared.Damage;
@@ -133,12 +134,17 @@ public sealed partial class RepairableSystem : EntitySystem
             return;
 
         // Far Horizons start
-        var limbTarget = _limbDamage.GetCurrentValidTarget(ent.Owner, args.User);
-        var fullBodyDamage = _limbDamage.TryGetFullBodyDamage(ent.Owner);
-        var shouldHealLimb = limbTarget != null &&
+        ProtoId<OrganCategoryPrototype>? limbTarget = null;
+        var shouldHealLimb = false;
+        if (TryComp<LimbDamageableComponent>(ent.Owner, out var limbDamageable))
+        {
+            limbTarget = _limbDamage.GetCurrentValidTarget((ent.Owner, limbDamageable), args.User);
+            var fullBodyDamage = _limbDamage.TryGetFullBodyDamage((ent.Owner, null, limbDamageable));
+            shouldHealLimb = limbTarget != null &&
                              fullBodyDamage != null &&
                              fullBodyDamage.TryGetValue(limbTarget.Value, out var limbDamage) &&
                              limbDamage.Sum(p => (float)p.Value) > 0;
+        }
 
         // Only try repair the target if it is damaged
         if (!shouldHealLimb && _damageableSystem.GetTotalDamage(ent.Owner) == 0)

--- a/Content.Shared/Repairable/RepairableSystem.cs
+++ b/Content.Shared/Repairable/RepairableSystem.cs
@@ -1,11 +1,17 @@
+using System.Linq;
+using Content.Shared._FarHorizons.LimbDamage;
 using Content.Shared.Administration.Logs;
+using Content.Shared.Body;
+using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
+using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Tools.Systems;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Repairable;
@@ -16,6 +22,7 @@ public sealed partial class RepairableSystem : EntitySystem
     [Dependency] private readonly DamageableSystem _damageableSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly LimbDamageSystem _limbDamage = default!; // Far Horizons
 
     public override void Initialize()
     {
@@ -30,15 +37,27 @@ public sealed partial class RepairableSystem : EntitySystem
 
         if (!TryComp(ent.Owner, out DamageableComponent? damageable))
             return;
+        
+        // Far Horizons start
+        var target = args.TargettedLimb;
+        FixedPoint2 totalDamage;
+        if (target != null && _limbDamage.TryGetFullBodyDamage(ent.Owner) is { } fullBodyDamage &&
+            fullBodyDamage.TryGetValue(target.Value, out var limbDamage))
+            totalDamage = limbDamage.Sum(p => (float)p.Value);
+        else
+        {
+            totalDamage = _damageableSystem.GetTotalDamage((ent.Owner, damageable));
+            target = null;
+        }
+        // Far Horizons end
 
-        var totalDamage = _damageableSystem.GetTotalDamage((ent.Owner, damageable));
-        if (totalDamage == 0)
+        if (target == null && totalDamage == 0)
             return;
 
         if (ent.Comp.DamageValue != null)
             RepairSomeDamage((ent, damageable), ent.Comp.DamageValue.Value, args.User);
         else if (ent.Comp.Damage != null)
-            RepairSomeDamage((ent, damageable), ent.Comp.Damage, args.User);
+            RepairSomeDamage((ent, damageable), ent.Comp.Damage, args.User, target);
         else
             RepairAllDamage((ent, damageable), args.User);
 
@@ -66,6 +85,7 @@ public sealed partial class RepairableSystem : EntitySystem
     /// <param name="user">who is doing the repair</param>
     private void RepairSomeDamage(Entity<DamageableComponent?> ent, float damageAmount, EntityUid user)
     {
+        _limbDamage.HealAllEvenly(ent.Owner, damageAmount, origin: user);  // Far Horizons
         var damageChanged = _damageableSystem.HealEvenly(ent.Owner, damageAmount, origin: user);
         _adminLogger.Add(LogType.Healed, $"{ToPrettyString(user):user} repaired {ToPrettyString(ent.Owner):target} by {damageChanged.GetTotal()}");
     }
@@ -76,10 +96,23 @@ public sealed partial class RepairableSystem : EntitySystem
     /// <param name="ent">entity to be repaired</param>
     /// <param name="damageAmount">how much damage to repair (values have to be negative to repair)</param>
     /// <param name="user">who is doing the repair</param>
-    private void RepairSomeDamage(Entity<DamageableComponent?> ent, Damage.DamageSpecifier damageAmount, EntityUid user)
+    private void RepairSomeDamage(Entity<DamageableComponent?> ent, Damage.DamageSpecifier damageAmount, EntityUid user, ProtoId<OrganCategoryPrototype>? limbTarget = null)
     {
-        var damageChanged = _damageableSystem.ChangeDamage(ent.Owner, damageAmount, true, false, origin: user);
-        _adminLogger.Add(LogType.Healed, $"{ToPrettyString(user):user} repaired {ToPrettyString(ent.Owner):target} by {damageChanged.GetTotal()}");
+        // Far Horizons start
+        DamageSpecifier healed = new();
+
+        var healingDoneToLimb = false;
+        if (limbTarget != null)
+        {
+            healingDoneToLimb = _limbDamage.TryChangeLimbDamage(ent.Owner, limbTarget.Value,
+                damageAmount, out healed, true, false, origin: user);
+        }
+
+        if (healed.Empty || !healingDoneToLimb)
+            _damageableSystem.TryChangeDamage(ent.Owner, damageAmount, out healed, true, false, origin: user);
+        // Far Horizons end
+        
+        _adminLogger.Add(LogType.Healed, $"{ToPrettyString(user):user} repaired {ToPrettyString(ent.Owner):target} by {healed.GetTotal()}");
     }
 
     /// <summary>
@@ -89,6 +122,7 @@ public sealed partial class RepairableSystem : EntitySystem
     /// <param name="user">who is doing the repair</param>
     private void RepairAllDamage(Entity<DamageableComponent?> ent, EntityUid user)
     {
+        _limbDamage.ClearAllDamage(ent.Owner); // Far Horizons
         _damageableSystem.ClearAllDamage(ent);
         _adminLogger.Add(LogType.Healed, $"{ToPrettyString(user):user} repaired {ToPrettyString(ent.Owner):target} back to full health");
     }
@@ -98,9 +132,18 @@ public sealed partial class RepairableSystem : EntitySystem
         if (args.Handled)
             return;
 
+        // Far Horizons start
+        var limbTarget = _limbDamage.GetCurrentValidTarget(ent.Owner, args.User);
+        var fullBodyDamage = _limbDamage.TryGetFullBodyDamage(ent.Owner);
+        var shouldHealLimb = limbTarget != null &&
+                             fullBodyDamage != null &&
+                             fullBodyDamage.TryGetValue(limbTarget.Value, out var limbDamage) &&
+                             limbDamage.Sum(p => (float)p.Value) > 0;
+
         // Only try repair the target if it is damaged
-        if (_damageableSystem.GetTotalDamage(ent.Owner) == 0)
+        if (!shouldHealLimb && _damageableSystem.GetTotalDamage(ent.Owner) == 0)
             return;
+        // Far Horizons end
 
         #region Starlight
         var canRepair = new CanRepairEvent();
@@ -124,7 +167,7 @@ public sealed partial class RepairableSystem : EntitySystem
         }
 
         // Run the repairing doafter
-        args.Handled = _toolSystem.UseTool(args.Used, args.User, ent.Owner, delay, ent.Comp.QualityNeeded, new RepairDoAfterEvent(), ent.Comp.FuelCost);
+        args.Handled = _toolSystem.UseTool(args.Used, args.User, ent.Owner, delay, ent.Comp.QualityNeeded, new RepairDoAfterEvent(limbTarget), ent.Comp.FuelCost);
     }
 }
 
@@ -141,7 +184,12 @@ public readonly record struct RepairedEvent(Entity<RepairableComponent> Ent, Ent
 /// This doafter is repeated if the entity has <see cref="AutoDoAfter"> set to true and not all damage was fixed yet.
 /// </summary>
 [Serializable, NetSerializable]
-public sealed partial class RepairDoAfterEvent : SimpleDoAfterEvent;
+public sealed partial class RepairDoAfterEvent : SimpleDoAfterEvent
+{
+    public ProtoId<OrganCategoryPrototype>? TargettedLimb; // Far Horizons
+
+    public RepairDoAfterEvent(ProtoId<OrganCategoryPrototype>? limb = null) => TargettedLimb = limb; // Far Horizons
+}
 
 #region Starlight
 

--- a/Content.Shared/Repairable/RepairableSystem.cs
+++ b/Content.Shared/Repairable/RepairableSystem.cs
@@ -109,7 +109,7 @@ public sealed partial class RepairableSystem : EntitySystem
                 damageAmount, out healed, true, false, origin: user);
         }
 
-        if (healed.Empty || !healingDoneToLimb)
+        if (!healingDoneToLimb)
             _damageableSystem.TryChangeDamage(ent.Owner, damageAmount, out healed, true, false, origin: user);
         // Far Horizons end
         

--- a/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.API.cs
+++ b/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.API.cs
@@ -63,6 +63,15 @@ public partial class LimbDamageSystem
         return totalHealed;
     }
 
+    public void ClearAllDamage(Entity<LimbDamageableComponent?> target)
+    {
+        if (!Resolve(target, ref target.Comp, false)) return;
+
+        var allLimbs = GetAllDamageable(target);
+        foreach (var limb in allLimbs)
+            _damageable.ClearAllDamage((limb.Owner, limb.Comp.Damageable));
+    }
+
     public bool LimbHasDamage(Entity<LimbDamageableComponent?> target, ProtoId<OrganCategoryPrototype> targetLimb, HealingComponent healing)
     {
         var limb = GetAllDamageable(target).Where(p => p.Comp.Organ!.Category == targetLimb).FirstOrNull();


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
When targeting a limb that has no damage and using topicals - you will use them on body instead
Welding now repairs limbs and follows the same rule as topicals do

## Why we need to add this
QoL

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/b7cbdcde-e53b-4f5e-ab63-4d9a1bde1c3c


https://github.com/user-attachments/assets/d8f08eef-74c1-4fad-8bd2-36baa088770b



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- tweak: When targeting a limb that has no damage and using topicals, torso will be healed instead
- tweak: Welding can now repair limbs for protogens and IPC, and follows the same rules as topicals regarding limb targets