### PR TITLE
Traitor RP Objective Expansion Take 2

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_FarHorizons/Objectives/objectiveGroups.yml
@@ -17,3 +17,11 @@
     MaintsBarObjective: 1
     ReputationObjective: 0.5
     FalseOutbreakObjective: 0.75
+    SabotageScienceObjective: 1
+    SabotageEngineeringObjective: 1
+    SabotageMedicalObjective: 1
+    SabotageServiceObjective: 1
+    SabotageCargoObjective: 1
+    SabotageSecurityObjective: 1
+    DisruptCommandStructureObjective: 1
+    MakeMaintenanceUnsafeAgainObjective: 1

--- a/Resources/Prototypes/_FarHorizons/Objectives/traitor.yml
+++ b/Resources/Prototypes/_FarHorizons/Objectives/traitor.yml
@@ -1,3 +1,5 @@
+
+
 ## Corpsman
 
 - type: entity
@@ -20,3 +22,109 @@
   - type: Objective
     # You'll have to snatch this from the corpsman's cold, dead hands. Also they're always in sec.
     difficulty: 2
+# RP Objective Additions Begin -- Do not forget to add them to the objectivesGroup.yml in the respective FH folder
+
+- type: entity
+  parent: BaseStoryObjective
+  id: SabotageScienceObjective
+  name: Disrupt the research department by various means of sabotage, be it assaulting research staff, deliberately causing anomalies to go critical or stealing of artefacts to name a few examples.
+  description: Escape to centcomm after the shift, one of our agents will debrief you. Don't show up in cuffs.
+  components:
+    - type: Objective
+      difficulty: 1
+      unique: true
+      icon:
+        sprite: _Starlight/Interface/Misc/rp_icon.rsi
+        state: icon
+        
+- type: entity
+  parent: BaseStoryObjective
+  id: SabotageEngineeringObjective
+  name: Disrupt the engineering department by various means of sabotage, be it assaulting engineering staff, causing hullbreaches in maintenance and hallways etc. Do not cause mass cass by, for instance plasmaflood or releasing the engine. The station is a greater asset if operational.
+  description: Escape to centcomm after the shift, one of our agents will debrief you. Don't show up in cuffs.
+  components:
+    - type: Objective
+      difficulty: 1
+      unique: true
+      icon:
+        sprite: _Starlight/Interface/Misc/rp_icon.rsi
+        state: icon
+
+- type: entity
+  parent: BaseStoryObjective
+  id: SabotageMedicalObjective
+  name: Disrupt the medical department by various means of sabotage, be it assaulting medical staff, sabotaging prepared chemicals with toxins, power outages or other means not listed here. Avoid rendering medbay completely non-functional if possible, as it may be required for other agents success.
+  description: Escape to centcomm after the shift, one of our agents will debrief you. Don't show up in cuffs.
+  components:
+    - type: Objective
+      difficulty: 1
+      unique: true
+      icon:
+        sprite: _Starlight/Interface/Misc/rp_icon.rsi
+        state: icon     
+
+- type: entity
+  parent: BaseStoryObjective
+  id: SabotageServiceObjective
+  name: Disrupt the Service department by various means of sabotage, be it assaulting service staff, poisoning food and drinks with toxins and narcotics, mutating botany plants etc. 
+  description: Escape to centcomm after the shift, one of our agents will debrief you. Don't show up in cuffs.
+  components:
+    - type: Objective
+      difficulty: 1
+      unique: true
+      icon:
+        sprite: _Starlight/Interface/Misc/rp_icon.rsi
+        state: icon
+        
+- type: entity
+  parent: BaseStoryObjective
+  id: SabotageCargoObjective
+  name: Disrupt the local GSL branch by various means of sabotage, be it assaulting GSL staff, disrupting and intercepting deliveries, spreading rumors of "Blue Borgs" etc. Avoid rendering the GSL department fully inoperable, we may need them in the future.
+  description: Escape to centcomm after the shift, one of our agents will debrief you. Don't show up in cuffs.
+  components:
+    - type: Objective
+      difficulty: 1
+      unique: true
+      icon:
+        sprite: _Starlight/Interface/Misc/rp_icon.rsi
+        state: icon
+
+- type: entity
+  parent: BaseStoryObjective
+  id: SabotageSecurityObjective
+  name: Disrupt the local security team by various means of sabotage, be it assaulting security personnel, freeing inmates, spreading rumors about false threats, framing people for arrest as a few examples.
+  description: Escape to centcomm after the shift, one of our agents will debrief you. Don't show up in cuffs.
+  components:
+    - type: Objective
+      difficulty: 3
+      unique: true
+      icon:
+        sprite: _Starlight/Interface/Misc/rp_icon.rsi
+        state: icon
+
+- type: entity
+  parent: BaseStoryObjective
+  id: DisruptCommandStructureObjective
+  name: The command structure of this station requires to be disrupted for some time. Find means to hinder command at coordinating the efforts of this station. Avoid mass destruction.
+  description: Escape to centcomm after the shift, one of our agents will debrief you. Don't show up in cuffs.
+  components:
+    - type: Objective
+      difficulty: 2
+      unique: true
+      icon:
+        sprite: _Starlight/Interface/Misc/rp_icon.rsi
+        state: icon
+
+- type: entity
+  parent: BaseStoryObjective
+  id: MakeMaintenanceUnsafeAgainObjective
+  name: The maintenance tunnels are so safe on this station. Show them why the lone assistant should not venture into maintenance again. Make them fear the tunnels.
+  description: Escape to centcomm after the shift, one of our agents will debrief you. Don't show up in cuffs.
+  components:
+    - type: Objective
+      difficulty: 1.5
+      unique: true
+      icon:
+        sprite: _Starlight/Interface/Misc/rp_icon.rsi
+        state: icon
+# RP Objective Addition End


### PR DESCRIPTION
Yup its not wizdens Repo.

Short description

I wanted to do this like 2-3 months ago but IRL had other ideas. Adds a bunch of Traitor RP objective involving general sabotage of each department. Indicators to not cause mass destruction for engineering sabotage i.e. by engine release etc are added in the description of each.
Why we need to add this

Traitor objectives, are bland. Kill a bloke, steal a thing, RR a bloke and spread a manifesto that nobody reads anyways. These objective aim to give some more freedom to traitors in how they can engage with crew and the round.

Rolled "MakeMaintUnsecureAgain" and you are an engineer? Shocked grilles and deathtraps, minecraft iron door traps with turnstiles, hidden turrets etc.

Assistant with that? Be a maint slasher.

Rolled Sci Sabotage? Go ahead shoot up the eggheads half life style or dont and go crit their precious anomalies. Go on an artefact heist. Or fuck with power so they cant research. Mess with research queue to research something they don't need.

This puts alot of trust into antag players, I am aware of it, but should overall, provided they roll such objectives, lead to more interesting experiences for everyone. The only thing needed is creativity of the Antag.

## Media (Video/Screenshots)
<img width="902" height="328" alt="image" src="https://github.com/user-attachments/assets/bc6a703f-f3dd-434a-a154-2f794f6c8a41" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Irkalla
- add: Added fun. More RP objectives for Antags with a greater degree of freedom leading to hopefully more interesting and memorable rounds.
