### PR TITLE
More limb targetters

### DIFF
--- a/Resources/Prototypes/Body/Species/arachnid.yml
+++ b/Resources/Prototypes/Body/Species/arachnid.yml
@@ -151,6 +151,8 @@
   - type: TypingIndicator
     proto: spider
   - type: VisionOrganRequiredForVision # Far Horizons
+  - type: LimbDamageable # Far Horizons
+    proto: LimbTargetArachnid
 
 - type: entity
   parent: OrganBase

--- a/Resources/Prototypes/Body/Species/diona.yml
+++ b/Resources/Prototypes/Body/Species/diona.yml
@@ -193,6 +193,8 @@
     - Diona
   - type: VisionOrganRequiredForVision # Far Horizons
   - type: RegrowableLimbs #FarHorizons
+  - type: LimbDamageable # Far Horizons
+    proto: LimbTargetDiona
 
 - type: entity
   parent: OrganBase

--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -216,6 +216,8 @@
       - AnomalyHost
       - Moth
   - type: VisionOrganRequiredForVision # Far Horizons
+  - type: LimbDamageable # Far Horizons
+    proto: LimbTargetMoth
 
 - type: entity
   parent: OrganBase

--- a/Resources/Prototypes/Body/Species/reptilian.yml
+++ b/Resources/Prototypes/Body/Species/reptilian.yml
@@ -186,6 +186,8 @@
       - AnomalyHost
       - Reptilian
   - type: VisionOrganRequiredForVision # Far Horizons
+  - type: LimbDamageable # Far Horizons
+    proto: LimbTargetReptilian
 
 - type: entity
   parent: OrganBase

--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -272,6 +272,8 @@
       - AnomalyHost
       - Vox
   - type: Wagging
+  - type: LimbDamageable # Far Horizons
+    proto: LimbTargetVox
 
 - type: entity
   parent: OrganBase

--- a/Resources/Prototypes/Body/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Body/Species/vulpkanin.yml
@@ -234,6 +234,8 @@
       reagents:
       - ReagentId: SulfurBlood
         Quantity: 300
+  - type: LimbDamageable # Far Horizons
+    proto: LimbTargetVulp
 
 - type: entity
   parent: OrganBase

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1490,6 +1490,8 @@
   - type: Vocal
     sounds:
       Unsexed: MonkeySounds
+  - type: LimbDamageable
+    proto: LimbTargetMonkey
   #FarHorizons End
 
 
@@ -1667,6 +1669,8 @@
     name: ghost-role-information-kobold-name
     description: ghost-role-information-kobold-description
     rules: ghost-role-information-nonantagonist-rules
+  - type: LimbDamageable # Far Horizons
+    proto: LimbTargetKobold
 
 - type: entity
   name: kobold

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
@@ -407,7 +407,7 @@
       - gloves
       - shoes
   - type: LimbDamageable # Far Horizons
-    proto: LimbTargetHuman
+    proto: LimbTargetIPC
 
 - type: entity
   parent: BaseMentalAction

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
@@ -150,6 +150,8 @@
   abstract: true
   components:
   - type: VisionOrganRequiredForVision
+  - type: LimbDamageable
+    proto: LimbTargetProtogen
 
 #region VULPKANIN ####
 
@@ -230,6 +232,8 @@
       reagents:
       - ReagentId: SulfurBlood
         Quantity: 300
+  - type: LimbDamageable
+    proto: LimbTargetVulp
 
 #region VOX ####
 
@@ -351,6 +355,8 @@
       - Protogen
       - Vox
   - type: VisionOrganRequiredForVision
+  - type: LimbDamageable
+    proto: LimbTargetVox
 
 #region THAVEN ####
 
@@ -451,6 +457,8 @@
       - Protogen
       - Thaven
   - type: VisionOrganRequiredForVision
+  - type: LimbDamageable
+    proto: LimbTargetThaven
 
 #region LAPSI ####
 
@@ -862,7 +870,7 @@
         - gloves
         - shoes
     - type: LimbDamageable # Far Horizons
-      proto: LimbTargetHuman
+      proto: LimbTargetShadekin
 
 #region RESOMI ####
 
@@ -1089,6 +1097,8 @@
   - type: FlashModifier
     modifier: 2
   - type: VisionOrganRequiredForVision
+  - type: LimbDamageable
+    proto: LimbTargetResomi
 
 #region REPTILIAN ####
 
@@ -1184,6 +1194,8 @@
       - Reptilian
   - type: VisionOrganRequiredForVision
   - type: Wagging
+  - type: LimbDamageable
+    proto: LimbTargetReptilian
 
 #region MOTH ####
 
@@ -1326,6 +1338,8 @@
       - Protogen
       - Moth
   - type: VisionOrganRequiredForVision
+  - type: LimbDamageable
+    proto: LimbTargetMoth
 
 #region HUMAN ####
 
@@ -1516,6 +1530,8 @@
           32:
             sprite: _Starlight/Mobs/Species/Felionoid/displacement.rsi
             state: shoes
+  - type: LimbDamageable
+    proto: LimbTargetFelionoid
 
 #region DWARF ####
 
@@ -1720,6 +1736,8 @@
   - type: Rootable
   - type: VisionOrganRequiredForVision
   - type: RegrowableLimbs
+  - type: LimbDamageable
+    proto: LimbTargetDiona
 
 #region CYCLORITE ####
 
@@ -1858,6 +1876,8 @@
       - Protogen
       - Cyclorite
   - type: VisionOrganRequiredForVision
+  - type: LimbDamageable
+    proto: LimbTargetCyclorite
 
 #region AVALI ####
 
@@ -2008,6 +2028,8 @@
       critHealingModifier: 0.5
       stasisDamageReduction: 0.7
     - type: VisionOrganRequiredForVision
+    - type: LimbDamageable
+      proto: LimbTargetAvali
 
 #region ARACHNID ####
 
@@ -2089,3 +2111,5 @@
     templateId: protoarachnid
     speciesId: arachnid
   - type: VisionOrganRequiredForVision
+  - type: LimbDamageable
+    proto: LimbTargetArachnid

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
@@ -1398,6 +1398,8 @@
       - Protogen
       - Human
   - type: VisionOrganRequiredForVision
+  - type: LimbDamageable
+    proto: LimbTargetHuman
 
 #region FELIONOID ####
 
@@ -1608,6 +1610,8 @@
       - Protogen
       - Dwarf
   - type: VisionOrganRequiredForVision
+  - type: LimbDamageable
+    proto: LimbTargetHuman
 
 #region DIONA ####
 

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/resomi.yml
@@ -118,3 +118,5 @@
   - type: NightVision
   - type: FlashModifier
     modifier: 2
+  - type: LimbDamageable
+    proto: LimbTargetResomi

--- a/Resources/Prototypes/_FarHorizons/LimbDamage/targetters.yml
+++ b/Resources/Prototypes/_FarHorizons/LimbDamage/targetters.yml
@@ -1,3 +1,5 @@
+# Default human guy
+
 - type: limbTargetting
   id: LimbTargetHuman
   drawDebugBoxes: false
@@ -51,6 +53,1038 @@
       area: 0.25, 0.9, 0.5, 1
       sprites:
         - sprite: Mobs/Species/Human/parts.rsi
+          state: r_foot
+  labels:
+    - text: R
+      position: 0.05, 0.1
+    - text: L
+      position: 0.8, 0.1
+
+# Marr
+
+- type: limbTargetting
+  id: LimbTargetShadekin
+  drawDebugBoxes: false
+  limbs:
+    - limb: Head
+      area: 0.35, 0.1, 0.65, 0.3
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Shadekin/parts.rsi
+          state: head_m
+        - sprite: _Starlight/Mobs/Customization/shadekin/ears.rsi
+          state: aqua_default
+    - limb: ArmLeft
+      area: 0.65, 0.3, 0.8, 0.55
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Shadekin/parts.rsi
+          state: l_arm
+    - limb: ArmRight
+      area: 0.2, 0.3, 0.35, 0.55
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Shadekin/parts.rsi
+          state: r_arm
+    - limb: HandLeft
+      area: 0.65, 0.55, 0.8, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Shadekin/parts.rsi
+          state: l_hand
+    - limb: HandRight
+      area: 0.2, 0.55, 0.35, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Shadekin/parts.rsi
+          state: r_hand
+    - limb: LegLeft
+      area: 0.5, 0.7, 0.65, 0.9
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Shadekin/parts.rsi
+          state: l_leg
+    - limb: LegRight
+      area: 0.35, 0.7, 0.5, 0.9
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Shadekin/parts.rsi
+          state: r_leg
+    - limb: FootLeft
+      area: 0.5, 0.9, 0.75, 1
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Shadekin/parts.rsi
+          state: l_foot
+    - limb: FootRight
+      area: 0.25, 0.9, 0.5, 1
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Shadekin/parts.rsi
+          state: r_foot
+    - limb: Torso
+      area: 0.35, 0.3, 0.65, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Shadekin/parts.rsi
+          state: torso_m
+        - sprite: _Starlight/Mobs/Customization/shadekin/tails64x32.rsi
+          state: shadekin_big
+  labels:
+    - text: R
+      position: 0.05, 0.1
+    - text: L
+      position: 0.8, 0.1
+
+# Chirp
+
+- type: limbTargetting
+  id: LimbTargetResomi
+  drawDebugBoxes: false
+  limbs:
+    - limb: Head
+      area: 0.35, 0.15, 0.65, 0.45
+      sprites:
+        - sprite: Mobs/Species/Resomi/parts.rsi
+          state: head_m
+    - limb: ArmLeft
+      area: 0.6, 0.4, 0.8, 0.6
+      sprites:
+        - sprite: Mobs/Species/Resomi/parts.rsi
+          state: l_arm
+    - limb: ArmRight
+      area: 0.2, 0.4, 0.4, 0.6
+      sprites:
+        - sprite: Mobs/Species/Resomi/parts.rsi
+          state: r_arm
+    - limb: HandLeft
+      area: 0.65, 0.6, 0.8, 0.8
+      sprites:
+        - sprite: Mobs/Species/Resomi/parts.rsi
+          state: l_hand
+    - limb: HandRight
+      area: 0.2, 0.6, 0.35, 0.8
+      sprites:
+        - sprite: Mobs/Species/Resomi/parts.rsi
+          state: r_hand
+    - limb: LegLeft
+      area: 0.5, 0.7, 0.65, 0.9
+      sprites:
+        - sprite: Mobs/Species/Resomi/parts.rsi
+          state: l_leg
+    - limb: LegRight
+      area: 0.35, 0.7, 0.5, 0.9
+      sprites:
+        - sprite: Mobs/Species/Resomi/parts.rsi
+          state: r_leg
+    - limb: FootLeft
+      area: 0.5, 0.9, 0.75, 1
+      sprites:
+        - sprite: Mobs/Species/Resomi/parts.rsi
+          state: l_foot
+    - limb: FootRight
+      area: 0.25, 0.9, 0.5, 1
+      sprites:
+        - sprite: Mobs/Species/Resomi/parts.rsi
+          state: r_foot
+    - limb: Torso
+      area: 0.4, 0.45, 0.6, 0.7
+      sprites:
+        - sprite: Mobs/Species/Resomi/parts.rsi
+          state: torso_m
+  labels:
+    - text: R
+      position: 0.05, 0.1
+    - text: L
+      position: 0.8, 0.1
+
+# Chirp (2)
+
+- type: limbTargetting
+  id: LimbTargetAvali
+  drawDebugBoxes: false
+  limbs:
+    - limb: Torso
+      area: 0.35, 0.3, 0.65, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Avali/parts.rsi
+          state: torso_m
+        - sprite: _Starlight/Mobs/Customization/Avali/avali_parts.rsi
+          state: tail_avalibase
+    - limb: Head
+      area: 0.35, 0.1, 0.65, 0.3
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Avali/parts.rsi
+          state: head_m
+        - sprite: _Starlight/Mobs/Customization/Avali/avali_parts.rsi
+          state: ears_avalibase_primary
+        - sprite: _Starlight/Mobs/Customization/Avali/avali_parts.rsi
+          state: ears_avalibase_secondary
+    - limb: ArmLeft
+      area: 0.65, 0.3, 0.8, 0.55
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Avali/parts.rsi
+          state: l_arm
+    - limb: ArmRight
+      area: 0.2, 0.3, 0.35, 0.55
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Avali/parts.rsi
+          state: r_arm
+    - limb: HandLeft
+      area: 0.65, 0.55, 0.8, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Avali/parts.rsi
+          state: l_hand
+    - limb: HandRight
+      area: 0.2, 0.55, 0.35, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Avali/parts.rsi
+          state: r_hand
+    - limb: LegLeft
+      area: 0.5, 0.7, 0.65, 0.9
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Avali/parts.rsi
+          state: l_leg
+    - limb: LegRight
+      area: 0.35, 0.7, 0.5, 0.9
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Avali/parts.rsi
+          state: r_leg
+    - limb: FootLeft
+      area: 0.5, 0.9, 0.75, 1
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Avali/parts.rsi
+          state: l_foot
+    - limb: FootRight
+      area: 0.25, 0.9, 0.5, 1
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Avali/parts.rsi
+          state: r_foot
+  labels:
+    - text: R
+      position: 0.05, 0.1
+    - text: L
+      position: 0.8, 0.1
+
+# Chirp ?
+
+- type: limbTargetting
+  id: LimbTargetVox
+  drawDebugBoxes: false
+  limbs:
+    - limb: Torso
+      area: 0.35, 0.3, 0.65, 0.7
+      sprites:
+        - sprite: Mobs/Species/Vox/parts.rsi
+          state: torso
+    - limb: Head
+      area: 0.35, 0.1, 0.65, 0.3
+      sprites:
+        - sprite: Mobs/Species/Vox/parts.rsi
+          state: head
+    - limb: ArmLeft
+      area: 0.65, 0.3, 0.8, 0.55
+      sprites:
+        - sprite: Mobs/Species/Vox/parts.rsi
+          state: l_arm
+    - limb: ArmRight
+      area: 0.2, 0.3, 0.35, 0.55
+      sprites:
+        - sprite: Mobs/Species/Vox/parts.rsi
+          state: r_arm
+    - limb: HandLeft
+      area: 0.65, 0.55, 0.8, 0.7
+      sprites:
+        - sprite: Mobs/Species/Vox/parts.rsi
+          state: l_hand
+    - limb: HandRight
+      area: 0.2, 0.55, 0.35, 0.7
+      sprites:
+        - sprite: Mobs/Species/Vox/parts.rsi
+          state: r_hand
+    - limb: LegLeft
+      area: 0.5, 0.7, 0.65, 0.9
+      sprites:
+        - sprite: Mobs/Species/Vox/parts.rsi
+          state: l_leg
+    - limb: LegRight
+      area: 0.35, 0.7, 0.5, 0.9
+      sprites:
+        - sprite: Mobs/Species/Vox/parts.rsi
+          state: r_leg
+    - limb: FootLeft
+      area: 0.5, 0.9, 0.75, 1
+      sprites:
+        - sprite: Mobs/Species/Vox/parts.rsi
+          state: l_foot
+    - limb: FootRight
+      area: 0.25, 0.9, 0.5, 1
+      sprites:
+        - sprite: Mobs/Species/Vox/parts.rsi
+          state: r_foot
+  labels:
+    - text: R
+      position: 0.05, 0.1
+    - text: L
+      position: 0.8, 0.1
+
+# Bark
+
+- type: limbTargetting
+  id: LimbTargetVulp
+  drawDebugBoxes: false
+  limbs:
+    - limb: Torso
+      area: 0.35, 0.3, 0.65, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Vulpkanin/parts.rsi
+          state: torso_m
+        - sprite: _Starlight/Mobs/Customization/vulpkanin/tail_markings.rsi
+          state: vulp
+    - limb: Head
+      area: 0.35, 0.1, 0.65, 0.3
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Vulpkanin/parts.rsi
+          state: head_m
+        - sprite: _Starlight/Mobs/Customization/vulpkanin/ear_markings.rsi
+          state: vulp
+    - limb: ArmLeft
+      area: 0.65, 0.3, 0.8, 0.55
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Vulpkanin/parts.rsi
+          state: l_arm
+    - limb: ArmRight
+      area: 0.2, 0.3, 0.35, 0.55
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Vulpkanin/parts.rsi
+          state: r_arm
+    - limb: HandLeft
+      area: 0.65, 0.55, 0.8, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Vulpkanin/parts.rsi
+          state: l_hand
+    - limb: HandRight
+      area: 0.2, 0.55, 0.35, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Vulpkanin/parts.rsi
+          state: r_hand
+    - limb: LegLeft
+      area: 0.5, 0.7, 0.65, 0.9
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Vulpkanin/parts.rsi
+          state: l_leg
+    - limb: LegRight
+      area: 0.35, 0.7, 0.5, 0.9
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Vulpkanin/parts.rsi
+          state: r_leg
+    - limb: FootLeft
+      area: 0.5, 0.9, 0.75, 1
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Vulpkanin/parts.rsi
+          state: l_foot
+    - limb: FootRight
+      area: 0.25, 0.9, 0.5, 1
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Vulpkanin/parts.rsi
+          state: r_foot
+  labels:
+    - text: R
+      position: 0.05, 0.1
+    - text: L
+      position: 0.8, 0.1
+
+# Moff
+
+- type: limbTargetting
+  id: LimbTargetMoth
+  drawDebugBoxes: false
+  limbs:
+    - limb: Torso
+      area: 0.35, 0.3, 0.65, 0.7
+      sprites:
+        - sprite: Mobs/Species/Moth/parts.rsi
+          state: torso_m
+        - sprite: Mobs/Customization/Moth/moth_wings.rsi
+          state: default
+    - limb: Head
+      area: 0.35, 0.1, 0.65, 0.3
+      sprites:
+        - sprite: Mobs/Species/Moth/parts.rsi
+          state: head
+        - sprite: Mobs/Customization/Moth/moth_antennas.rsi
+          state: default
+    - limb: ArmLeft
+      area: 0.65, 0.3, 0.8, 0.55
+      sprites:
+        - sprite: Mobs/Species/Moth/parts.rsi
+          state: l_arm
+    - limb: ArmRight
+      area: 0.2, 0.3, 0.35, 0.55
+      sprites:
+        - sprite: Mobs/Species/Moth/parts.rsi
+          state: r_arm
+    - limb: HandLeft
+      area: 0.65, 0.55, 0.8, 0.7
+      sprites:
+        - sprite: Mobs/Species/Moth/parts.rsi
+          state: l_hand
+    - limb: HandRight
+      area: 0.2, 0.55, 0.35, 0.7
+      sprites:
+        - sprite: Mobs/Species/Moth/parts.rsi
+          state: r_hand
+    - limb: LegLeft
+      area: 0.5, 0.7, 0.65, 0.9
+      sprites:
+        - sprite: Mobs/Species/Moth/parts.rsi
+          state: l_leg
+    - limb: LegRight
+      area: 0.35, 0.7, 0.5, 0.9
+      sprites:
+        - sprite: Mobs/Species/Moth/parts.rsi
+          state: r_leg
+    - limb: FootLeft
+      area: 0.5, 0.9, 0.75, 1
+      sprites:
+        - sprite: Mobs/Species/Moth/parts.rsi
+          state: l_foot
+    - limb: FootRight
+      area: 0.25, 0.9, 0.5, 1
+      sprites:
+        - sprite: Mobs/Species/Moth/parts.rsi
+          state: r_foot
+  labels:
+    - text: R
+      position: 0.05, 0.1
+    - text: L
+      position: 0.8, 0.1
+
+# Spooder
+
+- type: limbTargetting
+  id: LimbTargetArachnid
+  drawDebugBoxes: false
+  limbs:
+    - limb: Torso
+      area: 0.35, 0.3, 0.65, 0.7
+      sprites:
+        - sprite: Mobs/Species/Arachnid/parts.rsi
+          state: torso
+        - sprite: Mobs/Customization/Arachnid/appendages.rsi
+          state: long_primary
+        - sprite: Mobs/Customization/Arachnid/appendages.rsi
+          state: long_secondary
+    - limb: Head
+      area: 0.35, 0.1, 0.65, 0.3
+      sprites:
+        - sprite: Mobs/Species/Arachnid/parts.rsi
+          state: head
+        - sprite: Mobs/Customization/Arachnid/chelicerae.rsi
+          state: downwards
+    - limb: ArmLeft
+      area: 0.65, 0.3, 0.8, 0.55
+      sprites:
+        - sprite: Mobs/Species/Arachnid/parts.rsi
+          state: l_arm
+    - limb: ArmRight
+      area: 0.2, 0.3, 0.35, 0.55
+      sprites:
+        - sprite: Mobs/Species/Arachnid/parts.rsi
+          state: r_arm
+    - limb: HandLeft
+      area: 0.65, 0.55, 0.8, 0.7
+      sprites:
+        - sprite: Mobs/Species/Arachnid/parts.rsi
+          state: l_hand
+    - limb: HandRight
+      area: 0.2, 0.55, 0.35, 0.7
+      sprites:
+        - sprite: Mobs/Species/Arachnid/parts.rsi
+          state: r_hand
+    - limb: LegLeft
+      area: 0.5, 0.7, 0.65, 0.9
+      sprites:
+        - sprite: Mobs/Species/Arachnid/parts.rsi
+          state: l_leg
+    - limb: LegRight
+      area: 0.35, 0.7, 0.5, 0.9
+      sprites:
+        - sprite: Mobs/Species/Arachnid/parts.rsi
+          state: r_leg
+    - limb: FootLeft
+      area: 0.5, 0.9, 0.75, 1
+      sprites:
+        - sprite: Mobs/Species/Arachnid/parts.rsi
+          state: l_foot
+    - limb: FootRight
+      area: 0.25, 0.9, 0.5, 1
+      sprites:
+        - sprite: Mobs/Species/Arachnid/parts.rsi
+          state: r_foot
+  labels:
+    - text: R
+      position: 0.05, 0.1
+    - text: L
+      position: 0.8, 0.1
+
+# Tree gaming
+
+- type: limbTargetting
+  id: LimbTargetDiona
+  drawDebugBoxes: false
+  limbs:
+    - limb: Torso
+      area: 0.35, 0.3, 0.65, 0.7
+      sprites:
+        - sprite: Mobs/Species/Diona/parts.rsi
+          state: torso
+    - limb: Head
+      area: 0.35, 0.1, 0.65, 0.3
+      sprites:
+        - sprite: Mobs/Species/Diona/parts.rsi
+          state: head
+    - limb: HandLeft
+      area: 0.65, 0.55, 0.8, 0.7
+      sprites:
+        - sprite: Mobs/Species/Diona/parts.rsi
+          state: l_hand
+    - limb: HandRight
+      area: 0.2, 0.55, 0.35, 0.7
+      sprites:
+        - sprite: Mobs/Species/Diona/parts.rsi
+          state: r_hand
+    - limb: ArmLeft
+      area: 0.65, 0.3, 0.8, 0.55
+      sprites:
+        - sprite: Mobs/Species/Diona/parts.rsi
+          state: l_arm
+    - limb: ArmRight
+      area: 0.2, 0.3, 0.35, 0.55
+      sprites:
+        - sprite: Mobs/Species/Diona/parts.rsi
+          state: r_arm
+    - limb: LegLeft
+      area: 0.5, 0.7, 0.65, 0.9
+      sprites:
+        - sprite: Mobs/Species/Diona/parts.rsi
+          state: l_leg
+    - limb: LegRight
+      area: 0.35, 0.7, 0.5, 0.9
+      sprites:
+        - sprite: Mobs/Species/Diona/parts.rsi
+          state: r_leg
+    - limb: FootLeft
+      area: 0.5, 0.9, 0.75, 1
+      sprites:
+        - sprite: Mobs/Species/Diona/parts.rsi
+          state: l_foot
+    - limb: FootRight
+      area: 0.25, 0.9, 0.5, 1
+      sprites:
+        - sprite: Mobs/Species/Diona/parts.rsi
+          state: r_foot
+  labels:
+    - text: R
+      position: 0.05, 0.1
+    - text: L
+      position: 0.8, 0.1
+
+# Lizor
+
+- type: limbTargetting
+  id: LimbTargetReptilian
+  drawDebugBoxes: false
+  limbs:
+    - limb: Torso
+      area: 0.35, 0.3, 0.65, 0.7
+      sprites:
+        - sprite: Mobs/Species/Reptilian/parts.rsi
+          state: torso_m
+        - sprite: Mobs/Customization/reptilian_parts.rsi
+          state: tail_smooth_primary
+        - sprite: Mobs/Customization/reptilian_parts.rsi
+          state: tail_smooth_secondary
+    - limb: Head
+      area: 0.35, 0.1, 0.65, 0.3
+      sprites:
+        - sprite: Mobs/Species/Reptilian/parts.rsi
+          state: head_m
+    - limb: ArmLeft
+      area: 0.65, 0.3, 0.8, 0.55
+      sprites:
+        - sprite: Mobs/Species/Reptilian/parts.rsi
+          state: l_arm
+    - limb: ArmRight
+      area: 0.2, 0.3, 0.35, 0.55
+      sprites:
+        - sprite: Mobs/Species/Reptilian/parts.rsi
+          state: r_arm
+    - limb: HandLeft
+      area: 0.65, 0.55, 0.8, 0.7
+      sprites:
+        - sprite: Mobs/Species/Reptilian/parts.rsi
+          state: l_hand
+    - limb: HandRight
+      area: 0.2, 0.55, 0.35, 0.7
+      sprites:
+        - sprite: Mobs/Species/Reptilian/parts.rsi
+          state: r_hand
+    - limb: LegLeft
+      area: 0.5, 0.7, 0.65, 0.9
+      sprites:
+        - sprite: Mobs/Species/Reptilian/parts.rsi
+          state: l_leg
+    - limb: LegRight
+      area: 0.35, 0.7, 0.5, 0.9
+      sprites:
+        - sprite: Mobs/Species/Reptilian/parts.rsi
+          state: r_leg
+    - limb: FootLeft
+      area: 0.5, 0.9, 0.75, 1
+      sprites:
+        - sprite: Mobs/Species/Reptilian/parts.rsi
+          state: l_foot
+    - limb: FootRight
+      area: 0.25, 0.9, 0.5, 1
+      sprites:
+        - sprite: Mobs/Species/Reptilian/parts.rsi
+          state: r_foot
+  labels:
+    - text: R
+      position: 0.05, 0.1
+    - text: L
+      position: 0.8, 0.1
+
+# Cat
+
+- type: limbTargetting
+  id: LimbTargetFelionoid
+  drawDebugBoxes: false
+  limbs:
+    - limb: Head
+      area: 0.35, 0.1, 0.65, 0.3
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Felionoid/parts.rsi
+          state: head
+    - limb: ArmLeft
+      area: 0.65, 0.3, 0.8, 0.55
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Felionoid/parts.rsi
+          state: l_arm
+    - limb: ArmRight
+      area: 0.2, 0.3, 0.35, 0.55
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Felionoid/parts.rsi
+          state: r_arm
+    - limb: HandLeft
+      area: 0.65, 0.55, 0.8, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Felionoid/parts.rsi
+          state: l_hand
+    - limb: HandRight
+      area: 0.2, 0.55, 0.35, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Felionoid/parts.rsi
+          state: r_hand
+    - limb: LegLeft
+      area: 0.5, 0.7, 0.65, 0.9
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Felionoid/parts.rsi
+          state: l_leg
+    - limb: LegRight
+      area: 0.35, 0.7, 0.5, 0.9
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Felionoid/parts.rsi
+          state: r_leg
+    - limb: FootLeft
+      area: 0.5, 0.9, 0.75, 1
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Felionoid/parts.rsi
+          state: l_foot
+    - limb: FootRight
+      area: 0.25, 0.9, 0.5, 1
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Felionoid/parts.rsi
+          state: r_foot
+    - limb: Torso
+      area: 0.35, 0.3, 0.65, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Felionoid/parts.rsi
+          state: torso
+        - sprite: _Starlight/Mobs/Customization/felionoid_parts.rsi
+          state: tail
+  labels:
+    - text: R
+      position: 0.05, 0.1
+    - text: L
+      position: 0.8, 0.1
+
+# Fish
+
+- type: limbTargetting
+  id: LimbTargetThaven
+  drawDebugBoxes: false
+  limbs:
+    - limb: Torso
+      area: 0.35, 0.3, 0.65, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Thaven/parts.rsi
+          state: torso
+    - limb: Head
+      area: 0.35, 0.1, 0.65, 0.3
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Thaven/parts.rsi
+          state: head
+    - limb: ArmLeft
+      area: 0.65, 0.3, 0.8, 0.55
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Thaven/parts.rsi
+          state: l_arm
+    - limb: ArmRight
+      area: 0.2, 0.3, 0.35, 0.55
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Thaven/parts.rsi
+          state: r_arm
+    - limb: HandLeft
+      area: 0.65, 0.55, 0.8, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Thaven/parts.rsi
+          state: l_hand
+    - limb: HandRight
+      area: 0.2, 0.55, 0.35, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Thaven/parts.rsi
+          state: r_hand
+    - limb: LegLeft
+      area: 0.5, 0.7, 0.65, 0.9
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Thaven/parts.rsi
+          state: l_leg
+    - limb: LegRight
+      area: 0.35, 0.7, 0.5, 0.9
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Thaven/parts.rsi
+          state: r_leg
+    - limb: FootLeft
+      area: 0.5, 0.9, 0.75, 1
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Thaven/parts.rsi
+          state: l_foot
+    - limb: FootRight
+      area: 0.25, 0.9, 0.5, 1
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Thaven/parts.rsi
+          state: r_foot
+  labels:
+    - text: R
+      position: 0.05, 0.1
+    - text: L
+      position: 0.8, 0.1
+
+# Uh, rock?
+
+- type: limbTargetting
+  id: LimbTargetCyclorite
+  drawDebugBoxes: false
+  limbs:
+    - limb: Torso
+      area: 0.35, 0.3, 0.65, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
+          state: torso
+    - limb: Head
+      area: 0.35, 0.1, 0.65, 0.3
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
+          state: head
+    - limb: ArmLeft
+      area: 0.65, 0.3, 0.8, 0.55
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
+          state: l_arm
+    - limb: ArmRight
+      area: 0.2, 0.3, 0.35, 0.55
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
+          state: r_arm
+    - limb: HandLeft
+      area: 0.65, 0.55, 0.8, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
+          state: l_hand
+    - limb: HandRight
+      area: 0.2, 0.55, 0.35, 0.7
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
+          state: r_hand
+    - limb: LegLeft
+      area: 0.5, 0.7, 0.65, 0.9
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
+          state: l_leg
+    - limb: LegRight
+      area: 0.35, 0.7, 0.5, 0.9
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
+          state: r_leg
+    - limb: FootLeft
+      area: 0.5, 0.9, 0.75, 1
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
+          state: l_foot
+    - limb: FootRight
+      area: 0.25, 0.9, 0.5, 1
+      sprites:
+        - sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
+          state: r_foot
+  labels:
+    - text: R
+      position: 0.05, 0.1
+    - text: L
+      position: 0.8, 0.1
+
+# Toaster
+
+- type: limbTargetting
+  id: LimbTargetIPC
+  drawDebugBoxes: false
+  limbs:
+    - limb: Torso
+      area: 0.35, 0.3, 0.65, 0.7
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+          state: torso_m
+    - limb: Head
+      area: 0.35, 0.1, 0.65, 0.3
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+          state: head_m
+    - limb: ArmLeft
+      area: 0.65, 0.3, 0.8, 0.55
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+          state: l_arm
+    - limb: ArmRight
+      area: 0.2, 0.3, 0.35, 0.55
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+          state: r_arm
+    - limb: HandLeft
+      area: 0.65, 0.55, 0.8, 0.7
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+          state: l_hand
+    - limb: HandRight
+      area: 0.2, 0.55, 0.35, 0.7
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+          state: r_hand
+    - limb: LegLeft
+      area: 0.5, 0.7, 0.65, 0.9
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+          state: l_leg
+    - limb: LegRight
+      area: 0.35, 0.7, 0.5, 0.9
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+          state: r_leg
+    - limb: FootLeft
+      area: 0.5, 0.9, 0.75, 1
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+          state: l_foot
+    - limb: FootRight
+      area: 0.25, 0.9, 0.5, 1
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+          state: r_foot
+  labels:
+    - text: R
+      position: 0.05, 0.1
+    - text: L
+      position: 0.8, 0.1
+
+# Toaster with ears
+
+- type: limbTargetting
+  id: LimbTargetProtogen
+  drawDebugBoxes: false
+  limbs:
+    - limb: Torso
+      area: 0.35, 0.3, 0.65, 0.7
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/Protogen/parts.rsi
+          state: torso_m
+        - sprite: _FarHorizons/Mobs/Customization/protogen/protogen.rsi
+          state: tail_protogen
+    - limb: Head
+      area: 0.35, 0.1, 0.65, 0.3
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/Protogen/parts.rsi
+          state: head_m
+        - sprite: _FarHorizons/Mobs/Customization/protogen/visor_shapes.rsi
+          state: visor
+        - sprite: _FarHorizons/Mobs/Customization/protogen/protogen.rsi
+          state: ears_protogen
+    - limb: ArmLeft
+      area: 0.65, 0.3, 0.8, 0.55
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/Protogen/parts.rsi
+          state: l_arm
+    - limb: ArmRight
+      area: 0.2, 0.3, 0.35, 0.55
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/Protogen/parts.rsi
+          state: r_arm
+    - limb: HandLeft
+      area: 0.65, 0.55, 0.8, 0.7
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/Protogen/parts.rsi
+          state: l_hand
+    - limb: HandRight
+      area: 0.2, 0.55, 0.35, 0.7
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/Protogen/parts.rsi
+          state: r_hand
+    - limb: LegLeft
+      area: 0.5, 0.7, 0.65, 0.9
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/Protogen/parts.rsi
+          state: l_leg
+    - limb: LegRight
+      area: 0.35, 0.7, 0.5, 0.9
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/Protogen/parts.rsi
+          state: r_leg
+    - limb: FootLeft
+      area: 0.5, 0.9, 0.75, 1
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/Protogen/parts.rsi
+          state: l_foot
+    - limb: FootRight
+      area: 0.25, 0.9, 0.5, 1
+      sprites:
+        - sprite: _FarHorizons/Mobs/Species/Protogen/parts.rsi
+          state: r_foot
+  labels:
+    - text: R
+      position: 0.05, 0.1
+    - text: L
+      position: 0.8, 0.1
+
+# Nearly 1000th line, why stop at this point. Monke
+
+- type: limbTargetting
+  id: LimbTargetMonkey
+  drawDebugBoxes: false
+  limbs:
+    - limb: Torso
+      area: 0.4, 0.3, 0.6, 0.55
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/monkey.rsi
+          state: torso
+        - sprite: _FarHorizons/Mobs/Animals/monkey.rsi
+          state: tail
+    - limb: Head
+      area: 0.35, 0.1, 0.65, 0.3
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/monkey.rsi
+          state: head
+    - limb: ArmLeft
+      area: 0.6, 0.3, 0.8, 0.48
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/monkey.rsi
+          state: l_arm
+    - limb: ArmRight
+      area: 0.2, 0.3, 0.4, 0.48
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/monkey.rsi
+          state: r_arm
+    - limb: HandLeft
+      area: 0.6, 0.48, 0.8, 0.6
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/monkey.rsi
+          state: l_hand
+    - limb: HandRight
+      area: 0.2, 0.48, 0.4, 0.6
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/monkey.rsi
+          state: r_hand
+    - limb: LegLeft
+      area: 0.5, 0.55, 0.65, 0.7
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/monkey.rsi
+          state: l_leg
+    - limb: LegRight
+      area: 0.35, 0.55, 0.5, 0.7
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/monkey.rsi
+          state: r_leg
+    - limb: FootLeft
+      area: 0.5, 0.7, 0.75, 0.8
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/monkey.rsi
+          state: l_foot
+    - limb: FootRight
+      area: 0.25, 0.7, 0.5, 0.8
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/monkey.rsi
+          state: r_foot
+  labels:
+    - text: R
+      position: 0.05, 0.1
+    - text: L
+      position: 0.8, 0.1
+
+# Kobol
+
+- type: limbTargetting
+  id: LimbTargetKobold
+  drawDebugBoxes: false
+  limbs:
+    - limb: Torso
+      area: 0.4, 0.3, 0.6, 0.55
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/kobold.rsi
+          state: torso
+        - sprite: _FarHorizons/Mobs/Animals/kobold.rsi
+          state: tail
+    - limb: Head
+      area: 0.35, 0.1, 0.65, 0.3
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/kobold.rsi
+          state: head
+    - limb: ArmLeft
+      area: 0.6, 0.3, 0.8, 0.48
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/kobold.rsi
+          state: l_arm
+    - limb: ArmRight
+      area: 0.2, 0.3, 0.4, 0.48
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/kobold.rsi
+          state: r_arm
+    - limb: HandLeft
+      area: 0.6, 0.48, 0.8, 0.6
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/kobold.rsi
+          state: l_hand
+    - limb: HandRight
+      area: 0.2, 0.48, 0.4, 0.6
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/kobold.rsi
+          state: r_hand
+    - limb: LegLeft
+      area: 0.5, 0.55, 0.65, 0.7
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/kobold.rsi
+          state: l_leg
+    - limb: LegRight
+      area: 0.35, 0.55, 0.5, 0.7
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/kobold.rsi
+          state: r_leg
+    - limb: FootLeft
+      area: 0.5, 0.7, 0.75, 0.8
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/kobold.rsi
+          state: l_foot
+    - limb: FootRight
+      area: 0.25, 0.7, 0.5, 0.8
+      sprites:
+        - sprite: _FarHorizons/Mobs/Animals/kobold.rsi
           state: r_foot
   labels:
     - text: R

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
@@ -165,5 +165,7 @@
       stasisDamageReduction: 0.7
       # FarHorizon edit end
     - type: VisionOrganRequiredForVision # Far Horizons
+    - type: LimbDamageable # Far Horizons
+      proto: LimbTargetAvali
 
 # Chirp!

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/cyclorites.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/cyclorites.yml
@@ -135,3 +135,5 @@
       - AnomalyHost
       - Cyclorite
   - type: VisionOrganRequiredForVision # Far Horizons
+  - type: LimbDamageable # Far Horizons
+    proto: LimbTargetCyclorite

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
@@ -126,3 +126,5 @@
             sprite: _Starlight/Mobs/Species/Felionoid/displacement.rsi
             state: shoes
   - type: VisionOrganRequiredForVision # Far Horizons
+  - type: LimbDamageable # Far Horizons
+    proto: LimbTargetFelionoid

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/shadekin.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/shadekin.yml
@@ -179,4 +179,4 @@
         - gloves
         - shoes
     - type: LimbDamageable # Far Horizons
-      proto: LimbTargetHuman
+      proto: LimbTargetShadekin

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/thaven.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/thaven.yml
@@ -126,3 +126,5 @@
       - AnomalyHost
       - Thaven
   - type: VisionOrganRequiredForVision # Far Horizons
+  - type: LimbDamageable # Far Horizons
+    proto: LimbTargetThaven


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
lost my mind and make limb targets for all except slime and dwarf since they have identical profile anyways

## Why we need to add this
style

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/161f12c1-8bab-434f-b17a-eff63a9d587f



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- add: Limb damage display in health analyzer UI will look different for each different species you scan
