### PR TITLE
Hemophilia Shadekin

### DIFF
--- a/Resources/Prototypes/_StarLight/Traits/disabilities.yml
+++ b/Resources/Prototypes/_StarLight/Traits/disabilities.yml
@@ -111,7 +111,7 @@
     statusEffects:
     - PainNumbnessTraitStatusEffect
 
-- type: trait
+- type: trait #FH Edit Allows Shadekin to have Hemophilia.
   id: Hemophilia
   name: trait-hemophilia-name
   description: trait-hemophilia-desc
@@ -121,11 +121,6 @@
   - !type:AddStatusEffect
     statusEffects:
     - StatusEffectHemophiliaTrait
-  requirements:
-    - !type:SpeciesRequirement
-      species:
-        - Shadekin
-      inverted: true
 
 - type: trait
   id: ImpairedMobility


### PR DESCRIPTION
Yes. Its not Wizdens Repo

## Short description
This simple PR allows Shadekin to suffer through Hemophilia again.

## Why we need to add this
Some Shadekin players enjoy suffering through excessive bleeding and its part of their character. Its pretty nice to have the option if somebody is looking for this.

## Media (Video/Screenshots)
n/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

:cl: Irkalla
- tweak: Changed nothing important. Shadekin can now pick Hemophilia trait again.
