### PR TITLE
Makes WarOps better

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -63,7 +63,7 @@ public sealed partial class NukeopsRuleComponent : Component
     ///     This amount of TC will be given to each nukie
     /// </summary>
     [DataField]
-    public int WarTcAmountPerNukie = 40;
+    public int WarTcAmountPerNukie = 80; ///FH Edit, let the nukies have their fun. And crew too!
 
     /// <summary>
     ///     Delay between war declaration and nuke ops arrival on station map. Gives crew time to prepare

--- a/Resources/Maps/_FarHorizons/Shuttles/KillerTamashi-Gamma-Weapon-Large.yml
+++ b/Resources/Maps/_FarHorizons/Shuttles/KillerTamashi-Gamma-Weapon-Large.yml
@@ -26,7 +26,7 @@ entities:
   - uid: 1
     components:
     - type: MetaData
-      name: grid
+      name: NT-641 "War"
     - type: Transform
       pos: -8.625,27.40625
       parent: invalid

--- a/Resources/Maps/_FarHorizons/Shuttles/KillerTamashi-Gamma-Weapon-Large.yml
+++ b/Resources/Maps/_FarHorizons/Shuttles/KillerTamashi-Gamma-Weapon-Large.yml
@@ -1,0 +1,2658 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 272.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 04/06/2026 08:30:00
+  entityCount: 364
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  2: Space
+  6: FloorDarkPlastic
+  3: FloorMetalDiamond
+  5: FloorReinforced
+  4: FloorWhitePlastic
+  1: Lattice
+  0: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      pos: -8.625,27.40625
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAQAAAAAAAAEAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAABQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAUAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAABgAAAAAAAAYAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAYAAAAAAAAGAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAGAAAAAAAABgAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAABgAAAAAAAAYAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: AgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: AgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAFAAAAAAAABAAAAAAAAAQAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAABQAAAAAAAAQAAAAAAAAEAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAA==
+          version: 7
+        -1,-1:
+          ind: -1,-1
+          tiles: AgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: TileHistory
+      chunkHistory: {}
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: ImplicitRoof
+    - type: NavMap
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelCornerNe
+          decals:
+            45: 5,3
+            79: 8,5
+        - node:
+            color: '#0082D9D3'
+            id: BrickTileSteelCornerNe
+          decals:
+            92: 8,0
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelCornerNw
+          decals:
+            78: 7,5
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelCornerSe
+          decals:
+            82: 8,2
+        - node:
+            color: '#0082D9D3'
+            id: BrickTileSteelCornerSe
+          decals:
+            94: 8,-2
+        - node:
+            color: '#0082D9D3'
+            id: BrickTileSteelCornerSw
+          decals:
+            95: 7,-2
+        - node:
+            color: '#0082D996'
+            id: BrickTileSteelEndN
+          decals:
+            139: 0,4
+            140: 3,4
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelEndS
+          decals:
+            65: 0,-2
+            66: 3,-2
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelInnerNe
+          decals:
+            34: 0,3
+            35: 3,3
+            47: 5,2
+            49: 5,0
+            55: -1,0
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelInnerNw
+          decals:
+            32: 0,3
+            33: 3,3
+            36: 5,0
+            54: -1,0
+        - node:
+            color: '#0082D996'
+            id: BrickTileSteelInnerNw
+          decals:
+            102: 7,2
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelInnerSe
+          decals:
+            38: -1,3
+            48: 5,2
+            73: 0,0
+            74: 3,0
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelInnerSw
+          decals:
+            42: -1,3
+            46: 5,3
+            72: 0,0
+            75: 3,0
+        - node:
+            color: '#0082D9D3'
+            id: BrickTileSteelInnerSw
+          decals:
+            97: 7,0
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelLineE
+          decals:
+            5: -1,1
+            6: -1,2
+            44: 5,1
+            61: 3,-1
+            67: 0,-1
+            80: 8,4
+            81: 8,3
+        - node:
+            color: '#0082D9D3'
+            id: BrickTileSteelLineE
+          decals:
+            93: 8,-1
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelLineN
+          decals:
+            14: 0,0
+            15: 1,0
+            16: 2,0
+            17: 3,0
+            18: 4,0
+            20: 4,3
+            21: 2,3
+            22: 1,3
+            23: -1,3
+        - node:
+            color: '#0082D996'
+            id: BrickTileSteelLineN
+          decals:
+            98: 6,0
+            101: 6,2
+            105: -2,3
+            106: -2,0
+        - node:
+            color: '#0082D9D3'
+            id: BrickTileSteelLineN
+          decals:
+            91: 7,0
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelLineS
+          decals:
+            7: 0,3
+            8: 1,3
+            9: 2,3
+            10: 3,3
+            11: 4,3
+            56: -1,0
+            68: 1,0
+            69: 2,0
+            70: 4,0
+            71: 5,0
+            83: 7,2
+        - node:
+            color: '#0082D996'
+            id: BrickTileSteelLineS
+          decals:
+            99: 6,0
+            100: 6,2
+            103: -2,0
+            104: -2,3
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelLineW
+          decals:
+            12: 5,2
+            13: 5,1
+            40: -1,2
+            41: -1,1
+            57: 0,-1
+            59: 3,-1
+            76: 7,3
+            77: 7,4
+        - node:
+            color: '#0082D9D3'
+            id: BrickTileSteelLineW
+          decals:
+            96: 7,-1
+        - node:
+            color: '#0082D996'
+            id: WarnFullGreyscale
+          decals:
+            107: -1,-1
+            108: -1,-2
+            109: 1,-1
+            110: 2,-1
+            111: 2,-2
+            112: 1,-2
+            113: 4,-1
+            114: 4,-2
+            115: 5,-1
+            116: 5,-2
+            117: 4,2
+            118: 4,1
+            119: 3,1
+            120: 2,1
+            121: 1,1
+            122: 0,1
+            123: 0,2
+            124: 1,2
+            125: 2,2
+            126: 3,2
+            127: 5,4
+            128: 4,4
+            129: 4,5
+            130: 5,5
+            132: 1,4
+            133: 1,5
+            134: 2,5
+            135: -1,5
+            136: -1,4
+            137: 3,5
+            138: 0,5
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 65535
+          0,-1:
+            0: 65280
+          -1,0:
+            0: 51340
+          0,1:
+            0: 255
+          -1,1:
+            0: 136
+            1: 1024
+          1,0:
+            0: 48959
+          1,1:
+            0: 187
+          1,-1:
+            0: 47872
+          2,0:
+            0: 4353
+            1: 52428
+          2,1:
+            0: 17
+            1: 204
+          2,-1:
+            0: 4352
+            1: 52224
+          3,1:
+            1: 256
+          -1,-1:
+            0: 34816
+            1: 64
+          3,-1:
+            1: 16
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
+        - volume: 2500
+          immutable: True
+          moles: {}
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: ExplosionAirtightGrid
+    - type: RadiationGridResistance
+- proto: AirAlarm
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 10
+      - 205
+      - 200
+      - 156
+    - type: Fixtures
+      fixtures: {}
+  - uid: 3
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 204
+      - 199
+      - 9
+      - 8
+      - 203
+      - 202
+      - 157
+      - 156
+    - type: Fixtures
+      fixtures: {}
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 201
+      - 11
+      - 206
+      - 157
+    - type: Fixtures
+      fixtures: {}
+- proto: AirCanister
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      anchored: True
+      pos: 3.5,-1.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: AirlockGlassShuttleSecurityPlastitanium
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+- proto: AirSensor
+  entities:
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+- proto: APCBasic
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 13
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+- proto: Breachinghammer
+  entities:
+  - uid: 17
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.53724885,2.5580645
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5268322,2.4747312
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 4.4597573,2.610148
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.501424,2.578898
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 21
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 10.5,3.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 11.5,5.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 10.5,2.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 11.5,2.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 11.5,1.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 11.5,0.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+- proto: ClothingBackpackDuffelSurgeryFilled
+  entities:
+  - uid: 142
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.261216,-1.4312322
+      parent: 1
+- proto: CombatKnife
+  entities:
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 4.6685567,2.422648
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 0.77676606,2.328898
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 4.553973,2.5893145
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 0.5475993,2.641398
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 4.31439,2.7872312
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 0.42259932,2.703898
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 4.397723,2.6830645
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 0.6934327,2.4434812
+      parent: 1
+- proto: ComfyChairBlue
+  entities:
+  - uid: 151
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,5.5
+      parent: 1
+- proto: computerBodyScanner
+  entities:
+  - uid: 152
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,0.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 153
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,5.5
+      parent: 1
+- proto: FHAirlockSecurity
+  entities:
+  - uid: 154
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+- proto: Firelock
+  entities:
+  - uid: 156
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+      - 2
+  - uid: 157
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+      - 4
+- proto: GasPassiveVentAlt2
+  entities:
+  - uid: 158
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 159
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 162
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 163
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeBendAlt1
+  entities:
+  - uid: 164
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeBendAlt2
+  entities:
+  - uid: 165
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 166
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 167
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 168
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeManifold
+  entities:
+  - uid: 170
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 171
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 172
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 173
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 174
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 175
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeStraightAlt1
+  entities:
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 178
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeStraightAlt2
+  entities:
+  - uid: 179
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 180
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 182
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 184
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 185
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 186
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 187
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 188
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 189
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 190
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 191
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 192
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 193
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 194
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeTJunctionAlt2
+  entities:
+  - uid: 195
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 196
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 197
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPortAlt1
+  entities:
+  - uid: 198
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 199
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 201
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubberAlt2
+  entities:
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 204
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 206
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GeneratorBasic20kW
+  entities:
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 208
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 209
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-2.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,1.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 219
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,4.5
+      parent: 1
+- proto: LeftArmCyberBulwark
+  entities:
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 7.124157,-1.2958155
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 7.3012404,-1.285399
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 7.4783235,-1.2749822
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: 7.6762404,-1.2645655
+      parent: 1
+- proto: MedkitAdvancedFilled
+  entities:
+  - uid: 224
+    components:
+    - type: Transform
+      pos: 1.3289156,2.3705645
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: 1.974749,2.3809812
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 2.568499,2.735148
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 1.3393322,2.735148
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 3.1726656,2.7455645
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 3.1726656,2.422648
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 1.9643322,2.735148
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 2.5580823,2.391398
+      parent: 1
+- proto: MedkitBruteFilled
+  entities:
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 8.705582,-1.597899
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 8.715998,-1.2437322
+      parent: 1
+- proto: OperatingTable
+  entities:
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 1
+- proto: PlastitaniumWindow
+  entities:
+  - uid: 235
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-2.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,1.5
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 245
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-0.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,4.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+- proto: RightArmCyberBulwark
+  entities:
+  - uid: 252
+    components:
+    - type: Transform
+      pos: 7.3949904,-1.6187322
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: 7.5824904,-1.6187322
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: 7.7595735,-1.629149
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      pos: 7.9470735,-1.6187322
+      parent: 1
+- proto: Screen
+  entities:
+  - uid: 361
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,6.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 362
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,6.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 363
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-2.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 364
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-2.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: ShelfArmoryLaserFilled
+  entities:
+  - uid: 256
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 257
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 258
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 259
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 260
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: ShelfArmoryMixedRifleFilled
+  entities:
+  - uid: 261
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 262
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 263
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 264
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 265
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: ShelfArmoryMixedShotgunFilled
+  entities:
+  - uid: 266
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 267
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 268
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 269
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 270
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: ShelfArmoryMixedSMGFilled
+  entities:
+  - uid: 271
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 272
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 273
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 274
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 275
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: SpawnMechDurand
+  entities:
+  - uid: 276
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+- proto: SubstationWallBasic
+  entities:
+  - uid: 277
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 1
+- proto: SuitStorageArmored
+  entities:
+  - uid: 278
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Security
+      - - Cadet
+- proto: SuitStorageEvaBulk
+  entities:
+  - uid: 280
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal: []
+  - uid: 282
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 283
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 291
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,5.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 1
+  - uid: 293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,3.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 295
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,2.5
+      parent: 1
+  - uid: 296
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,1.5
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,5.5
+      parent: 1
+- proto: ToolboxElectricalFilled
+  entities:
+  - uid: 299
+    components:
+    - type: Transform
+      pos: 3.7817168,2.714889
+      parent: 1
+  - uid: 300
+    components:
+    - type: Transform
+      pos: 3.7713,2.871139
+      parent: 1
+- proto: ToolboxMechanicalFilled
+  entities:
+  - uid: 301
+    components:
+    - type: Transform
+      pos: 3.80255,2.5378058
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      pos: 3.8129668,2.3190558
+      parent: 1
+- proto: WallPlastitanium
+  entities:
+  - uid: 303
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,3.5
+      parent: 1
+  - uid: 321
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,4.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,5.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,4.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-0.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-1.5
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-2.5
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 336
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-0.5
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,0.5
+      parent: 1
+  - uid: 338
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,1.5
+      parent: 1
+  - uid: 339
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-2.5
+      parent: 1
+  - uid: 340
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 341
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,5.5
+      parent: 1
+  - uid: 342
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,2.5
+      parent: 1
+  - uid: 343
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,6.5
+      parent: 1
+  - uid: 344
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-1.5
+      parent: 1
+  - uid: 345
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 346
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,6.5
+      parent: 1
+  - uid: 347
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-2.5
+      parent: 1
+- proto: WallPlastitaniumDiagonal
+  entities:
+  - uid: 348
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 350
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-2.5
+      parent: 1
+  - uid: 351
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,6.5
+      parent: 1
+- proto: WallPlastitaniumIndestructible
+  entities:
+  - uid: 352
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,1.5
+      parent: 1
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 353
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 354
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 355
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,2.5
+      parent: 1
+- proto: WeaponMechChainSword
+  entities:
+  - uid: 357
+    components:
+    - type: Transform
+      pos: 3.5114422,5.331693
+      parent: 1
+- proto: WeaponMechCombatMissileRack6
+  entities:
+  - uid: 358
+    components:
+    - type: Transform
+      pos: 3.5114422,6.0191936
+      parent: 1
+- proto: WeaponMechCombatUltraRifle
+  entities:
+  - uid: 359
+    components:
+    - type: Transform
+      pos: 3.5218587,5.5400267
+      parent: 1
+- proto: WeaponMechCombatXray
+  entities:
+  - uid: 360
+    components:
+    - type: Transform
+      pos: 3.4906087,5.7275267
+      parent: 1
+...

--- a/Resources/Maps/_FarHorizons/Shuttles/KillerTamashi-Gamma-Weapon.yml
+++ b/Resources/Maps/_FarHorizons/Shuttles/KillerTamashi-Gamma-Weapon.yml
@@ -26,7 +26,7 @@ entities:
   - uid: 1
     components:
     - type: MetaData
-      name: grid
+      name: NT-418 "Skirmish"
     - type: Transform
       pos: -8.625,27.40625
       parent: invalid
@@ -385,8 +385,6 @@ entities:
       pos: 1.5,3.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 4
   - uid: 9
@@ -395,8 +393,6 @@ entities:
       pos: 3.5,0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 4
   - uid: 10
@@ -1185,8 +1181,6 @@ entities:
       pos: 6.5,2.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 2
       - 4
@@ -1197,8 +1191,6 @@ entities:
       pos: 6.5,0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 3
       - 4
@@ -1507,8 +1499,6 @@ entities:
       pos: 4.5,4.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 4
     - type: AtmosPipeColor
@@ -1520,8 +1510,6 @@ entities:
       pos: 2.5,-0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 4
     - type: AtmosPipeColor
@@ -1555,8 +1543,6 @@ entities:
       pos: 2.5,4.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 4
     - type: AtmosPipeColor
@@ -1568,8 +1554,6 @@ entities:
       pos: 4.5,-0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 4
     - type: AtmosPipeColor

--- a/Resources/Maps/_FarHorizons/Shuttles/KillerTamashi-Gamma-Weapon.yml
+++ b/Resources/Maps/_FarHorizons/Shuttles/KillerTamashi-Gamma-Weapon.yml
@@ -1,0 +1,2479 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 272.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 04/06/2026 09:18:58
+  entityCount: 333
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  2: Space
+  6: FloorDarkPlastic
+  3: FloorMetalDiamond
+  5: FloorReinforced
+  4: FloorWhitePlastic
+  1: Lattice
+  0: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      pos: -8.625,27.40625
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAQAAAAAAAAEAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAABQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAUAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAABgAAAAAAAAYAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAYAAAAAAAAGAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAGAAAAAAAABgAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAABgAAAAAAAAYAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: AgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAFAAAAAAAABAAAAAAAAAQAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAABQAAAAAAAAQAAAAAAAAEAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: TileHistory
+      chunkHistory: {}
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: ImplicitRoof
+    - type: NavMap
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelCornerNe
+          decals:
+            45: 5,3
+            79: 8,5
+        - node:
+            color: '#0082D9D3'
+            id: BrickTileSteelCornerNe
+          decals:
+            92: 8,0
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelCornerNw
+          decals:
+            78: 7,5
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelCornerSe
+          decals:
+            82: 8,2
+        - node:
+            color: '#0082D9D3'
+            id: BrickTileSteelCornerSe
+          decals:
+            94: 8,-2
+        - node:
+            color: '#0082D9D3'
+            id: BrickTileSteelCornerSw
+          decals:
+            95: 7,-2
+        - node:
+            color: '#0082D996'
+            id: BrickTileSteelEndN
+          decals:
+            144: 2,4
+            145: 4,4
+        - node:
+            color: '#0082D996'
+            id: BrickTileSteelEndS
+          decals:
+            156: 4,-1
+            157: 2,-1
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelInnerNe
+          decals:
+            47: 5,2
+            49: 5,0
+        - node:
+            color: '#0082D996'
+            id: BrickTileSteelInnerNe
+          decals:
+            153: 2,3
+            154: 4,3
+            193: 1,0
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelInnerNw
+          decals:
+            36: 5,0
+        - node:
+            color: '#0082D996'
+            id: BrickTileSteelInnerNw
+          decals:
+            102: 7,2
+            152: 2,3
+            155: 4,3
+            196: 1,0
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelInnerSe
+          decals:
+            48: 5,2
+        - node:
+            color: '#0082D996'
+            id: BrickTileSteelInnerSe
+          decals:
+            164: 2,0
+            165: 4,0
+            194: 1,3
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelInnerSw
+          decals:
+            46: 5,3
+        - node:
+            color: '#0082D996'
+            id: BrickTileSteelInnerSw
+          decals:
+            166: 2,0
+            167: 4,0
+            195: 1,3
+        - node:
+            color: '#0082D9D3'
+            id: BrickTileSteelInnerSw
+          decals:
+            97: 7,0
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelLineE
+          decals:
+            44: 5,1
+            80: 8,4
+            81: 8,3
+        - node:
+            color: '#0082D996'
+            id: BrickTileSteelLineE
+          decals:
+            191: 1,2
+            192: 1,1
+        - node:
+            color: '#0082D9D3'
+            id: BrickTileSteelLineE
+          decals:
+            93: 8,-1
+        - node:
+            color: '#0082D996'
+            id: BrickTileSteelLineN
+          decals:
+            98: 6,0
+            101: 6,2
+            151: 3,3
+            161: 2,0
+            162: 3,0
+            163: 4,0
+            170: 0,0
+            171: 0,3
+            190: 1,3
+        - node:
+            color: '#0082D9D3'
+            id: BrickTileSteelLineN
+          decals:
+            91: 7,0
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelLineS
+          decals:
+            71: 5,0
+            83: 7,2
+        - node:
+            color: '#0082D996'
+            id: BrickTileSteelLineS
+          decals:
+            99: 6,0
+            100: 6,2
+            146: 2,3
+            148: 4,3
+            150: 3,3
+            159: 3,0
+            169: 0,0
+            172: 0,3
+            187: 1,0
+        - node:
+            color: '#0082D993'
+            id: BrickTileSteelLineW
+          decals:
+            12: 5,2
+            13: 5,1
+            76: 7,3
+            77: 7,4
+        - node:
+            color: '#0082D996'
+            id: BrickTileSteelLineW
+          decals:
+            188: 1,1
+            189: 1,2
+        - node:
+            color: '#0082D9D3'
+            id: BrickTileSteelLineW
+          decals:
+            96: 7,-1
+        - node:
+            color: '#0082D996'
+            id: WarnFullGreyscale
+          decals:
+            115: 5,-1
+            116: 5,-2
+            117: 4,2
+            118: 4,1
+            119: 3,1
+            120: 2,1
+            125: 2,2
+            126: 3,2
+            173: 1,4
+            174: 1,5
+            175: 2,5
+            176: 3,5
+            177: 3,4
+            178: 4,5
+            179: 5,5
+            180: 5,4
+            181: 4,-2
+            182: 3,-2
+            183: 3,-1
+            184: 2,-2
+            185: 1,-2
+            186: 1,-1
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 65263
+          0,1:
+            0: 238
+            1: 256
+          0,-1:
+            0: 60928
+            1: 16
+          1,0:
+            0: 48959
+          1,1:
+            0: 187
+          1,-1:
+            0: 47872
+          2,0:
+            0: 4353
+            1: 52428
+          2,1:
+            0: 17
+            1: 204
+          2,-1:
+            0: 4352
+            1: 52224
+          3,1:
+            1: 256
+          3,-1:
+            1: 16
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
+        - volume: 2500
+          immutable: True
+          moles: {}
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: ExplosionAirtightGrid
+    - type: RadiationGridResistance
+- proto: AirAlarm
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 10
+      - 198
+      - 194
+      - 154
+    - type: Fixtures
+      fixtures: {}
+  - uid: 3
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 195
+      - 11
+      - 199
+      - 155
+    - type: Fixtures
+      fixtures: {}
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 193
+      - 197
+      - 155
+      - 154
+      - 192
+      - 196
+      - 8
+      - 9
+    - type: Fixtures
+      fixtures: {}
+- proto: AirCanister
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      anchored: True
+      pos: 4.5,-1.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: AirlockGlassShuttleSecurityPlastitanium
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+- proto: AirSensor
+  entities:
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 4
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 4
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+- proto: APCBasic
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 13
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+- proto: Breachinghammer
+  entities:
+  - uid: 17
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.579694,2.5886402
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 4.579694,2.5886402
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5430017,2.613102
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5430017,2.5519485
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 10.5,3.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 11.5,5.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 10.5,2.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 11.5,2.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 11.5,1.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 11.5,0.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+- proto: ClothingBackpackDuffelSurgeryFilled
+  entities:
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 7.9742103,-1.3793888
+      parent: 1
+- proto: CombatKnife
+  entities:
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 2.781796,-1.5453014
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 2.769565,-1.3129196
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 2.3904166,-1.2273064
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 2.353725,-1.4719181
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 2.6350288,-1.5208397
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 2.622798,-1.2884579
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 2.500492,-1.2884579
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 2.5249534,-1.496378
+      parent: 1
+- proto: ComfyChairBlue
+  entities:
+  - uid: 143
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,5.5
+      parent: 1
+- proto: computerBodyScanner
+  entities:
+  - uid: 144
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,0.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 145
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,5.5
+      parent: 1
+- proto: DrinkWhiskeyColaGlass
+  entities:
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 8.2603855,5.8128853
+      parent: 1
+- proto: EmergencyLight
+  entities:
+  - uid: 147
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+- proto: FHAirlockSecurity
+  entities:
+  - uid: 152
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+- proto: Firelock
+  entities:
+  - uid: 154
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 2
+      - 4
+  - uid: 155
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 3
+      - 4
+- proto: FoodBurgerBig
+  entities:
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 8.2603855,5.323662
+      parent: 1
+- proto: GasPassiveVentAlt2
+  entities:
+  - uid: 157
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 158
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 160
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 161
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeBendAlt2
+  entities:
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 163
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 165
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 166
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 167
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 168
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 169
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 170
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 171
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 172
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeStraightAlt2
+  entities:
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 174
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 175
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 176
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 177
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 178
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 179
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 180
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 181
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 182
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 185
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 186
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeTJunctionAlt2
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 188
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 189
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 190
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPort
+  entities:
+  - uid: 191
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 193
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 195
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubberAlt2
+  entities:
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 197
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 199
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GeneratorBasic20kW
+  entities:
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 202
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-2.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+- proto: GunSafeBaseSecure
+  entities:
+  - uid: 212
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Armory
+- proto: Gyroscope
+  entities:
+  - uid: 213
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,4.5
+      parent: 1
+- proto: LeftArmCyberBulwark
+  entities:
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 7.124157,-1.2958155
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 7.3012404,-1.285399
+      parent: 1
+- proto: MedkitAdvancedFilled
+  entities:
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 2.4835901,2.422411
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 3.156273,2.422411
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 3.156273,2.7648678
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 2.4713597,2.7770996
+      parent: 1
+- proto: MedkitBruteFilled
+  entities:
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 8.705582,-1.597899
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 8.715998,-1.2437322
+      parent: 1
+- proto: OperatingTable
+  entities:
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 1
+- proto: PlastitaniumWindow
+  entities:
+  - uid: 223
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-2.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 1
+- proto: PlushieKiller
+  entities:
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 7.53878,5.531582
+      parent: 1
+- proto: PlushieMorganaRound
+  entities:
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 8.744572,0.9214554
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-0.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-1.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+- proto: RightArmCyberBulwark
+  entities:
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 7.3949904,-1.6187322
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 7.5824904,-1.6187322
+      parent: 1
+- proto: Screen
+  entities:
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 246
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 247
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,6.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 248
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-2.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: ShelfArmoryLaserLargeFilled
+  entities:
+  - uid: 249
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Armory
+    - type: Fixtures
+      fixtures: {}
+  - uid: 250
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 251
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: ShelfArmoryMixedRifleFilled
+  entities:
+  - uid: 252
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 253
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 254
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: ShelfArmoryMixedShotgunFilled
+  entities:
+  - uid: 255
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-0.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Armory
+    - type: Fixtures
+      fixtures: {}
+  - uid: 256
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Armory
+    - type: Fixtures
+      fixtures: {}
+- proto: ShelfArmoryMixedSMGFilled
+  entities:
+  - uid: 257
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 258
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Armory
+    - type: Fixtures
+      fixtures: {}
+  - uid: 259
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Armory
+    - type: Fixtures
+      fixtures: {}
+- proto: SpawnMechDurand
+  entities:
+  - uid: 260
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+- proto: SubstationWallBasic
+  entities:
+  - uid: 261
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 1
+- proto: SuitStorageArmored
+  entities:
+  - uid: 262
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Security
+      - - Cadet
+- proto: SuitStorageEvaBulk
+  entities:
+  - uid: 263
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal: []
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 265
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 268
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 269
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 270
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,5.5
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,3.5
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,2.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,1.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 277
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,5.5
+      parent: 1
+- proto: ToolboxElectricalFilled
+  entities:
+  - uid: 278
+    components:
+    - type: Transform
+      pos: 3.7817168,2.714889
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      pos: 3.7713,2.871139
+      parent: 1
+- proto: ToolboxMechanicalFilled
+  entities:
+  - uid: 280
+    components:
+    - type: Transform
+      pos: 3.80255,2.5378058
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      pos: 3.8129668,2.3190558
+      parent: 1
+- proto: WallPlastitanium
+  entities:
+  - uid: 282
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 1
+  - uid: 293
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 295
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 296
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,3.5
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,4.5
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 300
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,5.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,4.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-0.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-1.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-2.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-0.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,0.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,1.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-2.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,5.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,2.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,6.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-1.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 321
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,6.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-2.5
+      parent: 1
+- proto: WallPlastitaniumDiagonal
+  entities:
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-2.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,6.5
+      parent: 1
+- proto: WallPlastitaniumIndestructible
+  entities:
+  - uid: 327
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,1.5
+      parent: 1
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 328
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,2.5
+      parent: 1
+- proto: WeaponMechChainSword
+  entities:
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 4.374436,5.3480797
+      parent: 1
+- proto: WeaponMechCombatMissileRack6
+  entities:
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 4.398897,5.9840736
+      parent: 1
+- proto: WeaponMechCombatUltraRifle
+  entities:
+  - uid: 332
+    components:
+    - type: Transform
+      pos: 4.4111276,5.70277
+      parent: 1
+- proto: WeaponMechCombatXray
+  entities:
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 4.3622055,5.54377
+      parent: 1
+...

--- a/Resources/Prototypes/_FarHorizons/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/_FarHorizons/Catalog/Fills/Lockers/suit_storage.yml
@@ -252,7 +252,82 @@
     - id: OxygenTankFilled
     - id: NitrogenTankFilled
 
+#Armored Hardsuit
+- type: entity
+  id: SuitStorageArmored
+  parent: SuitStorageBaseFH
+  suffix: Gamma, Crew, 15
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillSuitStorageArmored
+  - type: Sprite 
+    sprite: _FarHorizons/Structures/Storage/suit_storage.rsi
+    layers:
+    - state: sec
+      map: ["enum.StorageVisualLayers.Base"]
+    - state: door
+      map: ["enum.StorageVisualLayers.Door"]
+    - state: welded
+      visible: false
+      map: ["enum.WeldableLayers.BaseWelded"]
+    - state: locked
+      map: ["enum.LockVisualLayers.Lock"]
+      shader: unshaded
+    - state: screen-sec
+      map: ["computerLayerScreen"]
+  - type: EntityStorageVisuals
+    stateDoorOpen: sec 
+  # FH Suit Storage Unit Resprite - END -
+  - type: AccessReader
+    access: [["Security"], ["Cadet"]] # Starlight: add cadet
 
+- type: entityTable
+  id: FillSuitStorageArmored
+  table: !type:AllSelector
+    children:
+    - id: OxygenTankFilled
+      amount: 15
+    - id: ClothingOuterHardsuitSpaceHazardArmored
+      amount: 15
+
+#Bulk EVA
+- type: entity
+  id: SuitStorageEvaBulk
+  parent: SuitStorageBaseFH
+  suffix: Gamma, Crew, 15
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillSuitStorageEvaBulk
+  - type: Sprite 
+    sprite: _FarHorizons/Structures/Storage/suit_storage.rsi
+    layers:
+    - state: eva
+      map: ["enum.StorageVisualLayers.Base"]
+    - state: door
+      map: ["enum.StorageVisualLayers.Door"]
+    - state: welded
+      visible: false
+      map: ["enum.WeldableLayers.BaseWelded"]
+    - state: locked
+      map: ["enum.LockVisualLayers.Lock"]
+      shader: unshaded
+    - state: screen-eva
+      map: ["computerLayerScreen"]
+  - type: EntityStorageVisuals
+    stateDoorOpen: eva 
+
+- type: entityTable
+  id: FillSuitStorageEvaBulk
+  table: !type:AllSelector
+    children:
+    - id: ClothingHeadHelmetEVALarge
+      amount: 15
+    - id: ClothingOuterHardsuitEVA
+      amount: 15
 
 #region Syndicate
 

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -259,6 +259,66 @@
       - HeadOfSecurity
       - Captain
       - Detective
+
+#region Civilian
+
+#Basic Armored Hardsuit
+- type: entity
+  parent: [ClothingOuterHardsuitBase, BaseSecurityContraband]
+  id: ClothingOuterHardsuitSpaceHazardArmored
+  name: Armored Space Hazard Suit
+  description: A cheap and easily producable modification of the Space Hazard suit, used to suppliment a station's lack of combat-ready hardsuits for dangerous conditions.
+  suffix: NT
+  components:
+  - type: Sprite
+    sprite: _Starlight/Clothing/OuterClothing/Hardsuits/spacehazard.rsi
+  - type: Clothing
+    sprite: _Starlight/Clothing/OuterClothing/Hardsuits/spacehazard.rsi
+  - type: PressureProtection
+    highPressureMultiplier: 0.5
+    lowPressureMultiplier: 1000
+  - type: ExplosionResistance
+    damageCoefficient: 0.5
+  - type: Pierceable
+    level: Metal
+  - type: Armor
+    modifiers:
+      flatReductions:
+        Piercing: 5
+        Heat: 4
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.7
+        Caustic: 0.8
+    staminaModifier: 0.6
+    ignoreKnockdown: true
+  - type: LimbArmor
+    limbs:
+      ArmRight: {}
+      ArmLeft: {}
+      HandRight: {}
+      HandLeft: {}
+      LegRight: {}
+      LegLeft: {}
+      FootRight: {}
+      FootLeft: {}
+  - type: ClothingSpeedModifier
+    walkModifier: 0.80
+    sprintModifier: 0.80
+    requireActivated: false #FH cuz item toggle.
+  - type: HeldSpeedModifier
+  - type: ToggleableClothing
+    clothingPrototype: ClothingHeadHelmetHardsuitSpaceHazard
+  - type: Tag
+    tags:
+    - Hardsuit
+    - CorgiWearable
+    - WhitelistChameleon
+    - IPCExternalCooling # Far Horizons
+    - HardsuitSpatio #can now be used to make goliath hardsuit
+
 #region Syndicate 
 
 

--- a/Resources/Prototypes/_StarLight/Entities/Stations/base.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Stations/base.yml
@@ -11,7 +11,7 @@
     - type: AlertArmoryStation
       shuttles:
         gamma:
-          shuttle: /Maps/_Starlight/Shuttles/CC-NT/GammaWeaponry.yml
+          shuttle: /Maps/_FarHorizons/Shuttles/KillerTamashi-Gamma-Weapon.yml #FH
           announcement: announcement-gamma-armory
           recallAnnouncement: announcement-gamma-armory-recall
         psi:

--- a/Resources/ServerInfo/Guidebook/Antagonist/Nuclear Operatives.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Nuclear Operatives.xml
@@ -51,7 +51,7 @@
     <GuideEntityEmbed Entity="C4" Caption="Explosives"/>
     <GuideEntityEmbed Entity="ClothingOuterHardsuitJuggernaut" Caption="Wearables"/>
     <GuideEntityEmbed Entity="Stimpack" Caption="Chemicals"/>
-  </Box>
+  </Box> 
   <Box>
     <GuideEntityEmbed Entity="ChameleonProjector" Caption="Deception"/>
     <GuideEntityEmbed Entity="Emag" Caption="Disruption"/>
@@ -60,7 +60,7 @@
     <GuideEntityEmbed Entity="ClothingEyesGlassesOutlawGlasses" Caption="Pointless"/>
   </Box>
 
-  You'll also have to choose if you want to [color=red]declare war[/color] or not. Doing so grants your team [bold]40 extra telecrystals each[/bold].
+  You'll also have to choose if you want to [color=red]declare war[/color] or not. Doing so grants your team [bold]80 extra telecrystals each[/bold].
   However, the crew will immediately know of your existence and will have plenty of time to prepare for your arrival.
 
   The [bold]Commander[/bold] is the only person who can declare war. Make your choice quick, [italic]this is a limited-time offer![/italic]


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
yup
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Based on suggestion in discord. Gives warops nukies 120tc to work with, and throws a gamma armory that arms all of crew at, well, crew.

For greater enjoyment of the Warops mode for both sides.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Ze shuttle
<img width="801" height="611" alt="yfuiliuyl" src="https://github.com/user-attachments/assets/eb42462e-14e6-4db5-8450-903a1e97846a" />
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Killer Tamashi
- add: Added new Gamma Armory with ~ 44 guns / hardsuits, a kickass mech and some cyberlimbs. Good enough for the entire crew!
- tweak: Buffed Warops TC amount from 80 -> 120
