### PR TITLE
Limb 2

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -98,6 +98,20 @@ namespace Content.Client.Input
             human.AddFunction(ContentKeyFunctions.SmartEquipRig);
             human.AddFunction(ContentKeyFunctions.SmartEquipTankStorage);
             human.AddFunction(ContentKeyFunctions.OpenRig);
+
+            human.AddFunction(ContentKeyFunctions.TargetTorso);
+            human.AddFunction(ContentKeyFunctions.TargetHead);
+            human.AddFunction(ContentKeyFunctions.TargetArmLeft);
+            human.AddFunction(ContentKeyFunctions.TargetArmRight);
+            human.AddFunction(ContentKeyFunctions.TargetHandLeft);
+            human.AddFunction(ContentKeyFunctions.TargetHandRight);
+            human.AddFunction(ContentKeyFunctions.TargetLegLeft);
+            human.AddFunction(ContentKeyFunctions.TargetLegRight);
+            human.AddFunction(ContentKeyFunctions.TargetFootLeft);
+            human.AddFunction(ContentKeyFunctions.TargetFootRight);
+
+            human.AddFunction(ContentKeyFunctions.TargetNextLimb);
+            human.AddFunction(ContentKeyFunctions.TargetPreviousLimb);
             // Far Horizons end
 
             // actions should be common (for ghosts, mobs, etc)

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -216,6 +216,20 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.RotateObjectCounterclockwise);
             AddButton(ContentKeyFunctions.FlipObject);
 
+            AddHeader("ui-options-header-limb-targetting");
+            AddButton(ContentKeyFunctions.TargetNextLimb);
+            AddButton(ContentKeyFunctions.TargetPreviousLimb);
+            AddButton(ContentKeyFunctions.TargetTorso);
+            AddButton(ContentKeyFunctions.TargetHead);
+            AddButton(ContentKeyFunctions.TargetArmLeft);
+            AddButton(ContentKeyFunctions.TargetArmRight);
+            AddButton(ContentKeyFunctions.TargetHandLeft);
+            AddButton(ContentKeyFunctions.TargetHandRight);
+            AddButton(ContentKeyFunctions.TargetLegLeft);
+            AddButton(ContentKeyFunctions.TargetLegRight);
+            AddButton(ContentKeyFunctions.TargetFootLeft);
+            AddButton(ContentKeyFunctions.TargetFootRight);
+
             AddHeader("ui-options-header-ui");
             AddButton(ContentKeyFunctions.FocusChat);
             AddButton(ContentKeyFunctions.FocusLocalChat);

--- a/Content.Client/_FarHorizons/LimbDamage/UI/LimbTargettingSystem.cs
+++ b/Content.Client/_FarHorizons/LimbDamage/UI/LimbTargettingSystem.cs
@@ -1,6 +1,9 @@
+using System.Linq;
 using Content.Shared._FarHorizons.LimbDamage.Components;
 using Content.Shared.Body;
+using Content.Shared.Input;
 using Robust.Client.Player;
+using Robust.Shared.Input.Binding;
 using Robust.Shared.Prototypes;
 
 namespace Content.Client._FarHorizons.LimbDamage.UI;
@@ -8,6 +11,7 @@ namespace Content.Client._FarHorizons.LimbDamage.UI;
 public sealed class LimbTargettingSystem : EntitySystem
 {
     [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IPrototypeManager _protoMan = default!;
 
     public Action<ProtoId<OrganCategoryPrototype>>? LocalTargetUpdated;
 
@@ -16,6 +20,21 @@ public sealed class LimbTargettingSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<LimbTargettingComponent, AfterAutoHandleStateEvent>(OnState);
+
+        CommandBinds.Builder
+            .Bind(ContentKeyFunctions.TargetNextLimb, new PointerInputCmdHandler(CycleForward, outsidePrediction: true))
+            .Bind(ContentKeyFunctions.TargetPreviousLimb, new PointerInputCmdHandler(CycleBackward, outsidePrediction: true))
+            .Bind(ContentKeyFunctions.TargetTorso, new PointerInputCmdHandler(SelectTorso, outsidePrediction: true))
+            .Bind(ContentKeyFunctions.TargetHead, new PointerInputCmdHandler(SelectHead, outsidePrediction: true))
+            .Bind(ContentKeyFunctions.TargetArmLeft, new PointerInputCmdHandler(SelectArmLeft, outsidePrediction: true))
+            .Bind(ContentKeyFunctions.TargetArmRight, new PointerInputCmdHandler(SelectArmRight, outsidePrediction: true))
+            .Bind(ContentKeyFunctions.TargetHandLeft, new PointerInputCmdHandler(SelectHandLeft, outsidePrediction: true))
+            .Bind(ContentKeyFunctions.TargetHandRight, new PointerInputCmdHandler(SelectHandRight, outsidePrediction: true))
+            .Bind(ContentKeyFunctions.TargetLegLeft, new PointerInputCmdHandler(SelectLegLeft, outsidePrediction: true))
+            .Bind(ContentKeyFunctions.TargetLegRight, new PointerInputCmdHandler(SelectLegRight, outsidePrediction: true))
+            .Bind(ContentKeyFunctions.TargetFootLeft, new PointerInputCmdHandler(SelectFootLeft, outsidePrediction: true))
+            .Bind(ContentKeyFunctions.TargetFootRight, new PointerInputCmdHandler(SelectFootRight, outsidePrediction: true))
+            .Register<LimbTargettingUI>();
     }
 
     private void OnState(Entity<LimbTargettingComponent> ent, ref AfterAutoHandleStateEvent args)
@@ -26,4 +45,47 @@ public sealed class LimbTargettingSystem : EntitySystem
 
     public void SetTarget(ProtoId<OrganCategoryPrototype> target) => 
         RaiseNetworkEvent(new ChangeLimbTargetMessage(target));
+
+    private ProtoId<OrganCategoryPrototype>? CycleTarget(bool forward = true)
+    {
+        if (_player.LocalEntity == null ||
+            !TryComp<LimbTargettingComponent>(_player.LocalEntity, out var limbTargetting))
+            return null;
+
+        var targets = _protoMan.Index(limbTargetting.Proto).Limbs.Select(p => p.Limb).ToList();
+        var curIndex = targets.IndexOf(limbTargetting.Target);
+        int newIndex;
+        if (forward)
+            newIndex = curIndex + 1 >= targets.Count ? 0 : curIndex + 1;
+        else
+            newIndex = curIndex - 1 < 0 ? targets.Count - 1 : curIndex - 1;
+
+        return targets[newIndex];
+    }
+
+    private bool HandleInput(ProtoId<OrganCategoryPrototype> target)
+    {
+        if (_player.LocalEntity == null ||
+            !TryComp<LimbTargettingComponent>(_player.LocalEntity, out var limbTargetting))
+            return false;
+
+        limbTargetting.Target = target;
+        LocalTargetUpdated?.Invoke(target);
+        RaiseNetworkEvent(new ChangeLimbTargetMessage(target));
+        return true;
+    }
+
+    private bool CycleForward(in PointerInputCmdHandler.PointerInputCmdArgs args) => CycleTarget() is {} newTarget && HandleInput(newTarget);
+    private bool CycleBackward(in PointerInputCmdHandler.PointerInputCmdArgs args) => CycleTarget(false) is {} newTarget && HandleInput(newTarget);
+
+    private bool SelectTorso(in PointerInputCmdHandler.PointerInputCmdArgs args) => HandleInput("Torso");
+    private bool SelectHead(in PointerInputCmdHandler.PointerInputCmdArgs args) => HandleInput("Head");
+    private bool SelectArmLeft(in PointerInputCmdHandler.PointerInputCmdArgs args) => HandleInput("ArmLeft");
+    private bool SelectArmRight(in PointerInputCmdHandler.PointerInputCmdArgs args) => HandleInput("ArmRight");
+    private bool SelectHandLeft(in PointerInputCmdHandler.PointerInputCmdArgs args) => HandleInput("HandLeft");
+    private bool SelectHandRight(in PointerInputCmdHandler.PointerInputCmdArgs args) => HandleInput("HandRight");
+    private bool SelectLegLeft(in PointerInputCmdHandler.PointerInputCmdArgs args) => HandleInput("LegLeft");
+    private bool SelectLegRight(in PointerInputCmdHandler.PointerInputCmdArgs args) => HandleInput("LegRight");
+    private bool SelectFootLeft(in PointerInputCmdHandler.PointerInputCmdArgs args) => HandleInput("FootLeft");
+    private bool SelectFootRight(in PointerInputCmdHandler.PointerInputCmdArgs args) => HandleInput("FootRight");
 }

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -144,6 +144,20 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction SmartEquipRig = "SmartEquipRig";
         public static readonly BoundKeyFunction SmartEquipTankStorage = "SmartEquipTankStorage";
         public static readonly BoundKeyFunction OpenRig = "OpenRig";
+
+        public static readonly BoundKeyFunction TargetTorso = "TargetTorso";
+        public static readonly BoundKeyFunction TargetHead = "TargetHead";
+        public static readonly BoundKeyFunction TargetArmLeft = "TargetArmLeft";
+        public static readonly BoundKeyFunction TargetArmRight = "TargetArmRight";
+        public static readonly BoundKeyFunction TargetHandLeft = "TargetHandLeft";
+        public static readonly BoundKeyFunction TargetHandRight = "TargetHandRight";
+        public static readonly BoundKeyFunction TargetLegLeft = "TargetLegLeft";
+        public static readonly BoundKeyFunction TargetLegRight = "TargetLegRight";
+        public static readonly BoundKeyFunction TargetFootLeft = "TargetFootLeft";
+        public static readonly BoundKeyFunction TargetFootRight = "TargetFootRight";
+
+        public static readonly BoundKeyFunction TargetNextLimb = "TargetNextLimb";
+        public static readonly BoundKeyFunction TargetPreviousLimb = "TargetPreviousLimb";
         // Far Horizons end
     }
 }

--- a/Content.Shared/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/Medical/Healing/HealingSystem.cs
@@ -112,7 +112,7 @@ public sealed class HealingSystem : EntitySystem
                 origin: args.Args.User);
         }
 
-        if (!healingDoneToLimb)
+        if (!healingDoneToLimb || healed.Empty)
             healingDone = _damageable.TryChangeDamage(target.Owner,
                 healing.Damage * _damageable.UniversalTopicalsHealModifier, out healed, true,
                 origin: args.Args.User);

--- a/Content.Shared/Repairable/RepairableSystem.cs
+++ b/Content.Shared/Repairable/RepairableSystem.cs
@@ -43,7 +43,7 @@ public sealed partial class RepairableSystem : EntitySystem
         var target = args.TargettedLimb;
         FixedPoint2 totalDamage;
         if (target != null && _limbDamage.TryGetFullBodyDamage(ent.Owner) is { } fullBodyDamage &&
-            fullBodyDamage.TryGetValue(target.Value, out var limbDamage))
+            fullBodyDamage.TryGetValue(target.Value, out var limbDamage) && limbDamage.Count != 0)
             totalDamage = limbDamage.Sum(p => (float)p.Value);
         else
         {

--- a/Content.Shared/_FarHorizons/LimbDamage/Effect/Effects.cs
+++ b/Content.Shared/_FarHorizons/LimbDamage/Effect/Effects.cs
@@ -2,6 +2,8 @@ using System.Linq;
 using Content.Shared._FarHorizons.Body;
 using Content.Shared._FarHorizons.LimbDamage.Components;
 using Content.Shared.Body;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Stunnable;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
@@ -82,5 +84,31 @@ public sealed partial class LimbEffectDestroy : ILimbDamageEffect
     {
         entMan.System<SharedAudioSystem>().PlayPredicted(_gibSound, target, null);
         entMan.QueueDeleteEntity(target);
+    }
+}
+
+[Serializable, NetSerializable]
+[DataDefinition]
+public sealed partial class LimbEffectDisarm : ILimbDamageEffect
+{
+    [DataField] public string HandId = "";
+
+    public void Run(Entity<DamageableLimbComponent> limb, IEntityManager entMan, IPrototypeManager protoMan)
+    {
+        if (limb.Comp.Organ?.Body == null) return;
+        entMan.System<SharedHandsSystem>().TryDrop(limb.Comp.Organ.Body.Value, HandId, checkActionBlocker: false);
+    }
+}
+
+[Serializable, NetSerializable]
+[DataDefinition]
+public sealed partial class LimbEffectKnockdown : ILimbDamageEffect
+{
+    [DataField] public float KnockdownTime;
+
+    public void Run(Entity<DamageableLimbComponent> limb, IEntityManager entMan, IPrototypeManager protoMan)
+    {
+        if (limb.Comp.Organ?.Body == null) return;
+        entMan.System<SharedStunSystem>().TryKnockdown(limb.Comp.Organ.Body.Value, TimeSpan.FromSeconds(KnockdownTime), false, true, false);
     }
 }

--- a/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.Effect.cs
+++ b/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.Effect.cs
@@ -16,7 +16,7 @@ public partial class LimbDamageSystem
 
     private void OnDamageChanged(Entity<LimbDamageEffectComponent> ent, ref DamageChangedEvent args)
     {
-        if (args.DamageDelta == null || args.DamageDelta.Empty)
+        if (args.DamageDelta == null || args.DamageDelta.Empty || !_timing.IsFirstTimePredicted)
             return;
 
         foreach (var effect in ent.Comp.Effects)

--- a/Resources/Locale/en-US/_FarHorizons/escape-menu/options-menu.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/escape-menu/options-menu.ftl
@@ -1,3 +1,17 @@
 ui-options-function-smart-equip-rig = Smart-equip to rig
 ui-options-function-smart-equip-tank-storage = Smart-equip to tank storage
 ui-options-function-open-rig = Open Rig
+
+ui-options-header-limb-targetting = Limb Targetting
+ui-options-function-target-next-limb = Cycle Targets
+ui-options-function-target-previous-limb = Cycle Targets Reverse
+ui-options-function-target-torso = Target Torso
+ui-options-function-target-head = Target Head
+ui-options-function-target-arm-left = Target Left Arm
+ui-options-function-target-arm-right = Target Right Arm
+ui-options-function-target-hand-left = Target Left Hand
+ui-options-function-target-hand-right = Target Right Hand
+ui-options-function-target-leg-left = Target Left Leg
+ui-options-function-target-leg-right = Target Right Leg
+ui-options-function-target-foot-left = Target Left Foot
+ui-options-function-target-foot-right = Target Right Foot

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -116,8 +116,8 @@
       - ears
   - type: DamageableLimb
     bodyDamageFactor: 0.4 # Non vital variant is used for diona and slime, same 40% as legs/arms
-    missChance: 0.35 # 35% chance to miss
-    redirectChance: 0.2 # 20% chance to hit torso
+    missChance: 0 # Still 0
+    redirectChance: 0.4 # 40% chance to hit torso
     scatterHitChance: 0 # Disable chance to miss head without aiming
     aimedTowardsScatterHitChance: 0
   - type: LimbDamageEffect
@@ -222,11 +222,11 @@
     slots: [ gloves ]
   - type: DamageableLimb
     bodyDamageFactor: 0.2
-    missChance: 0.35
-    redirectChance: 0.2
+    missChance: 0
+    redirectChance: 0.4
     redirectTarget: ArmLeft
-    scatterHitChance: 0.05
-    aimedTowardsScatterHitChance: 0.1
+    scatterHitChance: 0.02
+    aimedTowardsScatterHitChance: 0.05
   - type: LimbDamageEffect
     effects:
       - effect: !type:LimbEffectDetach
@@ -272,11 +272,11 @@
     slots: [ gloves ]
   - type: DamageableLimb
     bodyDamageFactor: 0.2
-    missChance: 0.35
-    redirectChance: 0.2
+    missChance: 0
+    redirectChance: 0.4
     redirectTarget: ArmRight
-    scatterHitChance: 0.05
-    aimedTowardsScatterHitChance: 0.1
+    scatterHitChance: 0.02
+    aimedTowardsScatterHitChance: 0.05
   - type: LimbDamageEffect
     effects:
       - effect: !type:LimbEffectDetach
@@ -365,11 +365,11 @@
     slots: [ shoes ]
   - type: DamageableLimb
     bodyDamageFactor: 0.2
-    missChance: 0.35
-    redirectChance: 0.2
+    missChance: 0
+    redirectChance: 0.4
     redirectTarget: LegLeft
-    scatterHitChance: 0.05
-    aimedTowardsScatterHitChance: 0.1
+    scatterHitChance: 0.02
+    aimedTowardsScatterHitChance: 0.05
   - type: LimbDamageEffect
     effects:
       - effect: !type:LimbEffectDetach
@@ -410,11 +410,11 @@
     slots: [ shoes ]
   - type: DamageableLimb
     bodyDamageFactor: 0.2
-    missChance: 0.35
-    redirectChance: 0.2
+    missChance: 0
+    redirectChance: 0.4
     redirectTarget: LegLeft
-    scatterHitChance: 0.05
-    aimedTowardsScatterHitChance: 0.1
+    scatterHitChance: 0.02
+    aimedTowardsScatterHitChance: 0.05
   - type: LimbDamageEffect
     effects:
       - effect: !type:LimbEffectDetach

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -292,10 +292,6 @@
               damageAmount: 300
       - effect: !type:LimbEffectDisarm # Drop items each time hand takes damage when above treshold
           handId: left
-        condition: !type:LimbConditionTotalDamage
-          totalDamage: 50
-      - effect: !type:LimbEffectDisarm # Drop items each time hand takes damage when above treshold
-          handId: left
         condition: !type:LimbConditionOr
           conditions:
             - !type:LimbConditionTotalDamage

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -170,6 +170,30 @@
   # Far Horizons start
   - type: LimbDamageVisuals
     layer: "enum.HumanoidVisualLayers.LArm"
+  - type: LimbDamageEffect
+    effects:
+      - effect: !type:LimbEffectDetach # Amputate limb when it takes slash damage
+        condition: !type:LimbConditionSpecificDamage
+          damageType: Slash
+          damageAmount: 100
+      - effect: !type:LimbEffectDestroy # Gib limb. If it has organs (head), it will drop them
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 250
+            - !type:LimbConditionSpecificDamage
+              damageType: Heat
+              damageAmount: 500
+      - effect: !type:LimbEffectDisarm # Drop items each time hand takes damage when above treshold
+          handId: left
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionTotalDamage
+              totalDamage: 250
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 150
   # Far Horizons end
 
 - type: entity
@@ -193,6 +217,30 @@
   # Far Horizons start
   - type: LimbDamageVisuals
     layer: "enum.HumanoidVisualLayers.RArm"
+  - type: LimbDamageEffect
+    effects:
+      - effect: !type:LimbEffectDetach # Amputate limb when it takes slash damage
+        condition: !type:LimbConditionSpecificDamage
+          damageType: Slash
+          damageAmount: 100
+      - effect: !type:LimbEffectDestroy # Gib limb. If it has organs (head), it will drop them
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 250
+            - !type:LimbConditionSpecificDamage
+              damageType: Heat
+              damageAmount: 500
+      - effect: !type:LimbEffectDisarm # Drop items each time hand takes damage when above treshold
+          handId: right
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionTotalDamage
+              totalDamage: 250
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 150
   # Far Horizons end
 
 - type: entity
@@ -242,7 +290,19 @@
             - !type:LimbConditionSpecificDamage
               damageType: Heat
               damageAmount: 300
-          
+      - effect: !type:LimbEffectDisarm # Drop items each time hand takes damage when above treshold
+          handId: left
+        condition: !type:LimbConditionTotalDamage
+          totalDamage: 50
+      - effect: !type:LimbEffectDisarm # Drop items each time hand takes damage when above treshold
+          handId: left
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionTotalDamage
+              totalDamage: 150
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 50
   # Far Horizons end
 
 - type: entity
@@ -292,6 +352,15 @@
             - !type:LimbConditionSpecificDamage
               damageType: Heat
               damageAmount: 300
+      - effect: !type:LimbEffectDisarm # Drop items each time hand takes damage when above treshold
+          handId: right
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionTotalDamage
+              totalDamage: 150
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 50
   # Far Horizons end
 
 - type: entity
@@ -316,6 +385,30 @@
   - type: MovementOrgan
   - type: LimbDamageVisuals
     layer: "enum.HumanoidVisualLayers.LLeg"
+  - type: LimbDamageEffect
+    effects:
+      - effect: !type:LimbEffectDetach # Amputate limb when it takes slash damage
+        condition: !type:LimbConditionSpecificDamage
+          damageType: Slash
+          damageAmount: 100
+      - effect: !type:LimbEffectDestroy # Gib limb. If it has organs (head), it will drop them
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 250
+            - !type:LimbConditionSpecificDamage
+              damageType: Heat
+              damageAmount: 500
+      - effect: !type:LimbEffectKnockdown # Knockdown
+          knockdownTime: 0.25
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionTotalDamage
+              totalDamage: 250
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 150
   # Far Horizons end
 
 - type: entity
@@ -340,6 +433,30 @@
   - type: MovementOrgan
   - type: LimbDamageVisuals
     layer: "enum.HumanoidVisualLayers.RLeg"
+  - type: LimbDamageEffect
+    effects:
+      - effect: !type:LimbEffectDetach # Amputate limb when it takes slash damage
+        condition: !type:LimbConditionSpecificDamage
+          damageType: Slash
+          damageAmount: 100
+      - effect: !type:LimbEffectDestroy # Gib limb. If it has organs (head), it will drop them
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 250
+            - !type:LimbConditionSpecificDamage
+              damageType: Heat
+              damageAmount: 500
+      - effect: !type:LimbEffectKnockdown # Knockdown
+          knockdownTime: 0.25
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionTotalDamage
+              totalDamage: 250
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 150
   # Far Horizons end
 
 - type: entity
@@ -385,6 +502,15 @@
             - !type:LimbConditionSpecificDamage
               damageType: Heat
               damageAmount: 300
+      - effect: !type:LimbEffectKnockdown # Knockdown
+          knockdownTime: 0.5
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionTotalDamage
+              totalDamage: 150
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 50
   # Far Horizons end
 
 - type: entity
@@ -430,6 +556,15 @@
             - !type:LimbConditionSpecificDamage
               damageType: Heat
               damageAmount: 300
+      - effect: !type:LimbEffectKnockdown # Knockdown
+          knockdownTime: 0.5
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionTotalDamage
+              totalDamage: 150
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 50
   # Far Horizons end
 
 - type: entity

--- a/Resources/Prototypes/_FarHorizons/Body/Cybernetic/base.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Cybernetic/base.yml
@@ -62,6 +62,21 @@
       markingData:
         layers:
         - RArm
+    - type: LimbDamageEffect
+      effects:
+        - effect: !type:LimbEffectDetach # Amputate limb when it takes slash damage
+          condition: !type:LimbConditionSpecificDamage
+            damageType: Slash
+            damageAmount: 100
+        - effect: !type:LimbEffectDestroy # Gib limb. If it has organs (head), it will drop them
+          condition: !type:LimbConditionOr
+            conditions:
+              - !type:LimbConditionSpecificDamage
+                damageType: Blunt
+                damageAmount: 250
+              - !type:LimbConditionSpecificDamage
+                damageType: Heat
+                damageAmount: 500
 
 - type: entity
   parent: [ OrganBaseArmLeft, OrganCyberExternal ]
@@ -80,6 +95,21 @@
       markingData:
         layers:
         - LArm
+    - type: LimbDamageEffect
+      effects:
+        - effect: !type:LimbEffectDetach # Amputate limb when it takes slash damage
+          condition: !type:LimbConditionSpecificDamage
+            damageType: Slash
+            damageAmount: 100
+        - effect: !type:LimbEffectDestroy # Gib limb. If it has organs (head), it will drop them
+          condition: !type:LimbConditionOr
+            conditions:
+              - !type:LimbConditionSpecificDamage
+                damageType: Blunt
+                damageAmount: 250
+              - !type:LimbConditionSpecificDamage
+                damageType: Heat
+                damageAmount: 500
 
 - type: entity
   parent: [ OrganBaseHandRight, OrganCyberExternal ]
@@ -98,6 +128,21 @@
       markingData:
         layers:
         - RHand
+    - type: LimbDamageEffect
+      effects:
+        - effect: !type:LimbEffectDetach
+          condition: !type:LimbConditionSpecificDamage
+            damageType: Slash
+            damageAmount: 50
+        - effect: !type:LimbEffectDestroy
+          condition: !type:LimbConditionOr
+            conditions:
+              - !type:LimbConditionSpecificDamage
+                damageType: Blunt
+                damageAmount: 150
+              - !type:LimbConditionSpecificDamage
+                damageType: Heat
+                damageAmount: 300
 
 - type: entity
   parent: [ OrganBaseHandLeft, OrganCyberExternal ]
@@ -116,6 +161,21 @@
       markingData:
         layers:
         - LHand
+    - type: LimbDamageEffect
+      effects:
+        - effect: !type:LimbEffectDetach
+          condition: !type:LimbConditionSpecificDamage
+            damageType: Slash
+            damageAmount: 50
+        - effect: !type:LimbEffectDestroy
+          condition: !type:LimbConditionOr
+            conditions:
+              - !type:LimbConditionSpecificDamage
+                damageType: Blunt
+                damageAmount: 150
+              - !type:LimbConditionSpecificDamage
+                damageType: Heat
+                damageAmount: 300
 
 - type: entity
   parent: [ OrganBaseLegRight, OrganCyberExternal ]
@@ -136,6 +196,21 @@
       markingData:
         layers:
         - RLeg
+    - type: LimbDamageEffect
+      effects:
+        - effect: !type:LimbEffectDetach # Amputate limb when it takes slash damage
+          condition: !type:LimbConditionSpecificDamage
+            damageType: Slash
+            damageAmount: 100
+        - effect: !type:LimbEffectDestroy # Gib limb. If it has organs (head), it will drop them
+          condition: !type:LimbConditionOr
+            conditions:
+              - !type:LimbConditionSpecificDamage
+                damageType: Blunt
+                damageAmount: 250
+              - !type:LimbConditionSpecificDamage
+                damageType: Heat
+                damageAmount: 500
 
 - type: entity
   parent: [ OrganBaseLegLeft, OrganCyberExternal ]
@@ -156,6 +231,21 @@
       markingData:
         layers:
         - LLeg
+    - type: LimbDamageEffect
+      effects:
+        - effect: !type:LimbEffectDetach # Amputate limb when it takes slash damage
+          condition: !type:LimbConditionSpecificDamage
+            damageType: Slash
+            damageAmount: 100
+        - effect: !type:LimbEffectDestroy # Gib limb. If it has organs (head), it will drop them
+          condition: !type:LimbConditionOr
+            conditions:
+              - !type:LimbConditionSpecificDamage
+                damageType: Blunt
+                damageAmount: 250
+              - !type:LimbConditionSpecificDamage
+                damageType: Heat
+                damageAmount: 500
 
 - type: entity
   parent: [ OrganBaseFootRight, OrganCyberExternal ]
@@ -176,6 +266,21 @@
       markingData:
         layers:
         - RFoot
+    - type: LimbDamageEffect
+      effects:
+        - effect: !type:LimbEffectDetach
+          condition: !type:LimbConditionSpecificDamage
+            damageType: Slash
+            damageAmount: 50
+        - effect: !type:LimbEffectDestroy
+          condition: !type:LimbConditionOr
+            conditions:
+              - !type:LimbConditionSpecificDamage
+                damageType: Blunt
+                damageAmount: 150
+              - !type:LimbConditionSpecificDamage
+                damageType: Heat
+                damageAmount: 300
 
 - type: entity
   parent: [ OrganBaseFootLeft, OrganCyberExternal ]
@@ -196,3 +301,18 @@
       markingData:
         layers:
         - LFoot
+    - type: LimbDamageEffect
+      effects:
+        - effect: !type:LimbEffectDetach
+          condition: !type:LimbConditionSpecificDamage
+            damageType: Slash
+            damageAmount: 50
+        - effect: !type:LimbEffectDestroy
+          condition: !type:LimbConditionOr
+            conditions:
+              - !type:LimbConditionSpecificDamage
+                damageType: Blunt
+                damageAmount: 150
+              - !type:LimbConditionSpecificDamage
+                damageType: Heat
+                damageAmount: 300

--- a/Resources/Prototypes/_FarHorizons/Body/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/ipc.yml
@@ -164,6 +164,21 @@
         types:
           Shock: 3
           Heat: 2
+  - type: LimbDamageEffect
+    effects:
+      - effect: !type:LimbEffectDetach # Amputate limb when it takes slash damage
+        condition: !type:LimbConditionSpecificDamage
+          damageType: Slash
+          damageAmount: 100
+      - effect: !type:LimbEffectDestroy # Gib limb. If it has organs (head), it will drop them
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 250
+            - !type:LimbConditionSpecificDamage
+              damageType: Heat
+              damageAmount: 500
   - type: Tag
     tags:
       - Inorganic
@@ -180,6 +195,21 @@
         types:
           Shock: 3
           Heat: 2
+  - type: LimbDamageEffect
+    effects:
+      - effect: !type:LimbEffectDetach # Amputate limb when it takes slash damage
+        condition: !type:LimbConditionSpecificDamage
+          damageType: Slash
+          damageAmount: 100
+      - effect: !type:LimbEffectDestroy # Gib limb. If it has organs (head), it will drop them
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 250
+            - !type:LimbConditionSpecificDamage
+              damageType: Heat
+              damageAmount: 500
   - type: Tag
     tags:
       - Inorganic
@@ -196,6 +226,21 @@
         types:
           Shock: 3
           Heat: 1
+  - type: LimbDamageEffect
+    effects:
+      - effect: !type:LimbEffectDetach
+        condition: !type:LimbConditionSpecificDamage
+          damageType: Slash
+          damageAmount: 50
+      - effect: !type:LimbEffectDestroy
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 150
+            - !type:LimbConditionSpecificDamage
+              damageType: Heat
+              damageAmount: 300
   - type: Tag
     tags:
       - Inorganic
@@ -212,6 +257,21 @@
         types:
           Shock: 3
           Heat: 1
+  - type: LimbDamageEffect
+    effects:
+      - effect: !type:LimbEffectDetach
+        condition: !type:LimbConditionSpecificDamage
+          damageType: Slash
+          damageAmount: 50
+      - effect: !type:LimbEffectDestroy
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 150
+            - !type:LimbConditionSpecificDamage
+              damageType: Heat
+              damageAmount: 300
   - type: Tag
     tags:
       - Inorganic
@@ -230,6 +290,21 @@
         types:
           Shock: 3
           Heat: 2
+  - type: LimbDamageEffect
+    effects:
+      - effect: !type:LimbEffectDetach # Amputate limb when it takes slash damage
+        condition: !type:LimbConditionSpecificDamage
+          damageType: Slash
+          damageAmount: 100
+      - effect: !type:LimbEffectDestroy # Gib limb. If it has organs (head), it will drop them
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 250
+            - !type:LimbConditionSpecificDamage
+              damageType: Heat
+              damageAmount: 500
   - type: Tag
     tags:
       - Inorganic
@@ -248,6 +323,21 @@
         types:
           Shock: 3
           Heat: 2
+  - type: LimbDamageEffect
+    effects:
+      - effect: !type:LimbEffectDetach # Amputate limb when it takes slash damage
+        condition: !type:LimbConditionSpecificDamage
+          damageType: Slash
+          damageAmount: 100
+      - effect: !type:LimbEffectDestroy # Gib limb. If it has organs (head), it will drop them
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 250
+            - !type:LimbConditionSpecificDamage
+              damageType: Heat
+              damageAmount: 500
   - type: Tag
     tags:
       - Inorganic
@@ -266,6 +356,21 @@
         types:
           Shock: 3
           Heat: 1
+  - type: LimbDamageEffect
+    effects:
+      - effect: !type:LimbEffectDetach
+        condition: !type:LimbConditionSpecificDamage
+          damageType: Slash
+          damageAmount: 50
+      - effect: !type:LimbEffectDestroy
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 150
+            - !type:LimbConditionSpecificDamage
+              damageType: Heat
+              damageAmount: 300
   - type: Tag
     tags:
       - Inorganic
@@ -284,6 +389,21 @@
         types:
           Shock: 3
           Heat: 1
+  - type: LimbDamageEffect
+    effects:
+      - effect: !type:LimbEffectDetach
+        condition: !type:LimbConditionSpecificDamage
+          damageType: Slash
+          damageAmount: 50
+      - effect: !type:LimbEffectDestroy
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 150
+            - !type:LimbConditionSpecificDamage
+              damageType: Heat
+              damageAmount: 300
   - type: Tag
     tags:
       - Inorganic

--- a/Resources/Prototypes/_FarHorizons/Body/base_organs.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/base_organs.yml
@@ -6,11 +6,11 @@
       damageContainer: LimbDamageContainer # Only brute and heat
     - type: DamageableLimb
       bodyDamageFactor: 0.4 # 40% of the damage/healing limb takes is transferred to body
-      missChance: 0.2 # 20% chance that direct attack misses entirely
-      redirectChance: 0.1 # 10% chance if it didn't miss, it hit other part of the body instead
+      missChance: 0 # Tried with miss chance originally. Heard less complaints than I thought, but let's try without missing
+      redirectChance: 0.25 # 25% chance if it didn't miss, it hit other part of the body instead
       redirectTarget: Torso # Which part to redirect attack to
-      scatterHitChance: 0.1 # 10% chance to hit this limb when making indirrect attack without aiming at it
-      aimedTowardsScatterHitChance: 0.2 # 20% chance to hit it when making indirrect attack with it as target
+      scatterHitChance: 0.05 # 5% chance to hit this limb when making indirrect attack without aiming at it
+      aimedTowardsScatterHitChance: 0.1 # 10% chance to hit it when making indirrect attack with it as target
     - type: LimbDamageEffect
       effects:
         - effect: !type:LimbEffectDetach # Amputate limb when it takes slash damage

--- a/Resources/Prototypes/_FarHorizons/Body/base_organs.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/base_organs.yml
@@ -11,21 +11,6 @@
       redirectTarget: Torso # Which part to redirect attack to
       scatterHitChance: 0.05 # 5% chance to hit this limb when making indirrect attack without aiming at it
       aimedTowardsScatterHitChance: 0.1 # 10% chance to hit it when making indirrect attack with it as target
-    - type: LimbDamageEffect
-      effects:
-        - effect: !type:LimbEffectDetach # Amputate limb when it takes slash damage
-          condition: !type:LimbConditionSpecificDamage
-            damageType: Slash
-            damageAmount: 100
-        - effect: !type:LimbEffectDestroy # Gib limb. If it has organs (head), it will drop them
-          condition: !type:LimbConditionOr
-            conditions:
-              - !type:LimbConditionSpecificDamage
-                damageType: Blunt
-                damageAmount: 250
-              - !type:LimbConditionSpecificDamage
-                damageType: Heat
-                damageAmount: 500
 
 - type: entity
   parent: DamageableLimbBaseNoVisuals

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -672,4 +672,53 @@ binds:
   type: State
   key: V
   mod1: Control
+# Limbs
+- function: TargetNextLimb
+  type: State
+  key: Num3
+  mod1: Alt
+- function: TargetPreviousLimb
+  type: State
+  key: Num1
+  mod1: Alt
+- function: TargetTorso
+  type: State
+  key: NumpadNum5
+  mod1: Alt
+- function: TargetHead
+  type: State
+  key: NumpadNum8
+  mod1: Alt
+- function: TargetArmLeft
+  type: State
+  key: NumpadNum9
+  mod1: Alt
+- function: TargetArmRight
+  type: State
+  key: NumpadNum7
+  mod1: Alt
+- function: TargetHandLeft
+  type: State
+  key: NumpadNum6
+  mod1: Alt
+- function: TargetHandRight
+  type: State
+  key: NumpadNum4
+  mod1: Alt
+- function: TargetLegLeft
+  type: State
+  key: NumpadNum3
+  mod1: Alt
+- function: TargetLegRight
+  type: State
+  key: NumpadNum1
+  mod1: Alt
+- function: TargetFootLeft
+  type: State
+  key: NumpadNum2
+  mod1: Alt
+- function: TargetFootRight
+  type: State
+  key: NumpadNum0
+  mod1: Alt
 # Far Horizons end


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
More limb related content

## Why we need to add this
yes

## Media (Video/Screenshots)


https://github.com/user-attachments/assets/13c2e300-df89-4a5d-89e6-9d01175e3812


https://github.com/user-attachments/assets/d5b67176-23ec-4783-8f89-d6387c19ed39


https://github.com/user-attachments/assets/0c703d8f-2cd4-47c7-b81c-60c35d4405e8

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- tweak: Removed miss chance from direct attacks that target limbs. You may still randomly hit parts other than those you target, but you won't miss entirely.
- tweak: Reduced chance of hitting limbs randomly with indirect attacks
- add: Disarming limb damage effect - When organic hand or arm damage reaches threshold, and every instance of damage after, held items are dropped. Blunt damage is much more effective for this.
- add: Knockdown limb damage effect - Just like disarming on hands, excessive damage to legs and feet will cause you to drop down. Both disarming and knockdown only work on organic limbs and not on cybernetics/IPCs (as those already have similar effect on EMP and also not feel pain)
- add: Limb targeting hotkeys for your limb targeting needs. Configurable in options
- fix: Actually fixed topicals and welding to heal limbs and switch to torso now
