### PR TITLE
Fix contra tags on BSO and NTR shit

### DIFF
--- a/Resources/Locale/en-US/_FarHorizons/job/job-names.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/job/job-names.ftl
@@ -1,5 +1,6 @@
 job-name-secborg = Security Cyborg
 job-name-corpsman = Corpsman
+job-name-blueshield = Blueshield Officer
 job-name-cc-cad-official = CAD Official
 job-name-cc-csd-official = CSD Official
 job-name-cc-cid-official = CID Official

--- a/Resources/Locale/en-US/_Starlight/job/job.ftl
+++ b/Resources/Locale/en-US/_Starlight/job/job.ftl
@@ -1,7 +1,7 @@
 job-name-magistrate = Magistrate
 job-name-ntrep = NanoTrasen Representative
 job-name-iaa = Affairs Official
-job-name-blueshield = Officer “Blue Shield”
+job-name-blueshield = Blueshield Officer
 job-name-ntncblueshield = Nanotrasen Navy Corps Marine
 job-name-miningspec = Mining Specialist
 job-name-surgeon = Surgeon

--- a/Resources/Locale/en-US/_Starlight/job/job.ftl
+++ b/Resources/Locale/en-US/_Starlight/job/job.ftl
@@ -1,7 +1,6 @@
 job-name-magistrate = Magistrate
 job-name-ntrep = NanoTrasen Representative
 job-name-iaa = Affairs Official
-job-name-blueshield = Blueshield Officer
 job-name-ntncblueshield = Nanotrasen Navy Corps Marine
 job-name-miningspec = Mining Specialist
 job-name-surgeon = Surgeon

--- a/Resources/Prototypes/Entities/Objects/Devices/payload.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/payload.yml
@@ -81,7 +81,7 @@
 
 - type: entity
   name: flash payload
-  parent: [ BasePayload, BaseSecurityScienceCommandContraband ]
+  parent: [ BasePayload, BaseSecurityScienceCommandRepresentativesContraband ] # FH
   id: FlashPayload
   description: A single-use flash payload.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -125,7 +125,7 @@
 
 - type: entity
   name: flash
-  parent: [BaseItem, BaseSecurityScienceCommandContraband]
+  parent: [ BaseItem, BaseSecurityScienceCommandRepresentativesContraband ] # FH
   id: Flash
   description: An ultrabright flashbulb with a trigger, which causes the victim to be dazed and lose their eyesight for a moment. Useless when burnt out.
   components:

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -1,4 +1,4 @@
-﻿# generic "highly illegal" contraband; Syndicate/magical contraband are already considered highly illegal under Space Law,
+# generic "highly illegal" contraband; Syndicate/magical contraband are already considered highly illegal under Space Law,
 # so this is mostly for stuff that should be equally illegal but doesn't need its own unique contraband tier added
 - type: entity
   id: BaseHighlyIllegalContraband
@@ -88,6 +88,7 @@
   components:
   - type: Contraband
     allowedDepartments: [ Security ]
+    allowedJobs: [ BlueShield ] # FH
 
 - type: entity
   id: BaseEngineeringContraband
@@ -146,6 +147,7 @@
   components:
   - type: Contraband
     allowedDepartments: [ Security, Command ]
+    allowedJobs: [ BlueShield ] # FH
 
 - type: entity
   id: BaseSecurityScienceCommandContraband
@@ -154,6 +156,7 @@
   components:
   - type: Contraband
     allowedDepartments: [ Security, Science, Command ]
+    allowedJobs: [ BlueShield ] # FH
 
 - type: entity
   id: BaseSecurityEngineeringContraband
@@ -162,6 +165,7 @@
   components:
   - type: Contraband
     allowedDepartments: [ Security, Engineering ]
+    allowedJobs: [ BlueShield ] # FH
 
 - type: entity
   id: BaseSiliconScienceContraband
@@ -178,6 +182,7 @@
   components:
   - type: Contraband
     allowedDepartments: [ Security, Cargo ]
+    allowedJobs: [ BlueShield ] # FH
 
 - type: entity
   id: BaseMedicalScienceContraband
@@ -195,7 +200,7 @@
   components:
   - type: Contraband
     allowedDepartments: [ Security ]
-    allowedJobs: [ Bartender ]
+    allowedJobs: [ Bartender, BlueShield ]
 
 - type: entity
   id: BaseSecurityLawyerContraband
@@ -204,7 +209,7 @@
   components:
   - type: Contraband
     allowedDepartments: [ Security ]
-    allowedJobs: [ Lawyer ]
+    allowedJobs: [ Lawyer, BlueShield ]
 
 - type: entity
   id: BaseJanitorContraband

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -200,7 +200,7 @@
   components:
   - type: Contraband
     allowedDepartments: [ Security ]
-    allowedJobs: [ Bartender, BlueShield ]
+    allowedJobs: [ Bartender, BlueShield ] # FH
 
 - type: entity
   id: BaseSecurityLawyerContraband
@@ -209,7 +209,7 @@
   components:
   - type: Contraband
     allowedDepartments: [ Security ]
-    allowedJobs: [ Lawyer, BlueShield ]
+    allowedJobs: [ Lawyer, BlueShield ] # FH
 
 - type: entity
   id: BaseJanitorContraband

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Misc/identification_cards.yml
@@ -132,7 +132,7 @@
 #region Reps
 
 - type: entity
-  parent: [ IDCardStandard, BaseCommandContraband ]
+  parent: [ IDCardStandard, BaseRepresentativesContraband ]
   id: BlueShieldIDCard
   name: Blueshield Officer's ID Card
   components:
@@ -146,7 +146,7 @@
       heldPrefix: silver
 
 - type: entity
-  parent: [ IDCardStandard, BaseCommandContraband ]
+  parent: [ IDCardStandard, BaseRepresentativesContraband ]
   id: NanoTrasenRepresentativeIDCard
   name: NanoTrasen Representative ID Card
   components:

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/base_contraband.yml
@@ -1,6 +1,39 @@
-﻿- type: entity
+- type: entity
   id: BaseNanotrasenContraband
   abstract: true
   components:
   - type: Contraband
     severity: Nanotrasen
+
+- type: entity
+  id: BaseBlueshieldContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedJobs: [ BlueShield ]
+
+- type: entity
+  id: BaseBlueshieldCommandContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Command ]
+    allowedJobs: [ BlueShield ]
+
+- type: entity
+  id: BaseRepresentativesContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Representives ]
+
+- type: entity
+  id: BaseSecurityScienceCommandRepresentativesContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Security, Science, Command, Representives ]

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Back/backpacks.yml
@@ -17,7 +17,7 @@
     sprite: _Starlight/Clothing/Back/Backpacks/cargosenior.rsi
 
 - type: entity
-  parent: [ClothingBackpack, BaseCommandContraband]
+  parent: [ ClothingBackpack, BaseRepresentativesContraband ] # FH
   id: ClothingBackpackBlueShield
   name: blueshields backpack
   description: A lightweight but reliable backpack. Cant go wrong with the classics!

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Back/duffel.yml
@@ -39,7 +39,7 @@
     sprite: _Starlight/Clothing/Back/Duffels/cargosenior.rsi
 
 - type: entity
-  parent: [ClothingBackpackDuffel, BaseCommandContraband]
+  parent: [ ClothingBackpackDuffel, BaseRepresentativesContraband ] # FH
   id: ClothingBackpackDuffelBlueShield
   name: blueshield's duffel bag
   description: The bag for a Blueshield ready for any contingency. 

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Back/misc.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Back/misc.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [Clothing, BaseSecurityScienceCommandContraband]
+  parent: [ Clothing, BaseSecurityScienceCommandRepresentativesContraband ] # FH
   id: ClothingNullSpaceDrainer
   name: nullspace drainer
   description: A Superimposed device that occupies the physical and nullspace. Intaking external and foreign energy into data. This device restrains and blocks entities from entering and or leaving nullspace.

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Back/satchel.yml
@@ -17,7 +17,7 @@
     sprite: _Starlight/Clothing/Back/Satchels/cargosenior.rsi
 
 - type: entity
-  parent: [ClothingBackpackSatchel, BaseCommandContraband]
+  parent: [ ClothingBackpackSatchel, BaseRepresentativesContraband ] # FH
   id: ClothingBackpackSatchelBlueShield
   name: blueshield officer satchel
   description: Useful for holding everything a speedy blueshield officer needs!

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Belt/belts.yml
@@ -110,7 +110,7 @@
     damageCoefficient: 0
 
 - type: entity
-  parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseCommandContraband]
+  parent: [ ClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseBlueshieldContraband ] # FH
   id: ClothingBeltBlueShield
   name: Blueshield Webbing #Far Horizons - The Great Capitalization Crusade
   description: A tactical rig that can hold many items to save the lives of command.

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Ears/headsets_alt.yml
@@ -48,7 +48,7 @@
     sprite: Clothing/Ears/Headsets/command.rsi
 
 - type: entity
-  parent: [ClothingHeadsetAlt, BaseCommandContraband]
+  parent: [ ClothingHeadsetAlt, BaseBlueshieldContraband ] # FH
   id: ClothingHeadsetAltBSO
   name: officer blue shield over-ear headset
   components:

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Eyes/glasses.yml
@@ -58,7 +58,7 @@
     protectionTime: 5
 
 - type: entity
-  parent: [ClothingEyesBase, BaseCommandContraband]
+  parent: [ ClothingEyesBase, BaseBlueshieldContraband ] # FH
   id: ClothingEyesGlassesBlueShield
   name: Blueshield Officer's Glasses #Far Horizons - The Great Capitalization Crusade
   description: The innovative blue lenses hide your eyes from light flashes and have a built-in visor.

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Eyes/hud.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ ClothingEyesBase, BaseCommandContraband ]
+  parent: [ ClothingEyesBase, BaseBlueshieldContraband ] # FH
   id: ClothingEyesHudBlueShield
   name: Blueshield Officer's HUD #Far Horizons - The Great Capitalization Crusade
   description: An innovative heads-up display that scans the humanoids in view and provides accurate data about their ID status, security records, and medical information.
@@ -169,7 +169,7 @@
     protectionTime: 5
 
 - type: entity
-  parent: [ClothingEyesBase, BaseCommandContraband]
+  parent: [ ClothingEyesBase, BaseRepresentativesContraband ] # FH
   id: ClothingEyesNTRMonocle
   name: NanoTrasen Representative Monocle #Far Horizons - The Great Capitalization Crusade
   description: A fancy monocle that also functions as a HUD to make sure no functionality is lost for style.

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Head/hats.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ ClothingHeadBase, BaseRepresentativesContraband ]
+  parent: [ ClothingHeadBase, BaseRepresentativesContraband ] # FH
   id: ClothingHeadHatCapNtrep
   name: NT Representive Cap #Far Horizons - The Great Capitalization Crusade
   description: The cap of justice over command!
@@ -10,7 +10,7 @@
     sprite: _FarHorizons/Clothing/Head/Hats/ntrep.rsi #Far Horizons
     
 - type: entity
-  parent: [ ClothingHeadBase, BaseRepresentativesContraband ]
+  parent: [ ClothingHeadBase, BaseRepresentativesContraband ] # FH
   id: ClothingHeadHatBeretBlueShield
   name: Blueshield Officer's Beret #Far Horizons - The Great Capitalization Crusade
   description: This beret completes the outfit of any true BlueShield.
@@ -21,7 +21,7 @@
     sprite: _Starlight/Clothing/Head/Hats/blueshield.rsi
 
 - type: entity
-  parent: [ ClothingHeadBase, BaseRepresentativesContraband ]
+  parent: [ ClothingHeadBase, BaseRepresentativesContraband ] # FH
   id: ClothingHeadHatBlueShieldSheriff
   name: Blueshield Bounty Hunter's Hat #Far Horizons - The Great Capitalization Crusade
   description: For when your given charge do not wish to be tracked down.

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Head/hats.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ ClothingHeadBase, BaseCommandContraband ]
+  parent: [ ClothingHeadBase, BaseRepresentativesContraband ]
   id: ClothingHeadHatCapNtrep
   name: NT Representive Cap #Far Horizons - The Great Capitalization Crusade
   description: The cap of justice over command!
@@ -10,7 +10,7 @@
     sprite: _FarHorizons/Clothing/Head/Hats/ntrep.rsi #Far Horizons
     
 - type: entity
-  parent: [ClothingHeadBase, BaseCommandContraband]
+  parent: [ ClothingHeadBase, BaseRepresentativesContraband ]
   id: ClothingHeadHatBeretBlueShield
   name: Blueshield Officer's Beret #Far Horizons - The Great Capitalization Crusade
   description: This beret completes the outfit of any true BlueShield.
@@ -21,7 +21,7 @@
     sprite: _Starlight/Clothing/Head/Hats/blueshield.rsi
 
 - type: entity
-  parent: [ClothingHeadBase, BaseCommandContraband]
+  parent: [ ClothingHeadBase, BaseRepresentativesContraband ]
   id: ClothingHeadHatBlueShieldSheriff
   name: Blueshield Bounty Hunter's Hat #Far Horizons - The Great Capitalization Crusade
   description: For when your given charge do not wish to be tracked down.

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Masks/masks.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ ClothingMaskGas, BaseCommandContraband ]
+  parent: [ ClothingMaskGas, BaseBlueshieldContraband ] # FH
   id: ClothingMaskGasBSO
   name: Blue Swat Gas Mask
   description: A elite issue Security gas mask. Now in blue!

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
@@ -158,7 +158,7 @@
     price: 2000
 
 - type: entity
-  parent: [ ClothingNeckBase, BaseCommandContraband ]
+  parent: [ ClothingNeckBase, BaseRepresentativesContraband ] # FH
   id: ClothingNeckCloakBsoElite
   name: Blueshield Officer's Mantle # Far Horizons
   description: A Blueshield Officer's mantle crafted from the latest composite glowing fabric. Any true BlueShield is not afraid of shining in the dark! # Far Horizons
@@ -175,7 +175,7 @@
     price: 2000
 
 - type: entity
-  parent: [ ClothingNeckBase, BaseCommandContraband ]
+  parent: [ ClothingNeckBase, BaseRepresentativesContraband ] # FH
   id: ClothingNeckCloakBsoCape
   name: blueshield officer's formal cloak
   description: An incredibly large coat, owned only by the most experienced blueshields. It's said the sleeves have never been worn.
@@ -187,7 +187,7 @@
       - neck
 
 - type: entity
-  parent: [ ClothingNeckBase, BaseCommandContraband ]
+  parent: [ ClothingNeckBase, BaseRepresentativesContraband ] # FH
   id: ClothingNeckCloakBsoPoncho
   name: blueshield officer's poncho
   description: This type of poncho was the signature garment of a legendary BSO with no name, or so it is said.

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/armor.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingOuterArmorBase, BaseCommandContraband]
+  parent: [ ClothingOuterArmorBase, BaseBlueshieldContraband ] # FH
   id: ClothingOuterArmorBlueShield
   name: Blueshield Officer's Bulletproof Vest #Far Horizons - The Great Capitalization Crusade
   description: Much better than a standard type-1 security vest. Don't lose it, you will NOT get a replacement.

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/coats.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing, BaseCommandContraband]
+  parent: [ ClothingOuterStorageBase, AllowSuitStorageClothing, BaseBlueshieldContraband ] # FH
   id: ClothingOuterCoatBlueShield
   name: Blueshield Officer's Overcoat #Far Horizons - The Great Capitalization Crusade
   description: A coat worn by Blueshield Officers who don't mind a little diplomancy. Heavily reinforced for when diplomancy won't cut it.
@@ -31,7 +31,7 @@
   - type: Item
 
 - type: entity
-  parent: [ ClothingOuterStorageFoldableBase, BaseCommandContraband ]
+  parent: [ ClothingOuterStorageFoldableBase, BaseRepresentativesContraband ] # FH
   id: ClothingOuterCoatNtrep
   name: NT Representive Jacket #Far Horizons - The Great Capitalization Crusade
   description: A fancy black jacket, standart issue to Nanotrasen Representives.
@@ -56,7 +56,7 @@
       LegLeft: {}
 
 - type: entity
-  parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatNtrep, BaseCommandContraband ]
+  parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatNtrep ] # FH
   id: ClothingOuterCoatNtrepOpen
   name: NT Representive Jacket #Far Horizons - The Great Capitalization Crusade
 

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1,6 +1,6 @@
 #BSO Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseCommandContraband]
+  parent: [ ClothingOuterHardsuitBase, BaseBlueshieldContraband ] # FH
   id: ClothingOuterHardsuitBlueshield
   name: blueshield officer's hardsuit
   description: A high-tech hardsuit perfect for diving in front of Mr. Pre- Er, Captain.
@@ -49,7 +49,7 @@
 
 #NTRep Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseCommandContraband]
+  parent: [ ClothingOuterHardsuitBase, BaseRepresentativesContraband] # FH
   id: ClothingOuterHardsuitNtrep
   name: Nanotrasen Representative hardsuit
   description: It used to be blue, but too many premium cigars turned it tobacco brown.

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Shoes/magboots-bso.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Shoes/magboots-bso.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingShoesBootsMagBase, BaseCommandContraband, ClothingShoesMilitaryBase ]
+  parent: [ ClothingShoesBootsMagBase, BaseBlueshieldContraband, ClothingShoesMilitaryBase ] # FH
   id: ClothingShoesBootsMagBSO
   name: blueshield magboots
   description: A pair of standard magnetic boots, issued alongside the BSO Hardsuit.

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ ClothingUniformSkirtBase, BaseCommandContraband ]
+  parent: [ ClothingUniformSkirtBase, BaseRepresentativesContraband ] # FH
   id: ClothingUniformJumpskirtNtrep
   name: NT Representive Skirt #Far Horizons - The Great Capitalization Crusade
   description: That skirt that is better not to see.
@@ -10,7 +10,7 @@
     sprite: _FarHorizons/Clothing/Uniforms/Jumpskirt/ntrep.rsi #Far Horizons
 
 - type: entity
-  parent: [ ClothingUniformSkirtBase, BaseCommandContraband ]
+  parent: [ ClothingUniformSkirtBase, BaseRepresentativesContraband ] # FH
   id: ClothingUniformJumpskirtNtrepTurtleneck
   name: NT Representive's Turtleneck Jumpskirt #Far Horizons - The Great Capitalization Crusade
   description: For a more casual look while on the job.
@@ -21,7 +21,7 @@
     sprite: _FarHorizons/Clothing/Uniforms/Jumpskirt/ntrepturtleneck.rsi #Far Horizons
     
 - type: entity
-  parent: [ ClothingUniformSkirtBase, BaseCommandContraband ]
+  parent: [ ClothingUniformSkirtBase, BaseRepresentativesContraband ] # FH
   id: ClothingUniformJumpskirtBlueShield
   name: Blueshield Officer's Skirt #Far Horizons - The Great Capitalization Crusade
   description: Skirt of a glorified bodyguard
@@ -32,7 +32,7 @@
     sprite: _Starlight/Clothing/Uniforms/Jumpskirt/blueshield.rsi
 
 - type: entity
-  parent: [ ClothingUniformSkirtBase, BaseCommandContraband ]
+  parent: [ ClothingUniformSkirtBase, BaseRepresentativesContraband ] # FH
   id: ClothingUniformJumpskirtEliteBlueShield
   name: Elite Blueshield Officer's Skirt #Far Horizons - The Great Capitalization Crusade
   description: Skirt of an elite blueshield. To reach such a level, you must have protected command from a [REDACTED] threat.

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -27,7 +27,7 @@
   - type: VentCrawClothing
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseCommandContraband ]
+  parent: [ ClothingUniformBase, BaseRepresentativesContraband ] # FH
   id: MagistrateUniformSuit
   name: Magistrate's Jumpsuit
   components:
@@ -37,7 +37,7 @@
     sprite: _FarHorizons/Clothing/Uniforms/Jumpsuit/magistrate.rsi #Far Horizons
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseCommandContraband ]
+  parent: [ ClothingUniformBase, BaseRepresentativesContraband ] # FH
   id: ClothingUniformJumpsuitNtrep
   name: NT Representive Suit #Far Horizons - The Great Capitalization Crusade
   description: That suit that is better not to see.
@@ -48,7 +48,7 @@
     sprite: _FarHorizons/Clothing/Uniforms/Jumpsuit/ntrep.rsi #Far Horizons
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseCommandContraband ]
+  parent: [ ClothingUniformBase, BaseRepresentativesContraband ] # FH
   id: ClothingUniformJumpsuitNtrepFormal
   name: NT Representive Formal Suit #Far Horizons - The Great Capitalization Crusade
   description: That suit that is better not to see.
@@ -59,7 +59,7 @@
     sprite: _FarHorizons/Clothing/Uniforms/Jumpsuit/ntrepformal.rsi #Far Horizons
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseCommandContraband ]
+  parent: [ ClothingUniformBase, BaseRepresentativesContraband ] # FH
   id: ClothingUniformJumpsuitNtrepTurtleNeck
   name: NT Representive's Turtleneck Jumpsuit #Far Horizons - The Great Capitalization Crusade
   description: For a more casual look while on the job.
@@ -70,7 +70,7 @@
     sprite: _FarHorizons/Clothing/Uniforms/Jumpsuit/ntrepturtleneck.rsi #Far Horizons
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseCommandContraband ]
+  parent: [ ClothingUniformBase, BaseRepresentativesContraband ] # FH
   id: ClothingUniformJumpsuitNtrepNoble
   name: NT Representive's Noble Jumpsuit #Far Horizons - The Great Capitalization Crusade
   description: A more classical and elegant style of clothing, designed to emulate the fashion of old earth nobility.
@@ -81,7 +81,7 @@
     sprite: _FarHorizons/Clothing/Uniforms/Jumpsuit/ntrepnoble.rsi #Far Horizons
 
 - type: entity
-  parent: [ClothingUniformBase, BaseCommandContraband]
+  parent: [ ClothingUniformBase, BaseRepresentativesContraband ] # FH
   id: ClothingUniformJumpsuitBlueShield
   name: Blueshield Officer's Suit #Far Horizons - The Great Capitalization Crusade
   description: Suit of a glorified bodyguard
@@ -92,7 +92,7 @@
     sprite: _Starlight/Clothing/Uniforms/Jumpsuit/blueshield.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseCommandContraband]
+  parent: [ ClothingUniformBase, BaseRepresentativesContraband ] # FH
   id: ClothingUniformJumpsuitEliteBlueShield
   name: Elite Blueshield Officer's Suit #Far Horizons - The Great Capitalization Crusade
   description: Suit of an elite blueshield. To reach such a level, you must have protected command from a [REDACTED] threat.
@@ -103,7 +103,7 @@
     sprite: _Starlight/Clothing/Uniforms/Jumpsuit/eliteblueshield.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseCommandContraband]
+  parent: [ ClothingUniformBase, BaseRepresentativesContraband ] # FH
   id: ClothingUniformJumpsuitBlueShieldCaptain
   name: Blueshield Officer's Shirt #Far Horizons - The Great Capitalization Crusade
   description: A classic suit in theme with a blueshield. 

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/rubber_stamp.yml
@@ -15,7 +15,7 @@
 
 - type: entity
   name: NT representative's rubber stamp
-  parent: [ RubberStampBase, BaseCommandContraband ]
+  parent: [ RubberStampBase, BaseRepresentativesContraband ] # FH
   id: RubberStampNtrep
   suffix: DO NOT MAP
   components:
@@ -43,7 +43,7 @@
 
 - type: entity
   name: blueshield officer's rubber stamp
-  parent: RubberStampBase
+  parent: [ RubberStampBase, BaseRepresentativesContraband ] # FH
   id: RubberStampBSO
   suffix: DO NOT MAP
   components:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/handheld_bso_crew_monitor.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/handheld_bso_crew_monitor.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: CommandFriend™ X-02
-  parent: [ BaseHandheldComputer, BaseCommandContraband ]
+  parent: [ BaseHandheldComputer, BaseBlueshieldCommandContraband ] # FH
   id: HandheldBSOCrewMonitor
   description: Does not monitor the competence levels of command members.
   components:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -162,7 +162,7 @@
 
 - type: entity
   name: X-01 Multiphase Energy Gun #Far Horizons - The Great Capitalization Crusade
-  parent: [ BaseWeaponBatterySmall, BaseSecurityContraband ]
+  parent: [ BaseWeaponBatterySmall, BaseBlueshieldContraband ] # FH
   id: WeaponMultiphaseGun
   description: This is an expensive, modern version of the antique laser pistol, with several unique fire modes.
   components:


### PR DESCRIPTION
## Short description
This fixes the contra tags on things the BSO and NTR start with to prevent the “you probably shouldn’t be visibly carring this around without a good reason” tooltips. Also renames BSO as requested by @KillerTheFlareon.

## Why we need to add this
fixes #1133

## Media (Video/Screenshots)
<img width="753" height="34" src="https://github.com/user-attachments/assets/97e26180-f31e-45e6-9beb-8bada8d4a1bb" />
<img width="638" height="135" src="https://github.com/user-attachments/assets/257e1ba7-6f07-47ac-aac8-0d34b5505ad4" />
<img width="897" height="195" src="https://github.com/user-attachments/assets/fd2838c4-cf2a-4b9b-8207-519eab8ad176" />
<img width="769" height="153" src="https://github.com/user-attachments/assets/1c893f76-62c3-42cb-99a0-34be4b5c2312" />
<img width="643" height="126" src="https://github.com/user-attachments/assets/49ea813d-5b69-4838-9887-730e9eb171b2" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**

:cl: qriqii
- tweak: Renamed the BSO from “Officer “Blue Shield”” to “Blueshield Officer”.
- tweak: Made sec contra also legal for the BSO.
- fix: Fixed items the BSO and NTR start with having incorrect contra tags.