### PR TITLE
inspectable inorganic damage

### DIFF
--- a/Content.Server/_FarHorizons/Body/ConnectedOrganSystem.cs
+++ b/Content.Server/_FarHorizons/Body/ConnectedOrganSystem.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Shared._FarHorizons.Body;
 using Content.Shared.Body;
 using Content.Server.Mind;
+using Content.Shared.Starlight.Medical.Surgery.Steps.Parts;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server._FarHorizons.Body;
@@ -32,6 +33,10 @@ public sealed partial class ConnectedOrganSystem : SharedConnectedOrganSystem
             !TryComp<BodyComponent>(args.Target, out var body) || 
             body.Organs == null) 
             return;
+
+        // Sanity check to avoid endless bleed damage when they reattach surgically removed limbs
+        if (HasComp<IncisionOpenComponent>(ent))
+            RemCompDeferred<IncisionOpenComponent>(ent);
         
         var connectedCategories = _protoMan.EnumeratePrototypes<OrganCategoryPrototype>()
             .Where(p => p.ConnectsTo == ent.Comp.Category).Select(p => (ProtoId<OrganCategoryPrototype>)p.ID).ToList();

--- a/Content.Server/_FarHorizons/Body/ConnectedOrganSystem.cs
+++ b/Content.Server/_FarHorizons/Body/ConnectedOrganSystem.cs
@@ -48,12 +48,12 @@ public sealed partial class ConnectedOrganSystem : SharedConnectedOrganSystem
         if(HasComp<VisualOrganComponent>(ent))
         {
             var entName = MetaData(args.Target).EntityName;
-            _metaData.SetEntityName(ent, $"{entName}'s {GetPartName(ent.Owner)}");
+            _metaData.SetEntityName(ent, $"{entName}'s {GetPartName(ent.Owner)}", raiseEvents: false);
 
             if(TryComp<HeadOrganComponent>(ent, out var head))
             {
                 head.NameBackup = $"{entName}";
-                _metaData.SetEntityName(args.Target, "Unknown");
+                _metaData.SetEntityName(args.Target, "Unknown", raiseEvents: false);
             }
         }
     }

--- a/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.API.cs
+++ b/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.API.cs
@@ -6,6 +6,7 @@ using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
 using Content.Shared.Medical.Healing;
+using Content.Shared.Tag;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
@@ -14,16 +15,19 @@ namespace Content.Shared._FarHorizons.LimbDamage;
 public partial class LimbDamageSystem
 {
     public static ProtoId<OrganCategoryPrototype> DefaultLimb = "Torso";
+    public static ProtoId<TagPrototype> InorganicTag = "Inorganic";
 
     public bool TryChangeLimbDamage(Entity<LimbDamageableComponent?> target, ProtoId<OrganCategoryPrototype> targetLimb,
         DamageSpecifier damage, out DamageSpecifier bodyDamageDealt, bool ignoreResistances = false,
         bool interruptsDoAfters = true, EntityUid? origin = null, bool ignoreGlobalModifiers = false,
-        float armorPenetration = 0, bool canHeal = true, bool skipBodyDamage = false) => TryChangeLimbDamage(target, targetLimb, damage,
+        float armorPenetration = 0, bool canHeal = true, bool skipBodyDamage = false) => TryChangeLimbDamage(target,
+        targetLimb, damage,
         out bodyDamageDealt, out _, ignoreResistances, interruptsDoAfters, origin, ignoreGlobalModifiers,
         armorPenetration, canHeal, skipBodyDamage);
 
     public bool TryChangeLimbDamage(Entity<LimbDamageableComponent?> target, ProtoId<OrganCategoryPrototype> targetLimb,
-        DamageSpecifier damage, out DamageSpecifier bodyDamageDealt, out DamageSpecifier limbDamageDealt, bool ignoreResistances = false,
+        DamageSpecifier damage, out DamageSpecifier bodyDamageDealt, out DamageSpecifier limbDamageDealt,
+        bool ignoreResistances = false,
         bool interruptsDoAfters = true, EntityUid? origin = null, bool ignoreGlobalModifiers = false,
         float armorPenetration = 0, bool canHeal = true, bool skipBodyDamage = false)
     {
@@ -33,7 +37,7 @@ public partial class LimbDamageSystem
         if (!Resolve(target, ref target.Comp, false) ||
             target.Comp.DefaultLimb == targetLimb)
             return false; // Damage to torso is vanilla damage system which we don't handle.
-        
+
         var targetLimbEnt = GetAllDamageable(target).Where(p => p.Comp.Organ!.Category == targetLimb).FirstOrNull();
         if (targetLimbEnt == null)
             return false;
@@ -49,14 +53,17 @@ public partial class LimbDamageSystem
         return true;
     }
 
-    public void ChangeDamageAll(Entity<LimbDamageableComponent?> target, DamageSpecifier damage, bool ignoreResistances = false, bool interruptsDoAfters = true, EntityUid? origin = null, bool ignoreGlobalModifiers = false, float armorPenetration = 0, bool canHeal = true)
+    public void ChangeDamageAll(Entity<LimbDamageableComponent?> target, DamageSpecifier damage,
+        bool ignoreResistances = false, bool interruptsDoAfters = true, EntityUid? origin = null,
+        bool ignoreGlobalModifiers = false, float armorPenetration = 0, bool canHeal = true)
     {
         if (!Resolve(target, ref target.Comp, false))
             return;
 
         var allLimbs = GetAllDamageable(target);
         foreach (var limb in allLimbs)
-            _damageable.ChangeDamage(limb.Owner, damage, ignoreResistances, interruptsDoAfters, origin, ignoreGlobalModifiers, armorPenetration, canHeal);
+            _damageable.ChangeDamage(limb.Owner, damage, ignoreResistances, interruptsDoAfters, origin,
+                ignoreGlobalModifiers, armorPenetration, canHeal);
     }
 
     public DamageSpecifier HealAllEvenly(Entity<LimbDamageableComponent?> target, FixedPoint2 amount,
@@ -82,7 +89,8 @@ public partial class LimbDamageSystem
             _damageable.ClearAllDamage((limb.Owner, limb.Comp.Damageable));
     }
 
-    public bool LimbHasDamage(Entity<LimbDamageableComponent?> target, ProtoId<OrganCategoryPrototype> targetLimb, HealingComponent healing)
+    public bool LimbHasDamage(Entity<LimbDamageableComponent?> target, ProtoId<OrganCategoryPrototype> targetLimb,
+        HealingComponent healing)
     {
         var limb = GetAllDamageable(target).Where(p => p.Comp.Organ!.Category == targetLimb).FirstOrNull();
         if (limb?.Comp.Damageable == null)
@@ -94,7 +102,8 @@ public partial class LimbDamageSystem
         return false;
     }
 
-    public bool CheckAttackHit(Entity<LimbDamageableComponent?> target, ProtoId<OrganCategoryPrototype> targetLimb, out ProtoId<OrganCategoryPrototype>? overrideTarget)
+    public bool CheckAttackHit(Entity<LimbDamageableComponent?> target, ProtoId<OrganCategoryPrototype> targetLimb,
+        out ProtoId<OrganCategoryPrototype>? overrideTarget)
     {
         overrideTarget = null;
 
@@ -103,29 +112,31 @@ public partial class LimbDamageSystem
 
         var ev = new LimbHitCheckEvent(targetLimb);
         RaiseLocalEvent(target, ref ev);
-        
+
         overrideTarget = ev.HitTarget;
         return overrideTarget != null;
     }
 
-    public bool CheckAttackHit(Entity<LimbDamageableComponent?> target, Entity<LimbTargettingComponent?> source, out ProtoId<OrganCategoryPrototype>? overrideTarget)
+    public bool CheckAttackHit(Entity<LimbDamageableComponent?> target, Entity<LimbTargettingComponent?> source,
+        out ProtoId<OrganCategoryPrototype>? overrideTarget)
     {
         overrideTarget = null;
 
         if (!Resolve(target, ref target.Comp, false) ||
-            !Resolve(source, ref source.Comp, false)) 
+            !Resolve(source, ref source.Comp, false))
             return true; // No missing when attack shouldn't be handled by limb damage
-        
+
         if (source.Comp.Target == target.Comp.DefaultLimb)
         {
             overrideTarget = source.Comp.Target;
             return true;
         }
-        
+
         return CheckAttackHit(target, source.Comp.Target, out overrideTarget);
     }
 
-    public ProtoId<OrganCategoryPrototype>? TryScatterHitTarget(Entity<LimbDamageableComponent?> target, ProtoId<OrganCategoryPrototype>? aimedTowards = null)
+    public ProtoId<OrganCategoryPrototype>? TryScatterHitTarget(Entity<LimbDamageableComponent?> target,
+        ProtoId<OrganCategoryPrototype>? aimedTowards = null)
     {
         if (!Resolve(target, ref target.Comp, false))
             return null;
@@ -174,8 +185,9 @@ public partial class LimbDamageSystem
         foreach (var limb in allDamageable)
             if (limb.Comp.Organ!.Category != null &&
                 limb.Comp.Damageable != null)
-                damage[limb.Comp.Organ!.Category.Value] = _damageable.GetPositiveDamage((limb.Owner, limb.Comp.Damageable)).DamageDict;
-        
+                damage[limb.Comp.Organ!.Category.Value] =
+                    _damageable.GetPositiveDamage((limb.Owner, limb.Comp.Damageable)).DamageDict;
+
         return damage;
     }
 
@@ -187,7 +199,7 @@ public partial class LimbDamageSystem
 
         Dictionary<ProtoId<OrganCategoryPrototype>, IReadOnlyDictionary<ProtoId<DamageGroupPrototype>, FixedPoint2>>
             damage = new() { [DefaultLimb] = _damageable.GetDamagePerGroup((ent, ent.Comp1)) };
-        
+
 
         if (!Resolve(ent, ref ent.Comp2, false))
             return damage;
@@ -196,8 +208,9 @@ public partial class LimbDamageSystem
         foreach (var limb in allDamageable)
             if (limb.Comp.Organ!.Category != null &&
                 limb.Comp.Damageable != null)
-                damage[limb.Comp.Organ!.Category.Value] = _damageable.GetDamagePerGroup((limb.Owner, limb.Comp.Damageable));
-        
+                damage[limb.Comp.Organ!.Category.Value] =
+                    _damageable.GetDamagePerGroup((limb.Owner, limb.Comp.Damageable));
+
         return damage;
     }
 
@@ -245,5 +258,17 @@ public partial class LimbDamageSystem
             else
                 RemCompDeferred<ChangelingLimbComponent>(limb);
         }
+    }
+
+    public List<ProtoId<OrganCategoryPrototype>> GetInorganicOrgans(Entity<LimbDamageableComponent?> target)
+    {
+        if (!Resolve(target, ref target.Comp, false) ||
+            target.Comp.Body is not { Organs: not null })
+            return new();
+
+        return target.Comp.Body.Organs.ContainedEntities
+            .Select(p => (Entity<OrganComponent?>)(p, CompOrNull<OrganComponent>(p)))
+            .Where(p => p.Comp is { Category: not null } && _tag.HasTag(p.Owner, InorganicTag))
+            .Select(p => p.Comp!.Category!.Value).ToList();
     }
 }

--- a/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.Inspect.cs
+++ b/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.Inspect.cs
@@ -108,6 +108,7 @@ public partial class LimbDamageSystem
         var msg = new FormattedMessage();
 
         var fullDamage = TryGetFullBodyDamage((ent, null, ent.Comp));
+        var inorganicLimbs = GetInorganicOrgans(ent.AsNullable());
 
         if (fullDamage == null)
             return msg;
@@ -122,6 +123,8 @@ public partial class LimbDamageSystem
         foreach (var limb in _inspectOrder)
         {
             var limbName = Loc.GetString($"limb-category-limb-name-{limb.Id.ToLower()}");
+            var inorganic = inorganicLimbs.Contains(limb);
+
             string? finalMessage = null;
 
             if (!fullDamage.TryGetValue(limb, out var limbDamage))
@@ -133,7 +136,7 @@ public partial class LimbDamageSystem
                 if (thresholds.Count != 0)
                     finalMessage = Loc.GetString("limb-health-damage-combined",
                         ("target", Identity.Entity(ent, EntityManager)), ("limb", limbName),
-                        ("damage", ProcessDamageText(thresholds)));
+                        ("damage", ProcessDamageText(thresholds, inorganic)));
             }
 
             if (finalMessage == null) continue;
@@ -229,6 +232,7 @@ public partial class LimbDamageSystem
         var limbName = Loc.GetString($"limb-category-limb-name-{ent.Comp.Organ.Category.Value.Id.ToLower()}");
         var damage = _damageable.GetPositiveDamage((ent.Owner, ent.Comp.Damageable)).DamageDict;
         var thresholds = ProcessThresholds(damage, _inspectThresholds);
+        var inorganic = _tag.HasTag(ent.Owner, InorganicTag);
 
         string baseMessage;
 
@@ -236,7 +240,7 @@ public partial class LimbDamageSystem
             baseMessage = Loc.GetString("limb-health-examinable-detached-ok", ("limb", limbName));
         else
             baseMessage = Loc.GetString("limb-health-examinable-detached-damage-combined", ("limb", limbName),
-                ("damage", ProcessDamageText(thresholds)));
+                ("damage", ProcessDamageText(thresholds, inorganic)));
         
         msg.AddMarkupOrThrow(baseMessage);
 
@@ -250,6 +254,7 @@ public partial class LimbDamageSystem
                 var organName = Loc.GetString($"limb-category-limb-name-{damageableOrgan.Organ.Category.Value.Id.ToLower()}");
                 var organDamage = _damageable.GetPositiveDamage((organ, damageableOrgan.Damageable)).DamageDict;
                 var organThresholds = ProcessThresholds(organDamage, _inspectThresholds);
+                var organInorganic = _tag.HasTag(organ, InorganicTag);
 
                 msg.PushNewline();
 
@@ -258,7 +263,7 @@ public partial class LimbDamageSystem
                         ("limb", organName)));
                 else
                     msg.AddMarkupOrThrow(Loc.GetString("limb-health-examinable-detached-attachment-damage-combined",
-                        ("limb", organName), ("damage", ProcessDamageText(organThresholds))));
+                        ("limb", organName), ("damage", ProcessDamageText(organThresholds, organInorganic))));
             }
 
         return msg;
@@ -277,11 +282,13 @@ public partial class LimbDamageSystem
         return result;
     }
 
-    private string ProcessDamageText(Dictionary<ProtoId<DamageTypePrototype>, FixedPoint2> limbThresholds)
+    private string ProcessDamageText(Dictionary<ProtoId<DamageTypePrototype>, FixedPoint2> limbThresholds, bool inorganic = false)
     {
+        var damagePrefix = inorganic ? "limb-health-silicon-" : "limb-health-";
+
         List<string> damageStrings = new();
         foreach (var (damage, threshold) in limbThresholds)
-            if (Loc.TryGetString($"limb-health-{damage.Id.ToLower()}-{threshold}", out var damageString))
+            if (Loc.TryGetString($"{damagePrefix}{damage.Id.ToLower()}-{threshold}", out var damageString))
                 damageStrings.Add(damageString);
 
         if (damageStrings.Count == 0)

--- a/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.cs
+++ b/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Body;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Examine;
+using Content.Shared.Tag;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -14,6 +15,7 @@ public sealed partial class LimbDamageSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPrototypeManager _protoMan = default!;
     [Dependency] private readonly ExamineSystemShared _examine = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
 
     public override void Initialize()
     {

--- a/Resources/Locale/en-US/_FarHorizons/health-examinable/limb-health-examinable.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/health-examinable/limb-health-examinable.ftl
@@ -48,3 +48,33 @@ limb-health-shock-50 = is carbonized and smoking
 limb-health-caustic-10 = is discolored
 limb-health-caustic-30 = has bubbling burns
 limb-health-caustic-50 = is violently sizzling
+
+
+
+limb-health-silicon-blunt-10 = is slightly dented
+limb-health-silicon-blunt-30 = is crumpled and deformed
+limb-health-silicon-blunt-50 = is crushed
+
+limb-health-silicon-slash-10 = is scratched
+limb-health-silicon-slash-30 = has deep metal gouges
+limb-health-silicon-slash-50 = is sliced open
+
+limb-health-silicon-piercing-10 = has small puncture
+limb-health-silicon-piercing-30 = is pierced in several spots
+limb-health-silicon-piercing-50 = is riddled with holes
+
+limb-health-silicon-heat-10 = is slightly warped
+limb-health-silicon-heat-30 = is starting to melt
+limb-health-silicon-heat-50 = is melted into a slag
+
+limb-health-silicon-cold-10 = is coated in frost crystals
+limb-health-silicon-cold-30 = has ice clogging internals
+limb-health-silicon-cold-50 = has cold cracks
+
+limb-health-silicon-shock-10 = is twitching with static
+limb-health-silicon-shock-30 = is smelling of burnt electronics
+limb-health-silicon-shock-50 = is a fried mess
+
+limb-health-silicon-caustic-10 = is oxidizing on the surface
+limb-health-silicon-caustic-30 = has bubbling chemical erosion
+limb-health-silicon-caustic-50 = is dissolving into a sludge

--- a/Resources/Locale/en-US/_FarHorizons/health-examinable/limb-health-examinable.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/health-examinable/limb-health-examinable.ftl
@@ -63,18 +63,18 @@ limb-health-silicon-piercing-10 = has small puncture
 limb-health-silicon-piercing-30 = is pierced in several spots
 limb-health-silicon-piercing-50 = is riddled with holes
 
-limb-health-silicon-heat-10 = is slightly warped
-limb-health-silicon-heat-30 = is starting to melt
-limb-health-silicon-heat-50 = is melted into a slag
+limb-health-silicon-heat-10 = has some scorch marks
+limb-health-silicon-heat-30 = is somewhat warped
+limb-health-silicon-heat-50 = is warped and partially slagged
 
-limb-health-silicon-cold-10 = is coated in frost crystals
+limb-health-silicon-cold-10 = is coated in frost
 limb-health-silicon-cold-30 = has ice clogging internals
-limb-health-silicon-cold-50 = has cold cracks
+limb-health-silicon-cold-50 = has thick reflective layer of ice
 
-limb-health-silicon-shock-10 = is twitching with static
+limb-health-silicon-shock-10 = is sparking and twitching occasionally
 limb-health-silicon-shock-30 = is smelling of burnt electronics
-limb-health-silicon-shock-50 = is a fried mess
+limb-health-silicon-shock-50 = is looking burnt and its surface peeling off
 
-limb-health-silicon-caustic-10 = is oxidizing on the surface
-limb-health-silicon-caustic-30 = has bubbling chemical erosion
-limb-health-silicon-caustic-50 = is dissolving into a sludge
+limb-health-silicon-caustic-10 = looks tarnished
+limb-health-silicon-caustic-30 = is eroded on the surface
+limb-health-silicon-caustic-50 = has a thick iridescent oxidized layer

--- a/Resources/Prototypes/_FarHorizons/Body/Cybernetic/base.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Cybernetic/base.yml
@@ -77,6 +77,9 @@
               - !type:LimbConditionSpecificDamage
                 damageType: Heat
                 damageAmount: 500
+    - type: Tag
+      tags:
+        - Inorganic
 
 - type: entity
   parent: [ OrganBaseArmLeft, OrganCyberExternal ]
@@ -110,6 +113,9 @@
               - !type:LimbConditionSpecificDamage
                 damageType: Heat
                 damageAmount: 500
+    - type: Tag
+      tags:
+        - Inorganic
 
 - type: entity
   parent: [ OrganBaseHandRight, OrganCyberExternal ]
@@ -143,6 +149,9 @@
               - !type:LimbConditionSpecificDamage
                 damageType: Heat
                 damageAmount: 300
+    - type: Tag
+      tags:
+        - Inorganic
 
 - type: entity
   parent: [ OrganBaseHandLeft, OrganCyberExternal ]
@@ -176,6 +185,9 @@
               - !type:LimbConditionSpecificDamage
                 damageType: Heat
                 damageAmount: 300
+    - type: Tag
+      tags:
+        - Inorganic
 
 - type: entity
   parent: [ OrganBaseLegRight, OrganCyberExternal ]
@@ -211,6 +223,9 @@
               - !type:LimbConditionSpecificDamage
                 damageType: Heat
                 damageAmount: 500
+    - type: Tag
+      tags:
+        - Inorganic
 
 - type: entity
   parent: [ OrganBaseLegLeft, OrganCyberExternal ]
@@ -246,6 +261,9 @@
               - !type:LimbConditionSpecificDamage
                 damageType: Heat
                 damageAmount: 500
+    - type: Tag
+      tags:
+        - Inorganic
 
 - type: entity
   parent: [ OrganBaseFootRight, OrganCyberExternal ]
@@ -281,6 +299,9 @@
               - !type:LimbConditionSpecificDamage
                 damageType: Heat
                 damageAmount: 300
+    - type: Tag
+      tags:
+        - Inorganic
 
 - type: entity
   parent: [ OrganBaseFootLeft, OrganCyberExternal ]
@@ -316,3 +337,6 @@
               - !type:LimbConditionSpecificDamage
                 damageType: Heat
                 damageAmount: 300
+    - type: Tag
+      tags:
+        - Inorganic


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
adds text for inorganic damage so robots don't run around with bruises and and blisters

## Why we need to add this
RP

## Media (Video/Screenshots)
<img width="517" height="302" alt="image" src="https://github.com/user-attachments/assets/760cea77-04ec-4553-aecb-661aa91c39e8" />
<img width="368" height="248" alt="image" src="https://github.com/user-attachments/assets/f160bca0-9d7d-4a4f-b17a-46176cb2dbf9" />
<img width="574" height="326" alt="image" src="https://github.com/user-attachments/assets/eb1c5451-4730-46df-affd-5ad8fd69b497" />
<img width="494" height="320" alt="image" src="https://github.com/user-attachments/assets/fee497ca-1fea-4882-860e-e776845bb77c" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- add: Health inspect text for inorganic limbs is now different from organics.
- fix: Fixed cybernetic limbs being considered meat
- fix: Removing someone's head will no longer rename their ID and their station records
- fix: Slimes no longer bleed after reattaching surgically removed limbs