### PR TITLE
Gives Security Cadets Access To Security Again

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -16,7 +16,7 @@
   supervisors: job-supervisors-security
   canBeAntag: false
   access:
-# - Security # Starlight change
+  - Security # Far Horizon Change
   - Cadet # Starlight change
   - Brig
   - Maintenance


### PR DESCRIPTION
Yes its not wizden Repo

## Short description
Allows Cadets to access sec again, this means lockers, the turret in the armory wont shoot them and most importantly they can actually be taught how to properly imprison somebody.

## Why we need to add this
Its an SL holdover  that makes no sense whatsoever. Also Killer was a killer and asked me to change it quickly for him.

## Media (Video/Screenshots)

<img width="1111" height="860" alt="image" src="https://github.com/user-attachments/assets/9ca6912c-27b4-477e-87e1-204cc123fe35" />

<img width="564" height="556" alt="image" src="https://github.com/user-attachments/assets/a10dfb55-e449-4a3a-8017-85fe241ded17" />

<img width="470" height="372" alt="image" src="https://github.com/user-attachments/assets/cabf650c-d5fc-47d2-9ef2-df43b4053798" />

<img width="506" height="321" alt="image" src="https://github.com/user-attachments/assets/faf061bd-d19c-4f77-82ef-0a13786f490c" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: IrkallaEpsilon
- tweak: Changed something important. Sec Cadets can access sec lockers again and can imprison folks now. Useful for teaching them how to.
