### PR TITLE
More assorted fixes

### DIFF
--- a/Content.Shared/_FarHorizons/Silicons/IPC/Components/IPCRadioComponent.cs
+++ b/Content.Shared/_FarHorizons/Silicons/IPC/Components/IPCRadioComponent.cs
@@ -5,23 +5,23 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared._FarHorizons.Silicons.IPC.Components;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class IPCRadioComponent : Component
 {
-    [DataField]
+    [DataField, AutoNetworkedField]
     public bool CopyHeadsetKeys = false;
-    [DataField("removeHeadset")]
+    [DataField("removeHeadset"), AutoNetworkedField]
     public bool RemoveHeadsetOnRoundstart = false;
-    [DataField]
+    [DataField, AutoNetworkedField]
     public int KeysCapacity = 0;
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public string EncryptionKeysContainerID = "key_slots";
-    [DataField]
+    [DataField, AutoNetworkedField]
     public string HeadsetContainerID = "ears";
-    [DataField]
+    [DataField, AutoNetworkedField]
     public SoundSpecifier KeyInsertionSound = new SoundPathSpecifier("/Audio/Items/pistol_magin.ogg");
-    [DataField]
+    [DataField, AutoNetworkedField]
     public SoundSpecifier KeyExtractionSound = new SoundPathSpecifier("/Audio/Items/pistol_magout.ogg");
 
     [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/_FarHorizons/Vehicles/SharedVehicleSystem.cs
+++ b/Content.Shared/_FarHorizons/Vehicles/SharedVehicleSystem.cs
@@ -56,6 +56,7 @@ using Content.Shared.CombatMode.Pacification;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Hands;
 using Content.Shared._FarHorizons.ReagentDraw.EntitySystems;
+using Robust.Shared.Network;
 
 namespace Content.Shared._FarHorizons.Vehicles;
 
@@ -90,6 +91,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
     [Dependency] private readonly SharedGunSystem _gun = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly INetManager _net = default!;
     private static readonly ProtoId<TagPrototype> _vehicleKeyTag = "VehicleKey";
     private static readonly string _bluntname = "Blunt";
     private EntityQuery<ProjectileComponent> _projQuery;
@@ -298,11 +300,8 @@ public abstract partial class SharedVehicleSystem : EntitySystem
 
             for (var i = 0; i < ent.Comp.HandsNeeded; i++)
             {
-                if (_virtualItem.TrySpawnVirtualItem(ent.Owner, ent.Comp.Rider.Value, out var virtItem))
-                {
+                if (_virtualItem.TrySpawnVirtualItemInHand(ent.Owner, ent.Comp.Rider.Value, out var virtItem, true, silent: true))
                     EnsureComp<UnremoveableComponent>(virtItem.Value);
-                    _handsSystem.TryForcePickupAnyHand(ent.Comp.Rider.Value, virtItem.Value);
-                }
             }
         }
 
@@ -333,7 +332,8 @@ public abstract partial class SharedVehicleSystem : EntitySystem
 
     private void HandleCollide(Entity<VehicleComponent> ent, ref StartCollideEvent args)
     {
-        if(!_gameTiming.IsFirstTimePredicted) return;
+        if(_net.IsClient) return;
+
         if(ent.Comp.Rider == null) return;
         var rider = ent.Comp.Rider.Value;
         
@@ -355,8 +355,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
         
         if (args.OurFixture.Hard && args.OtherFixture.Hard)
         {
-            if (_gameTiming.IsFirstTimePredicted)
-                _audio.PlayPredicted(ent.Comp.SoundHit, ent.Owner, null, AudioParams.Default.WithVariation(0.125f).WithVolume(-0.125f));
+            _audio.PlayPredicted(ent.Comp.SoundHit, ent.Owner, null, AudioParams.Default.WithVariation(0.125f).WithVolume(-0.125f));
                 
             if(TryComp<VehicleBuckleComponent>(ent.Owner, out var vbComp) && TryComp<BuckleComponent>(rider, out var buckleComp))
             {
@@ -382,8 +381,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
         {
             if(!HasComp<DamageableComponent>(args.OtherEntity) || HasComp<PacifiedComponent>(ent.Owner)) return; 
 
-            if (_gameTiming.IsFirstTimePredicted)
-                _audio.PlayPredicted(ent.Comp.SoundHit, ent.Owner, null, AudioParams.Default.WithVariation(0.125f).WithVolume(-0.125f));
+            _audio.PlayPredicted(ent.Comp.SoundHit, ent.Owner, null, AudioParams.Default.WithVariation(0.125f).WithVolume(-0.125f));
 
             DamageTypePrototype? _blunt = _prototypes.Index<DamageTypePrototype>(_bluntname);
             DamageSpecifier? _damage = new(_blunt, Math.Clamp(10 * (1 + (0.5 * speed / crashingSpeed)), 10, 20));
@@ -637,15 +635,19 @@ public abstract partial class SharedVehicleSystem : EntitySystem
     {
         if(args.Container != component.PassengerSlot) return;
         
-        if(_whitelist.IsWhitelistFail(component.PassengerWhitelist, args.Entity))
+        var tagert = args.Entity; 
+        Timer.Spawn(0, () =>
         {
-            if(HasComp<RiderComponent>(args.Entity) && TryComp<VehicleComponent>(ent, out var vehicleComp))
-                RemoveRider(args.Entity, ent, vehicleComp);
+            if(_whitelist.IsWhitelistFail(component.PassengerWhitelist, tagert))
+            {
+                if(HasComp<RiderComponent>(tagert) && TryComp<VehicleComponent>(ent, out var vehicleComp))
+                    RemoveRider(tagert, ent, vehicleComp);
 
-            if(_tags.HasTag(args.Entity, _vehicleKeyTag)) return;
-            
-            _container.Remove(args.Entity, component.PassengerSlot);
-        }
+                if(_tags.HasTag(tagert, _vehicleKeyTag)) return;
+                
+                _container.Remove(tagert, component.PassengerSlot);
+            }
+        });
     }
 
     #endregion
@@ -881,11 +883,8 @@ public abstract partial class SharedVehicleSystem : EntitySystem
         {
             for (var i = 0; i < vehicleComp.HandsNeeded; i++)
             {
-                if (_virtualItem.TrySpawnVirtualItem(vehicle, rider, out var virtItem))
-                {
+                if (_virtualItem.TrySpawnVirtualItemInHand(vehicle, rider, out var virtItem, true, silent: true))
                     EnsureComp<UnremoveableComponent>(virtItem.Value);
-                    Timer.Spawn(0, () => _handsSystem.TryForcePickupAnyHand(rider, virtItem.Value, checkActionBlocker: false));
-                }
             }
         }
     }

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -95,14 +95,14 @@
       path: /Audio/_Starlight/Medical/Surgery/cautery1.ogg
     endSound:
       path: /Audio/_Starlight/Medical/Surgery/cautery2.ogg
+  #- type: HeldSpeedModifier
+  #  walkModifier: 1
+  #  sprintModifier: 0.9
   #FarHorizons End
-  - type: HeldSpeedModifier
-    walkModifier: 1
-    sprintModifier: 0.9
   - type: MeleeWeapon
     damage:
       types:
-        Heat: 0
+        Heat: 8 #FH
   - type: Tag
     tags:
       - CyberHandItem
@@ -186,14 +186,14 @@
     speed: 1.2
     startSound:
       path: /Audio/_Starlight/Medical/Surgery/saw.ogg
+  #- type: HeldSpeedModifier
+  #  walkModifier: 1
+  #  sprintModifier: 0.9
   #FarHorizons End
-  - type: HeldSpeedModifier
-    walkModifier: 1
-    sprintModifier: 0.9
   - type: MeleeWeapon
     damage:
       types:
-        Piercing: 0
+        Piercing: 8 #FH
   - type: Tag
     tags:
       - CyberHandItem
@@ -292,14 +292,14 @@
       path: /Audio/_Starlight/Medical/Surgery/scalpel1.ogg
     endSound:
       path: /Audio/_Starlight/Medical/Surgery/scalpel2.ogg
+#  - type: HeldSpeedModifier
+#    walkModifier: 1
+#    sprintModifier: 0.9
   #FarHorizons End
-  - type: HeldSpeedModifier
-    walkModifier: 1
-    sprintModifier: 0.9
   - type: MeleeWeapon
     damage:
       types:
-        Slash: 0
+        Slash: 6 #FH
   - type: Tag
     tags:
       - CyberHandItem
@@ -497,10 +497,10 @@
       path: /Audio/_Starlight/Medical/Surgery/retractor1.ogg
     endSound:
       path: /Audio/_Starlight/Medical/Surgery/retractor2.ogg
+  # - type: HeldSpeedModifier
+  #   walkModifier: 1
+  #   sprintModifier: 0.9
   #FarHorizons end
-  - type: HeldSpeedModifier
-    walkModifier: 1
-    sprintModifier: 0.9
   - type: Tag
     tags:
       - CyberHandItem
@@ -593,10 +593,10 @@
     speed: 1.2
     startSound:
       path: /Audio/_Starlight/Medical/Surgery/hemostat1.ogg
+  #- type: HeldSpeedModifier
+  #   walkModifier: 1
+  #  sprintModifier: 0.9
   #FarHorizons End
-  - type: HeldSpeedModifier
-    walkModifier: 1
-    sprintModifier: 0.9
   - type: Tag
     tags:
       - CyberHandItem
@@ -701,10 +701,10 @@
     speed: 1.2
     startSound:
       path: /Audio/_Starlight/Medical/Surgery/bone_setter.ogg
+  #- type: HeldSpeedModifier
+  #  walkModifier: 1
+  #  sprintModifier: 0.9
   #FarHorizons End
-  - type: HeldSpeedModifier
-    walkModifier: 1
-    sprintModifier: 0.9
   - type: Tag
     tags:
       - CyberHandItem
@@ -882,14 +882,15 @@
       path: /Audio/_Starlight/Medical/Surgery/saw.ogg
     endSound:
       path: /Audio/Items/drill_hit.ogg
+  #- type: HeldSpeedModifier
+  #  walkModifier: 1
+  #  sprintModifier: 0.9
   #FarHorizons End
-  - type: HeldSpeedModifier
-    walkModifier: 1
-    sprintModifier: 0.9
   - type: MeleeWeapon
     damage:
       types:
-        Slash: 0
+        Slash: 10 #FH
+    attackRate: 0.7
   - type: Tag
     tags:
       - CyberHandItem

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1058,7 +1058,26 @@
           tags:
           - Syringe #Starlight end
     - item: BorgDropper
+    #FH Start
     - item: Beaker
+      hand:
+        emptyLabel: borg-slot-chemical-containers-empty
+        emptyRepresentative: Beaker
+        whitelist:
+          components:
+          - FitsInDispenser
+          tags:
+          - ChemDispensable
+    - item: Beaker
+      hand:
+        emptyLabel: borg-slot-chemical-containers-empty
+        emptyRepresentative: Beaker
+        whitelist:
+          components:
+          - FitsInDispenser
+          tags:
+          - ChemDispensable
+    #FH End
     - item: Gauze
       hand:
         emptyLabel: borg-slot-topicals-empty

--- a/Resources/Prototypes/_StarLight/Body/Implants/brain.yml
+++ b/Resources/Prototypes/_StarLight/Body/Implants/brain.yml
@@ -36,16 +36,15 @@
   components:
   - type: Sprite
     state: brain_implant_comms
-  - type: EncryptionKeyHolder
-    keySlots: 4
-  - type: ContainerContainer
-    containers:
-      key_slots: !type:Container
   - type: FunctionalOrgan
     comps:
     - type: ActiveRadio
     - type: IntrinsicRadioReceiver
     - type: IntrinsicRadioTransmitter
-    - type: EncryptionKeyHolder
-      keySlots: 4
-      canBeExamined: false
+    #FH Start
+    - type: IPCRadio
+      keysCapacity: 4
+      copyHeadsetKeys: false  
+      removeHeadset: false 
+    - type: WiresPanel
+    #FH End

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/medical.yml
@@ -65,6 +65,8 @@
   - RightArmCyberResearcher #FH
   - LeftArmCyberScribe
   - RightArmCyberScribe
+  - LeftArmCyberRipper #FH
+  - RightArmCyberRipper #FH
 
 #
 

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/medical.yml
@@ -179,8 +179,8 @@
   completetime: 10
   materials:
     Plastic: 550
-    Steel: 100
-    Silver: 450
+    Steel: 400 #FH Less Hygenic so less silver
+    Silver: 150 #FH
     Glass: 100
 
 - type: latheRecipe
@@ -191,8 +191,8 @@
   completetime: 10
   materials:
     Plastic: 550
-    Steel: 100
-    Silver: 450
+    Steel: 400 #FH
+    Silver: 150 #FH
     Glass: 100
 #
 #
@@ -203,10 +203,10 @@
   - Cyberlimbs
   completetime: 10
   materials:
-    Plastic: 10000
-    Steel: 500
+    Plastic: 550
+    Steel: 100
     Silver: 450
-    Glass: 1000
+    Glass: 100
 
 - type: latheRecipe
   id: RightArmCyberReaper


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
- Hopefully fixes the vehicle reload bug ( I couldn't replicate it so I just made the collision stuff server sided)
- Fixed Reaper Doc Arm being really expensive.
- Tweaked the recipe on the ripper doc arm to use less silver but more steel since its a cheaper less sanitary thing.
- Fixed the ripper doc arm not showing on the lathe when unlocked.
- Swapped the Integrated radio to use our IPC radio system. Rejoice on the new maintenace hatch in the back of your head.
- Reverted the no damage on ripper doc arm parts since its unrealistic. Also removed the speed penalty on the ripper doc arm.
- Tweaked the borg advanced topical module's beaker to use the same style of beaker whitelist from the chemical module. Also there is an extra beaker slot now to give it a nice even 2 full rows of items.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Tweaks and fixes.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Radio Implant change:
<video src="https://github.com/user-attachments/assets/c5498b75-e59b-4642-acc8-f60df12183c3"></video>

Changes to the advanced topical borg module:
<video src="https://github.com/user-attachments/assets/0fcf309b-ac2b-4458-92e9-d110aba4d132"></video>

Reaper Arms Prices match now:
<img width="867" height="718" alt="LeftArmPrice" src="https://github.com/user-attachments/assets/f2a29a61-2f15-45a7-be8e-81845e52905c" />
<img width="904" height="654" alt="RightArmPrice" src="https://github.com/user-attachments/assets/ea1ad638-58a2-4530-b0a8-244a72b95b9d" />

Ripper Doc Arms new prices and now show in med fab.
<img width="853" height="579" alt="RipperDocPriceChanges" src="https://github.com/user-attachments/assets/10497028-227d-4c02-a9c0-4ea9ee4248d7" />
<img width="787" height="576" alt="RipperDocShowingProperly" src="https://github.com/user-attachments/assets/556aa16b-7a1a-4f42-bbff-5ac5474a0761" />

The new damage for ripper doc tools. (subject to change)
<img width="476" height="281" alt="CauteryDamage" src="https://github.com/user-attachments/assets/4ff1b90d-9bd7-4710-a2c6-058818bf529c" />
<img width="544" height="362" alt="DrillDamage" src="https://github.com/user-attachments/assets/4a2cd491-6c9c-47b7-bae9-22ee8c8adeeb" />
<img width="467" height="246" alt="SawDamage" src="https://github.com/user-attachments/assets/8de31a20-9bda-40aa-826e-525adbc5b6aa" />
<img width="798" height="293" alt="ScalpelDamage" src="https://github.com/user-attachments/assets/edf8d786-fe66-45cc-a38b-d6fda00cc66c" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: AthenaAI
- fix: Hopefully fixes the container vehicle reload bug.
- fix: Fixed Reaper Doc Arm being really expensive.
- fix: Fixed the ripper doc arm not showing on the lathe when unlocked.
- tweak: Tweaked the recipe on the ripper doc arm to use less silver but more steel since its a cheaper less sanitary thing.
- tweak: Swapped the Integrated radio to use our IPC radio system. Rejoice on the new maintenace hatch in the back of your head.
- tweak: Reverted the no damage on ripper doc arm parts since its unrealistic. Also removed the speed penalty on the ripper doc arm.
- tweak: Tweaked the borg advanced topical module's beaker to use the same style of beaker whitelist from the chemical module. Also there is an extra beaker slot now to give it a nice even 2 full rows of items.