### PR TITLE
Bug Fixes & Addition - Metabolisers not being right - Stechkin bundle - Syndi segway - Vulp Stomach capacity increase

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoVulp.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoVulp.yml
@@ -33,8 +33,8 @@
       Tongue: OrganProtogenTongue
       Ears: OrganProtogenEars
       Lungs: OrganProtogenLungs
-      Heart: OrganProtogenHeart
-      Stomach: OrganProtogenStomach
+      Heart: OrganProtoVulpHeart
+      Stomach: OrganProtoVulpStomach
       Liver: OrganProtogenLiver
       Kidneys: OrganProtogenKidneys
   - type: HumanoidProfile
@@ -115,3 +115,35 @@
 - type: entity
   parent: [ OrganBaseFootRight, OrganProtoVulpExternal ]
   id: OrganProtoVulpFootRight
+
+#Internal Organs
+
+- type: entity
+  parent: [ OrganBaseHeart, OrganProtogenInternal, OrganProtogenMetabolizer ]
+  id: OrganProtoVulpHeart
+  name: Cybernetic Heart
+  description: "Doesn't actually need to beat, simply mimics the movement to provide comfort for the user."
+  suffix: Protogen-Vulpkanin
+  components:
+  - type: Metabolizer
+    updateInterval: 0.75
+
+- type: entity
+  parent: [ OrganBaseStomach, OrganProtogenInternal, OrganProtogenMetabolizer ]
+  id: OrganProtoVulpStomach
+  name: Biological Reactor
+  description: "Some call it over-engineered, but it's vital to the function of a protogen. Turns organic matter into organic and electrical energy to power the protogen's cybernetics and flesh."
+  suffix: Protogen-Vulpkanin
+  components:
+  - type: Metabolizer
+    updateInterval: 0.75
+  - type: SolutionContainerManager
+    solutions:
+      food: {}
+      stomach:
+        maxVol: 100 #he hungers
+  - type: Stomach
+    specialDigestible:
+      tags:
+      - RamChip
+    isSpecialDigestibleExclusive: false

--- a/Resources/Prototypes/_FarHorizons/Body/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/vulpkanin.yml
@@ -93,12 +93,17 @@
   parent: [ OrganBaseHeart, OrganVulpkaninInternal, OrganVulpkaninMetabolizer ]
   id: OrganVulpkaninHeart
   components:
-    - type: Metabolizer
-      updateInterval: 0.8
+  - type: Metabolizer
+    updateInterval: 0.75
 
 - type: entity
   parent: [ OrganBaseStomach, OrganVulpkaninInternal, OrganVulpkaninMetabolizer ]
   id: OrganVulpkaninStomach
   components:
   - type: Metabolizer
-    updateInterval: 1.5
+    updateInterval: 0.75
+  - type: SolutionContainerManager
+    solutions:
+      food: {}
+      stomach:
+        maxVol: 100 #he hungers

--- a/Resources/Prototypes/_FarHorizons/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/_FarHorizons/Catalog/Fills/Backpacks/duffelbag.yml
@@ -37,7 +37,7 @@
     containers:
       storagebase: !type:AllSelector
         children:
-        - id: WeaponPistolDeagle
+        - id: WeaponPistolStechkin
         - id: MagazinePistol38SP
           amount: 2
         - id: MagazineBoxRevolver38SP

--- a/Resources/Prototypes/_FarHorizons/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_FarHorizons/Catalog/uplink_catalog.yml
@@ -87,7 +87,7 @@
   name: uplink-syndicate-secway-name
   description: uplink-syndicate-secway-description
   icon: { sprite: /Textures/_FarHorizons/Objects/Vehicles/syndicate_segway.rsi, state: icon}
-  productEntity: VehicleSegwayNST
+  productEntity: VehicleSegwayNSTFilled
   cost:
     Telecrystal: 2 # What's more loud than a bloodred? A red segway. Plus, not that useful in the grand theme of things, asides from the universal key you get.. Funny though.
   categories:

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Vehicles/vehicles_battery.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Vehicles/vehicles_battery.yml
@@ -277,7 +277,7 @@
     - type: VehicleMods
       startingEquipment:
         - BasicTires
-        - ElectricTurboEngine
+        - ElectricEngine
         - BasicArmorKit
         - HeadlightLED
   
@@ -295,7 +295,7 @@
     - type: VehicleMods
       startingEquipment:
         - BasicTires
-        - ElectricTurboEngine
+        - ElectricEngine
         - LightArmorKit
         - HeadlightLED
 

--- a/Resources/Prototypes/_FarHorizons/Reagents/toxins.yml
+++ b/Resources/Prototypes/_FarHorizons/Reagents/toxins.yml
@@ -8,22 +8,6 @@
   flavor: shocking
   color: "#ffe270"
   metabolisms:
-    Bloodstream:
-      effects:
-      - !type:HealthChange
-        conditions:
-        - !type:MetabolizerTypeCondition
-          type: [ Protogen, ProtoBird ] # Harmless to protogens
-          inverted: true
-        damage:
-          types: # Drinking battery acid is bad for you? Woh.
-            Shock: 0.5 
-            Caustic: 0.5
-      - !type:SatiateThirst
-        conditions:
-        - !type:MetabolizerTypeCondition
-          type: [ Protogen, ProtoBird ]
-        factor: 1 #yummy
     Metabolites: #Acts like vitamin but for protogens. Keep in mind the -50% healing debuff they get, hence buffed numbers.
       effects:
       - !type:HealthChange
@@ -39,6 +23,20 @@
             Shock: -0.33
             Cold: -0.33
         affectAllLimbs: true
+      - !type:HealthChange
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Protogen, ProtoBird ] # Harmless to protogens
+          inverted: true
+        damage:
+          types: # Drinking battery acid is bad for you? Woh.
+            Shock: 0.5 
+            Caustic: 0.5
+      - !type:SatiateThirst
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Protogen, ProtoBird ]
+        factor: 1 #yummy
       - !type:ModifyBleed #smth smth burns you from the inside so it stops internal bleeding, clearly.
         amount: -0.5
       - !type:SatiateHunger


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes protobirds AND protogens not getting fed from battery acid, as well as the stechkin bundle somehow coming with a jhawk, syndi segway using wrong proto and vulpkanin metaboliser in code not reflecting guidebook entry.
Also tweaks vulp stomach to have 100u instead of default 50u.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix
Also I added the vulp stomach thing because I thought it'd be funny to watch them absolutely devour food that exists around them (also matches their higher metabolism). Balancewise- I'm not worried about the increased capacity. There's more busted combos you can pull with patches than being able to eat a few more pills.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="908" height="731" alt="fyiulyil" src="https://github.com/user-attachments/assets/210e0b4b-78c8-4d34-9cd6-4cec43f06064" />
<img width="446" height="474" alt="yfulkyiujl" src="https://github.com/user-attachments/assets/bd7d6dad-e4a7-4f3f-ba3a-e211ef25438e" />

ᵉˣᵃᵍᵍᵉʳᵃᵗᵉᵈ ᶠᵒʳ ᶜᵒᵐᵉᵈᶦᶜ ᵉᶠᶠᵉᶜᵗ

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Killer Tamashi
- tweak: Changed Vulpkanin & Protogen-Vulpkanin stomach capacity from 50u (default) to 100u to reflect fact they eat a LOT more.
- fix: Fixed Stechkin Bundle somehow coming with JHawk.
- fix: Fixed Vulpkanin Metabolizers not being correctly set at 25% more speed, like the guidebook says (the stomach was SLOWER, somehow??)
- fix: Fixed Protogen-Vulpkanin not having faster metabolizers like Vulpkanin.
- fix: Fixed Syndicate Segway not coming with, well, anything.
- fix: Fixed Battery Acid not feeding Protogen/Protobirds, bloodstream+metabolite should not be mixed lol.