### PR TITLE
Mechanically fixing a rule loophole

### DIFF
--- a/Resources/Locale/en-US/_FarHorizons/reagents/generic.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/reagents/generic.ftl
@@ -1,0 +1,1 @@
+generic-reagent-effect-sleepy = Your eyelids feel heavy..

--- a/Resources/Locale/en-US/_FarHorizons/reagents/meta/toxins.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/reagents/meta/toxins.ftl
@@ -1,2 +1,5 @@
 reagent-name-batteryacid = Battery Acid
 reagent-desc-batteryacid = A mildly corrosive liquid commonly found in electronic devices that carry batteries, including machine boards.
+
+reagent-name-hydrogen-sulfide = Hydrogen Sulfide
+reagent-desc-hydrogen-sulfide = A liquid that causes an individual to become slower, toxic at high doses.

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -68,15 +68,26 @@
       - !type:MovementSpeedModifier
         walkSpeedModifier: 0.65
         sprintSpeedModifier: 0.65
+#FH - Start
+      - !type:PopupMessage
+        type: Local
+        visualType: LargeCaution
+        messages: [ "generic-reagent-effect-sleepy"]
+        probability: 0.33
       - !type:ModifyStatusEffect
-        effectProto: StatusEffectDrowsiness
-        time: 4
-        type: Update
+        conditions:
+        - !type:ReagentCondition
+          reagent: ChloralHydrate
+          min: 19 # No syringe of instant sleep
+        effectProto: StatusEffectForcedSleeping
+        time: 9
+        delay: 8 # Less effective than noct + warning
+#FH - End
       - !type:HealthChange
         conditions:
         - !type:ReagentCondition
           reagent: ChloralHydrate
-          min: 20
+          min: 25 #FH
         damage:
           types:
             Poison: 1.5

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -69,6 +69,13 @@
         walkSpeedModifier: 0.65
         sprintSpeedModifier: 0.65
 #FH - Start
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentCondition # No stacking for you
+          reagent: Nocturine
+          min: 1
+        reagent: Nocturine
+        amount: -10
       - !type:PopupMessage
         type: Local
         visualType: LargeCaution
@@ -78,19 +85,19 @@
         conditions:
         - !type:ReagentCondition
           reagent: ChloralHydrate
-          min: 19 # No syringe of instant sleep
+          min: 18 # No syringe of instant sleep
         effectProto: StatusEffectForcedSleeping
         time: 9
         delay: 8 # Less effective than noct + warning
+#      - !type:HealthChange
+#        conditions:
+#        - !type:ReagentCondition
+#          reagent: ChloralHydrate
+#          min: 25 #FH
+#        damage:
+#          types:
+#            Poison: 1.5
 #FH - End
-      - !type:HealthChange
-        conditions:
-        - !type:ReagentCondition
-          reagent: ChloralHydrate
-          min: 25 #FH
-        damage:
-          types:
-            Poison: 1.5
 
 - type: reagent
   id: GastroToxin

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Medical/healing.yml
@@ -247,6 +247,21 @@
           - ReagentId: Amoxla
             Quantity: 15
 
+- type: entity
+  suffix: Chloral Hydrate
+  parent: PrefilledSyringe
+  id: SyringeChloralHydrate
+  components:
+  - type: Label
+    currentLabel: reagent-name-chloral-hydrate 
+  - type: SolutionContainerManager
+    solutions:
+      injector:
+        maxVol: 15
+        reagents:
+          - ReagentId: ChloralHydrate
+            Quantity: 15
+
 #region Blue Ointment
 - type: entity
   parent: [BaseAutoMender, DrinkVisualsOpenable, DrinkVisualsFill] # You have no idea how long this took me to get to layer properly

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/chemistry-bottles.yml
@@ -62,3 +62,18 @@
   - type: StaticPrice
     price: 0
   - type: DnaSubstanceTrace
+
+- type: entity
+  id: ChemistryBottleChloralHydrate
+  suffix: Chloral Hydrate
+  parent: BaseChemistryBottleFilled
+  components:
+  - type: Label
+    currentLabel: reagent-name-chloral-hydrate
+  - type: SolutionContainerManager
+    solutions:
+      drink: # This solution name and target volume is hard-coded in ChemMasterComponent
+        maxVol: 30
+        reagents:
+        - ReagentId: ChloralHydrate
+          Quantity: 30

--- a/Resources/Prototypes/_FarHorizons/Reagents/toxins.yml
+++ b/Resources/Prototypes/_FarHorizons/Reagents/toxins.yml
@@ -43,3 +43,27 @@
         conditions:
         - !type:MetabolizerTypeCondition
           type: [ Protogen, ProtoBird ]
+
+- type: reagent
+  id: HydrogenSulfide
+  name: reagent-name-hydrogen-sulfide
+  group: Toxins
+  desc: reagent-desc-hydrogen-sulfide
+  flavor: bitter
+  color: "#7D7C30"
+  physicalDesc: reagent-physical-desc-nondescript
+  contrabandSeverity: Major
+  metabolisms:
+    Bloodstream:
+      effects:
+      - !type:MovementSpeedModifier
+        walkSpeedModifier: 0.65
+        sprintSpeedModifier: 0.65
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentCondition
+          reagent: HydrogenSulfide
+          min: 40
+        damage:
+          types:
+            Poison: 1.30

--- a/Resources/Prototypes/_StarLight/Actions/changeling.yml
+++ b/Resources/Prototypes/_StarLight/Actions/changeling.yml
@@ -244,7 +244,7 @@
       - Body
     canTargetSelf: false
     event: !type:StingChemEvent {
-      chems: { Fresium: 20, ChloralHydrate: 20 }
+      chems: { Fresium: 20, HydrogenSulfide: 20 } #FH
     }
 
   - type: ChangelingAction


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixing a loophole created by using chloral hydrate's drowsiness effect to cause a "micro sleep" which, due to it technically being sleeping forces a player to forget the circumstances up to the injection, even if the sleep only lasted half a second or a second
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This is incredibly unintuitive to the player, as most would not even clock the very quick sleep time letalone think rule 3 would apply to a circumstance such as this just because it was so short. From a gameplay standpoint, this objectively sucks as 1-2 chloral hydrate injections would stack enough drowsiness for a micro-sleep (0.5 - 1 second), forcing the player to have to follow rule 3 as it technically applies, no matter the circumstance (mid-chase, talking, ect)

Even though rule 3 is intended to protect antagonists completing objectives stealthily (injecting noct into the cmo and taking his hypospray, then getting away scot free since they don't remember you doing it as an example) right now with how chloral hydrate works the rule can be abused and technically applied in situations it really shouldn't be applied in with the micro-sleep mechanic abuse.

Also chloral hydrate kinda just sucks for putting people to sleep since they can wake up right away due to drowsiness not causing forced sleep in the first place so, you know, that too. Due to this change, I am also adding a warning for the player being injected, since, that is something you would feel.

Nocturine is exempt from using a warning since it's a syndicate chemical so magical space bullshit idk.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="562" height="376" alt="fyiulkuyilj" src="https://github.com/user-attachments/assets/fde75174-b0d9-4477-bfe1-961c2dbd740f" />
<img width="272" height="165" alt="tduykuytkg" src="https://github.com/user-attachments/assets/d519e3c4-35f2-479c-93d2-3364fd1756d5" />
(new chem for ling cryo sting since hydrogen chloride sleeps now)
<img width="554" height="262" alt="guio;luioj;" src="https://github.com/user-attachments/assets/809978cc-5893-42fa-80f8-06e4f8843234" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Killer Tamashi
- add: Added Hydrogen Sulfide for the explicit purpose of slowing people, also toxic at high doses.
- add: Added Chloral Hydrate Syringe and Bottle for mapping purposes.
- tweak: Changed Changeling Cryogenic Sting to use Hydrogen Sulfide.
- tweak: Changed Chloral Hydrate to warn the player if they're about to sleep (noct is exempt due to being syndicate chemical)
- tweak: Changed Chloral Hydrate to clear Nocturine if both is in the bloodstream (no stacking eepy)
- fix: Fixed Mechanic Rule Loophole caused by Chloral Hydrate causing a "micro sleep" effect. It now forces sleep for 9 seconds at 19u, instead of making you sleep for 0.5 - 1 second with 4u.
