### PR TITLE
Symspeech fix radio effect

### DIFF
--- a/Content.Server/_Starlight/TextToSpeech/TTSSystem.cs
+++ b/Content.Server/_Starlight/TextToSpeech/TTSSystem.cs
@@ -107,7 +107,7 @@ public sealed partial class TTSSystem : EntitySystem
             var channel = new ProtoId<RadioChannelPrototype>(args.Channel.ID);
             
             // Far Horizons edit
-            await GenerateAndStream(TTSType.Radio, symspeech, text, filter, TTSEffect.Walkie, chime, null, channel);
+            await GenerateAndStream(TTSType.Radio, symspeech, text, filter, TTSEffect.Radio, chime, null, channel);
         }
         catch (TaskCanceledException ex)
         {


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Radio was using incorrect "Walkie" effect which gave it a very dissatisfying noise, and in general was unpleasant, and this was never intended.

## Why we need to add this
In general sounds work better when we use effects that are indented for them

## Media (Video/Screenshots)


https://github.com/user-attachments/assets/63777d67-d448-47dd-8738-10bb43bd0c9d

https://github.com/user-attachments/assets/38d87ba4-aa28-4290-b891-64e98e932879

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- fix: Fixed incorrect effect being applied to radios.
