### PR TITLE
Magistrate to Concord Liaison

### DIFF
--- a/Resources/Locale/en-US/_FarHorizons/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/guidebook/guides.ftl
@@ -41,8 +41,10 @@ guide-entry-station-management-sop-general-procedures-intro = General Station Ma
 guide-entry-station-management-sop-staff-intro = Individual Station Management Procedures
 guide-entry-station-management-sop-nanotrasen-rep = NanoTrasen Representative
 guide-entry-station-management-sop-blueshield-officer = Blueshield Officer
-guide-entry-station-management-sop-magistrate = Magistrate
+guide-entry-station-management-sop-magistrate = Concord Liaison (Magistrate)
 guide-entry-station-management-sop-affairs-offical = Affairs Offical (IAA)
+
+guide-entry-sl-nano-trasen-employee-sop-magistrate = Concord Liaison
 
 guide-entry-sl-medical-sop-viral-outbreak = Viral Outbreak Protocol
 

--- a/Resources/Locale/en-US/_FarHorizons/job/job-names.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/job/job-names.ftl
@@ -1,3 +1,4 @@
+job-name-magistrate = Concord Liaison
 job-name-secborg = Security Cyborg
 job-name-corpsman = Corpsman
 job-name-blueshield = Blueshield Officer

--- a/Resources/Locale/en-US/_FarHorizons/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/preferences/loadout-groups.ftl
@@ -24,6 +24,7 @@ loadout-group-magistrate-eyewear = Concord Liaison Eyewear
 loadout-group-magistrate-uniform = Concord Liaison Uniform
 loadout-group-magistrate-neck = Concord Liaison Neck
 loadout-group-magistrate-outer = Concord Liaison Outer Clothing
+loadout-group-magistrate-shoes = Concord Liaison Shoes
 
 loadout-group-mining-head = Mining Specialist Head
 loadout-group-mining-backpack = Mining Specialist Backpack

--- a/Resources/Locale/en-US/_FarHorizons/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/preferences/loadout-groups.ftl
@@ -19,11 +19,11 @@ loadout-group-doctor-backpack = Medical Doctor Backpack
 
 loadout-group-iaa-eyewear = IAA Eyewear
 
-loadout-group-magistrate-hat = Magistrate Head
-loadout-group-magistrate-eyewear = Magistrate Eyewear
-loadout-group-magistrate-uniform = Magistrate Uniform
-loadout-group-magistrate-neck = Magistrate Neck
-loadout-group-magistrate-outer = Magistrate Outer Clothing
+loadout-group-magistrate-hat = Concord Liaison Head
+loadout-group-magistrate-eyewear = Concord Liaison Eyewear
+loadout-group-magistrate-uniform = Concord Liaison Uniform
+loadout-group-magistrate-neck = Concord Liaison Neck
+loadout-group-magistrate-outer = Concord Liaison Outer Clothing
 
 loadout-group-mining-head = Mining Specialist Head
 loadout-group-mining-backpack = Mining Specialist Backpack

--- a/Resources/Locale/en-US/_Starlight/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_Starlight/guidebook/guides.ftl
@@ -130,7 +130,7 @@ guide-entry-sl-nano-trasen-employee-sop-safety-protocol = Safety Protocol
 guide-entry-sl-nano-trasen-employee-sop-staff-intro = Staff Procedures
 guide-entry-sl-nano-trasen-employee-sop-nt-rep = NanoTrasen Representative
 guide-entry-sl-nano-trasen-employee-sop-bso = BlueShield Officer
-guide-entry-sl-nano-trasen-employee-sop-magistrate = Magistrate
+guide-entry-sl-nano-trasen-employee-sop-magistrate = Concord Liaison
 guide-entry-sl-nano-trasen-employee-sop-iaa = Affairs Official
 
 guide-entry-sl-service-sop-intro = Service

--- a/Resources/Locale/en-US/_Starlight/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_Starlight/guidebook/guides.ftl
@@ -130,7 +130,6 @@ guide-entry-sl-nano-trasen-employee-sop-safety-protocol = Safety Protocol
 guide-entry-sl-nano-trasen-employee-sop-staff-intro = Staff Procedures
 guide-entry-sl-nano-trasen-employee-sop-nt-rep = NanoTrasen Representative
 guide-entry-sl-nano-trasen-employee-sop-bso = BlueShield Officer
-guide-entry-sl-nano-trasen-employee-sop-magistrate = Concord Liaison
 guide-entry-sl-nano-trasen-employee-sop-iaa = Affairs Official
 
 guide-entry-sl-service-sop-intro = Service

--- a/Resources/Locale/en-US/_Starlight/job/job.ftl
+++ b/Resources/Locale/en-US/_Starlight/job/job.ftl
@@ -1,4 +1,4 @@
-job-name-magistrate = Magistrate
+job-name-magistrate = Concord Liaison
 job-name-ntrep = NanoTrasen Representative
 job-name-iaa = Affairs Official
 job-name-ntncblueshield = Nanotrasen Navy Corps Marine

--- a/Resources/Locale/en-US/_Starlight/job/job.ftl
+++ b/Resources/Locale/en-US/_Starlight/job/job.ftl
@@ -1,4 +1,3 @@
-job-name-magistrate = Concord Liaison
 job-name-ntrep = NanoTrasen Representative
 job-name-iaa = Affairs Official
 job-name-ntncblueshield = Nanotrasen Navy Corps Marine

--- a/Resources/Locale/en-US/_Starlight/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Starlight/preferences/loadout-groups.ftl
@@ -44,7 +44,6 @@ loadout-group-brigmedic-mask = Brigmedic mask
 loadout-group-brigmedic-tie = Brigmedic tie
 
 # Law
-loadout-group-magistrate-shoes = Concord Liaison Shoes
 loadout-group-iia-shoes = Lawyer Shoes
 
 # Civilian

--- a/Resources/Locale/en-US/_Starlight/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Starlight/preferences/loadout-groups.ftl
@@ -44,7 +44,7 @@ loadout-group-brigmedic-mask = Brigmedic mask
 loadout-group-brigmedic-tie = Brigmedic tie
 
 # Law
-loadout-group-magistrate-shoes = Magistrate Shoes
+loadout-group-magistrate-shoes = Concord Liaison Shoes
 loadout-group-iia-shoes = Lawyer Shoes
 
 # Civilian

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Eyes/glasses.yml
@@ -23,7 +23,7 @@
 - type: entity
   parent: [ClothingEyesBase, ShowSecurityIcons, BaseCommandContraband]
   id: ClothingEyesGlassesMagistrate
-  name: Magistrate's Glasses
+  name: Concord Liaison's Glasses
   suffix: CFA
   description: A set of slick looking glasses for the space law overseer. Includes information about people's ID status and security information.
   components:

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Eyes/hud.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: [ClothingEyesBase, ShowSecurityIcons, BaseCommandContraband]
   id: ClothingEyesHudCommandMagistrate
-  name: Magistrate HUD
+  name: Concord Liaison HUD
   suffix: CFA
   description: A heads-up display that scans the humanoids in view and provides accurate data about their ID status and some extra security information.
   components:

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -4,7 +4,7 @@
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitMagistrate
   categories: [ HideSpawnMenu ]
-  name: Magistate Hardsuit Helmet
+  name: Concord Liaison Hardsuit Helmet
   components:
   - type: Sprite
     sprite: _FarHorizons/Clothing/Head/Hardsuits/magistrate.rsi

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Head/hats.yml
@@ -32,8 +32,8 @@
 
 - type: entity
   parent: ClothingHeadBase
-  id: ClothingHeadHatMagistrateCap
-  name: Magistrate's Cap
+  id: ClothingHeadHatMagistrateCap # Far Horizons
+  name: Concord Liaison's Cap
   description: A well maintained cap that just exemplifies order.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Neck/mantle.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Neck/mantle.yml
@@ -3,9 +3,9 @@
 - type: entity
   parent: [ ClothingNeckBase, BaseCommandContraband ]
   id: ClothingNeckMantleMagistrate
-  name: Magistrate's Mantle
+  name: Concord Liaison's Mantle
   suffix: NT
-  description: Did you hear that? That was the sound of criminals whispering, "That Magistrate is so cool", as they witness this mantle in their sentencing.
+  description: Did you hear that? That was the sound of criminals whispering, "That Concord Liaison is so cool", as they witness this mantle in their sentencing.
   components:
   - type: Sprite
     sprite: _FarHorizons/Clothing/Neck/Mantles/magistrate.rsi

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/OuterClothing/coats.yml
@@ -31,7 +31,7 @@
 - type: entity
   parent: [ BaseCommandContraband, ClothingOuterStorageBase ]
   id: ClothingOuterCoatMagistrate
-  name: Magistrate's Jacket
+  name: Concord Liaison's Jacket
   suffix: NT
   description: A sleek coat for the justicar of space law.
   components:

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -62,9 +62,9 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseCommandContraband]
   id: ClothingOuterHardsuitMagistrate
-  name: Magistate Hardsuit
+  name: Concord Liaison Hardsuit
   suffix: NT
-  description: In order to uphold the law, Concord Frontier Authority has seen fit to supply their magistrates a state of the art hardsuit.
+  description: In order to uphold the law, Concord Frontier Authority has seen fit to supply their liaisons a state of the art hardsuit.
   components:
   - type: Sprite
     sprite: _FarHorizons/Clothing/OuterClothing/Hardsuits/magistrate.rsi

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -44,7 +44,7 @@
 - type: entity
   parent: [ ClothingUniformSkirtBase, BaseCommandContraband ]
   id: ClothingUniformJumpskirtTurtleneckMagistrate
-  name: Magistrate's Turtleneck Jumpskirt
+  name: Concord Liaison's Turtleneck Jumpskirt
   suffix: CFA
   description: A state of the art turtleneck jumpskirt that the CFA supplies their law justicars.
   components:

--- a/Resources/Prototypes/_FarHorizons/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -26,7 +26,7 @@
 - type: entity
   parent: [ ClothingUniformBase, BaseCommandContraband ]
   id: ClothingUniformJumpsuitTurtleneckMagistrate
-  name: Magistrate's Turtleneck Jumpsuit
+  name: Concord Liaison's Turtleneck Jumpsuit
   suffix: CFA
   description: A state of the art turtleneck jumpsuit that the CFA supplies their law justicars.
   components:

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Misc/identification_cards.yml
@@ -181,7 +181,7 @@
 - type: entity
   parent: [ IDCardStandard, BaseCommandContraband ]
   id: MagistrateIDCard
-  name: Magistrate ID Card
+  name: Concord Liaison ID Card
   components:
     - type: Sprite
       layers:

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -524,7 +524,7 @@
 - type: entity
   parent: [ ClothingUniformBase, BaseCommandContraband ]
   id: MagistrateUniformSkirt
-  name: Concord Liaison's Jumpskirt
+  name: Concord Liaison's Jumpskirt #Far Horizons
   components:
   - type: Sprite
     sprite: _FarHorizons/Clothing/Uniforms/Jumpskirt/magistrate.rsi #Far Horizons

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -524,7 +524,7 @@
 - type: entity
   parent: [ ClothingUniformBase, BaseCommandContraband ]
   id: MagistrateUniformSkirt
-  name: Magistrate's Jumpskirt
+  name: Concord Liaison's Jumpskirt
   components:
   - type: Sprite
     sprite: _FarHorizons/Clothing/Uniforms/Jumpskirt/magistrate.rsi #Far Horizons

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -29,7 +29,7 @@
 - type: entity
   parent: [ ClothingUniformBase, BaseRepresentativesContraband ] # FH
   id: MagistrateUniformSuit
-  name: Magistrate's Jumpsuit
+  name: Concord Liaison's Jumpsuit
   components:
   - type: Sprite
     sprite: _FarHorizons/Clothing/Uniforms/Jumpsuit/magistrate.rsi #Far Horizons

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -29,7 +29,7 @@
 - type: entity
   parent: [ ClothingUniformBase, BaseRepresentativesContraband ] # FH
   id: MagistrateUniformSuit
-  name: Concord Liaison's Jumpsuit
+  name: Concord Liaison's Jumpsuit #Far Horizons
   components:
   - type: Sprite
     sprite: _FarHorizons/Clothing/Uniforms/Jumpsuit/magistrate.rsi #Far Horizons

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Devices/pda.yml
@@ -141,7 +141,7 @@
 - type: entity
   parent: BasePDA
   id: MagistratePDA
-  name: Magistrate PDA #Far Horizons - The Great Capitalization Crusade
+  name: Concord Liaison PDA #Far Horizons - The Great Capitalization Crusade
   components:
   - type: Pda
     id: MagistrateIDCard

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/rubber_stamp.yml
@@ -1,12 +1,12 @@
 # NT stamps
 - type: entity
-  name: magistrate stamp
+  name: concord liaison stamp
   parent: [ RubberStampBase, BaseCommandContraband ]
   id: RubberStampMagistrate
   suffix: DO NOT MAP
   components:
   - type: Stamp
-    stampedName: Magistrate
+    stampedName: "Concord Liaison" # Far Horizons
     stampedColor: "#FF5297"
     stampState: "paper_stamp-magistrate"
   - type: Sprite

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/rubber_stamp.yml
@@ -1,6 +1,6 @@
 # NT stamps
 - type: entity
-  name: concord liaison stamp
+  name: concord liaison stamp #Far Horizons
   parent: [ RubberStampBase, BaseCommandContraband ]
   id: RubberStampMagistrate
   suffix: DO NOT MAP


### PR DESCRIPTION
## Short description
Renames the Magistrate to Concord Liaison, along with all player facing references

// note I did this all in the span of an hour so if I missed anything please inform me or make a PR review

## Why we need to add this
I was asked to do it and got written approval to do so

## Media (Video/Screenshots)
<img width="814" height="253" alt="image" src="https://github.com/user-attachments/assets/25383cbf-160e-45ee-ba32-699ce3d84698" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**

:cl: KittenColony
- tweak: Renamed Magistrate to Concord Liaison.
