### PR TITLE
Fixes - Bodybag starting locked / Dominator Autolock not working / Weird behavior when alt clicking on locked & folded item

### DIFF
--- a/Content.Shared/Foldable/FoldableSystem.cs
+++ b/Content.Shared/Foldable/FoldableSystem.cs
@@ -155,7 +155,7 @@ public sealed class FoldableSystem : EntitySystem
             Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/fold.svg.192dpi.png")),
 
             // If the object is unfolded and they click it, they want to fold it, if it's folded, they want to pick it up
-            Priority = component.IsFolded ? 0 : 2,
+            Priority = 2, ///FH - Edit - Unfolds on Alt+Click too now instead of locking
         };
 
         args.Verbs.Add(verb);

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
@@ -96,7 +96,8 @@
   - type: Lock
     lockOnClick: false
     autoUnlock: false
-    autoLock: false 
+    autoLock: false
+    locked: false
   - type: LockVisuals
   - type: AccessReader
     access: [["Medical"]]

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -203,6 +203,8 @@
     steps: 11
     zeroVisible: true
   - type: Lock
+    autoUnlock: true
+    autoLock: true
   - type: AccessReader
     access: [["Security"]]
   - type: Battery 
@@ -281,6 +283,8 @@
     steps: 4
     zeroVisible: true
   - type: Lock
+    autoUnlock: true
+    autoLock: true
   - type: AccessReader
     access: [["Security"]]
   - type: BatteryAmmoProvider


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Just some fixes for stuff. Bodybag auto starting locked caused issues in the fact no one else could use them, and it was also pretty clunky that you'd unlock a bag instead of unfolding it. Dominator autolock has been broken for a while, little did I know that it was a two-line fix..
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Killer Tamashi
- fix: Fixed Bodybag starting locked.
- fix: Fixed Dominator auto unlock/lock not working.
- fix: Fixed Unlocking taking priority over unfolding.