### PR TITLE
Random fixes

### DIFF
--- a/Content.IntegrationTests/Tests/Station/EvacShuttleTest.cs
+++ b/Content.IntegrationTests/Tests/Station/EvacShuttleTest.cs
@@ -32,7 +32,7 @@ public sealed class EvacShuttleTest
         pair.Server.CfgMan.SetCVar(CCVars.EmergencyShuttleEnabled, true);
         pair.Server.CfgMan.SetCVar(CCVars.GameDummyTicker, false);
         var gameMap = pair.Server.CfgMan.GetCVar(CCVars.GameMap);
-        pair.Server.CfgMan.SetCVar(CCVars.GameMap, "Saltern");
+        pair.Server.CfgMan.SetCVar(CCVars.GameMap, "FHOmega"); // Far Horizons - rest of maps is disabled, have to use ours
 
         await server.WaitPost(() => ticker.RestartRound());
         await pair.RunTicksSync(25);

--- a/Content.Server/_FarHorizons/Research/ResearchSystem.Tree.cs
+++ b/Content.Server/_FarHorizons/Research/ResearchSystem.Tree.cs
@@ -161,7 +161,8 @@ public sealed partial class FHResearchSystem
 
     public bool AddResearchToQueue(Entity<FHResearchTreeComponent?> ent, ProtoId<ResearchTreeNodePrototype> node)
     {
-        if (!Resolve(ent, ref ent.Comp))
+        if (!Resolve(ent, ref ent.Comp) ||
+            ent.Comp.Queue.Contains(node))
             return false;
 
         if (ent.Comp.Queue.Count < GetCurrentQueueSize((ent, ent.Comp)))

--- a/Content.Server/_FarHorizons/Shuttles/SpaceRescuePingSystem.cs
+++ b/Content.Server/_FarHorizons/Shuttles/SpaceRescuePingSystem.cs
@@ -61,6 +61,11 @@ public sealed class SpaceRescuePingSystem : EntitySystem
                     sndTransform.MapID != rcvTransform.MapID)
                     continue;
 
+                var parent = _transform.GetParentUid(pingUid); // Likely a person wearing the suit
+                var parentsParent = _transform.GetParentUid(parent); // Container that person is inside of
+                if (HasComp<SpaceRescuePingMutedComponent>(parentsParent))
+                    continue;
+
                 var netCoords = new NetCoordinates(GetNetEntity(pingUid), _transform.GetWorldPosition(sndTransform));
                 pings.Add((netCoords.Position, pingComp.Color));
             }

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -744,6 +744,12 @@ namespace Content.Shared.Preferences
             {
                 SpeciesLoadout ??= new RoleLoadout(speciesPrototype.Loadout.Value);
                 SpeciesLoadout.Role = speciesPrototype.Loadout.Value;
+
+                var loadout = prototypeManager.Index(SpeciesLoadout.Role);
+                foreach (var (group, _) in SpeciesLoadout.SelectedLoadouts.ShallowClone())
+                    if (!loadout.Groups.Contains(group))
+                        SpeciesLoadout.SelectedLoadouts.Remove(group);
+
                 SpeciesLoadout.SetDefault(this, session, prototypeManager);
             }
 

--- a/Content.Shared/_FarHorizons/Shuttles/SpaceRescuePing.cs
+++ b/Content.Shared/_FarHorizons/Shuttles/SpaceRescuePing.cs
@@ -1,5 +1,4 @@
 using System.Numerics;
-using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._FarHorizons.Shuttles;
@@ -25,3 +24,6 @@ public sealed class SpaceRescuePingMessage(List<(Vector2, Color)> pings, TimeSpa
     public List<(Vector2, Color)> Pings = pings;
     public TimeSpan RefreshRate = refreshRate;
 }
+
+[RegisterComponent]
+public sealed partial class SpaceRescuePingMutedComponent : Component;

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -205,6 +205,7 @@
   - type: Damageable
     damageModifierSet: DragonResistances 
   #endregion Starlight
+  - type: SpaceRescuePingMuted # Far Horizons - mutes pings coming from inside the dragon
 
 - type: entity
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -1,15 +1,16 @@
-- type: gameMapPool
-  id: DefaultMapPool
-  maps:
-  - Bagel
-  - Box
-  - Elkridge
-  - Fland
-  - Marathon
-  - Oasis
-  - Packed
-  - Plasma
-  - Reach
-  - Exo
-  - Snowball
-  - Serpentcrest
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMapPool
+#   id: DefaultMapPool
+#   maps:
+#   - Bagel
+#   - Box
+#   - Elkridge
+#   - Fland
+#   - Marathon
+#   - Oasis
+#   - Packed
+#   - Plasma
+#   - Reach
+#   - Exo
+#   - Snowball
+#   - Serpentcrest

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -1,66 +1,67 @@
-- type: gameMap
-  id: Bagel
-  mapName: 'Bagel Station'
-  mapPath: /Maps/bagel.yml
-  minPlayers: 35
-  maxPlayers: 80
-  stations:
-    Bagel:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Bagel Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_lox.yml
-        - type: StationJobs
-          availableJobs: # 60 jobs total w/o latejoins & interns, 77 jobs total w/ latejoins & interns
-            #command (7)
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            HeadOfSecurity: [ 1, 1 ]
-            ChiefMedicalOfficer: [ 1, 1 ]
-            ChiefEngineer: [ 1, 1 ]
-            ResearchDirector: [ 1, 1 ]
-            Quartermaster: [ 1, 1 ]
-            #service (13 - 14)
-            Bartender: [ 1, 2 ]
-            Botanist: [ 2, 2 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            Reporter: [ 2, 2 ]
-            #engineering (7)
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 4, 4 ] #intern, not counted
-            #medical (6)
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 3 ]
-            Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 4, 4 ] #intern, not counted
-            #science (5)
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 4, 4 ] #intern, not counted
-            #security (10)
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 6, 6 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ] #intern, not counted
-            Lawyer: [ 2, 2 ]
-            #Brigmedic: [ 1, 1 ]
-            #supply
-            SalvageSpecialist: [ 6, 6 ]
-            CargoTechnician: [ 3, 3 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon (3)
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: Bagel
+#   mapName: 'Bagel Station'
+#   mapPath: /Maps/bagel.yml
+#   minPlayers: 35
+#   maxPlayers: 80
+#   stations:
+#     Bagel:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Bagel Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_lox.yml
+#         - type: StationJobs
+#           availableJobs: # 60 jobs total w/o latejoins & interns, 77 jobs total w/ latejoins & interns
+#             #command (7)
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             HeadOfSecurity: [ 1, 1 ]
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             ChiefEngineer: [ 1, 1 ]
+#             ResearchDirector: [ 1, 1 ]
+#             Quartermaster: [ 1, 1 ]
+#             #service (13 - 14)
+#             Bartender: [ 1, 2 ]
+#             Botanist: [ 2, 2 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 2, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             Reporter: [ 2, 2 ]
+#             #engineering (7)
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 4, 4 ]
+#             TechnicalAssistant: [ 4, 4 ] #intern, not counted
+#             #medical (6)
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 3, 3 ]
+#             Paramedic: [ 1, 1 ]
+#             MedicalIntern: [ 4, 4 ] #intern, not counted
+#             #science (5)
+#             Scientist: [ 5, 5 ]
+#             ResearchAssistant: [ 4, 4 ] #intern, not counted
+#             #security (10)
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 6, 6 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 4 ] #intern, not counted
+#             Lawyer: [ 2, 2 ]
+#             #Brigmedic: [ 1, 1 ]
+#             #supply
+#             SalvageSpecialist: [ 6, 6 ]
+#             CargoTechnician: [ 3, 3 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon (3)
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -1,66 +1,67 @@
-- type: gameMap
-  id: Box
-  mapName: 'Box Station'
-  mapPath: /Maps/box.yml
-  minPlayers: 50
-  stations:
-    Boxstation:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Box Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'TG'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_box.yml
-        - type: StationJobs
-          availableJobs: # 63 jobs total w/o latejoins & interns, 82 jobs total w/ latejoins & interns
-            #Command (7)
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            HeadOfSecurity: [ 1, 1 ]
-            ChiefMedicalOfficer: [ 1, 1 ]
-            ChiefEngineer: [ 1, 1 ]
-            ResearchDirector: [ 1, 1 ]
-            Quartermaster: [ 1, 1 ]
-            #Service (14)
-            Bartender: [ 2, 2 ]
-            Botanist: [ 3, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            Reporter: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            #Engineering (8)
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 4, 4 ] #intern, exclude from dept count
-            #Medical (8)
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
-            Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 4, 4 ] #intern, exclude from dept count
-            Psychologist: [ 1, 1 ]
-            #Science (5)
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 4, 4 ] #intern, exclude from dept count
-            #Security (9 - 11)
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 5, 7 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 2, 4 ] #intern, exclude from dept count
-            Lawyer: [ 2, 2 ]
-            #Brigmedic: [ 1, 1 ]
-            #supply
-            SalvageSpecialist: [ 6, 6 ]
-            CargoTechnician: [ 3, 3 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #Silicon (3)
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 3 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: Box
+#   mapName: 'Box Station'
+#   mapPath: /Maps/box.yml
+#   minPlayers: 50
+#   stations:
+#     Boxstation:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Box Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'TG'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_box.yml
+#         - type: StationJobs
+#           availableJobs: # 63 jobs total w/o latejoins & interns, 82 jobs total w/ latejoins & interns
+#             #Command (7)
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             HeadOfSecurity: [ 1, 1 ]
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             ChiefEngineer: [ 1, 1 ]
+#             ResearchDirector: [ 1, 1 ]
+#             Quartermaster: [ 1, 1 ]
+#             #Service (14)
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 3, 3 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 2, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             Reporter: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             #Engineering (8)
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 5, 5 ]
+#             TechnicalAssistant: [ 4, 4 ] #intern, exclude from dept count
+#             #Medical (8)
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 4, 4 ]
+#             Paramedic: [ 1, 1 ]
+#             MedicalIntern: [ 4, 4 ] #intern, exclude from dept count
+#             Psychologist: [ 1, 1 ]
+#             #Science (5)
+#             Scientist: [ 5, 5 ]
+#             ResearchAssistant: [ 4, 4 ] #intern, exclude from dept count
+#             #Security (9 - 11)
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 5, 7 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 2, 4 ] #intern, exclude from dept count
+#             Lawyer: [ 2, 2 ]
+#             #Brigmedic: [ 1, 1 ]
+#             #supply
+#             SalvageSpecialist: [ 6, 6 ]
+#             CargoTechnician: [ 3, 3 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #Silicon (3)
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Maps/elkridge.yml
+++ b/Resources/Prototypes/Maps/elkridge.yml
@@ -1,68 +1,69 @@
-- type: gameMap
-  id: Elkridge
-  mapName: 'Elkridge Depot'
-  mapPath: /Maps/elkridge.yml
-  minPlayers: 15
-  maxPlayers: 45
-  stations:
-    Elkridge:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Elkridge Depot {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'DS'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_elkridge.yml
-        - type: StationCargoShuttle
-          path: /Maps/Shuttles/cargo_elkridge.yml
-        - type: StationJobs
-          availableJobs: # 46 jobs total w/o latejoins & interns, 61 jobs total w/ latejoins & interns
-            #command (7)
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            HeadOfSecurity: [ 1, 1 ]
-            ChiefMedicalOfficer: [ 1, 1 ]
-            ChiefEngineer: [ 1, 1 ]
-            ResearchDirector: [ 1, 1 ]
-            Quartermaster: [ 1, 1 ]
-            #service (9 - 11)
-            Bartender: [ 1, 1 ]
-            Botanist: [ 1, 2 ]
-            Chef: [ 1, 1 ]
-            Janitor: [ 1, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            Reporter: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            #engineering (5 - 6)
-            AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 3, 4 ]
-            TechnicalAssistant: [ 2, 2 ] #intern, not counted
-            #medical (6 - 7)
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 2, 3 ]
-            MedicalIntern: [ 2, 2 ] #intern, not counted
-            Paramedic: [ 1, 1 ]
-            Psychologist: [ 1, 1 ]
-            #science (3 - 4)
-            Scientist: [ 3, 4 ]
-            ResearchAssistant: [ 2, 2 ] #intern, not counted
-            #security (6 - 7)
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 3, 4 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 2, 2 ] #intern, not counted
-            Lawyer: [ 1, 1 ]
-            #supply (4 - 5)
-            SalvageSpecialist: [ 2, 2 ]
-            CargoTechnician: [ 2, 3 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon (3)
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: Elkridge
+#   mapName: 'Elkridge Depot'
+#   mapPath: /Maps/elkridge.yml
+#   minPlayers: 15
+#   maxPlayers: 45
+#   stations:
+#     Elkridge:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Elkridge Depot {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'DS'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_elkridge.yml
+#         - type: StationCargoShuttle
+#           path: /Maps/Shuttles/cargo_elkridge.yml
+#         - type: StationJobs
+#           availableJobs: # 46 jobs total w/o latejoins & interns, 61 jobs total w/ latejoins & interns
+#             #command (7)
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             HeadOfSecurity: [ 1, 1 ]
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             ChiefEngineer: [ 1, 1 ]
+#             ResearchDirector: [ 1, 1 ]
+#             Quartermaster: [ 1, 1 ]
+#             #service (9 - 11)
+#             Bartender: [ 1, 1 ]
+#             Botanist: [ 1, 2 ]
+#             Chef: [ 1, 1 ]
+#             Janitor: [ 1, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             Reporter: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             #engineering (5 - 6)
+#             AtmosphericTechnician: [ 2, 2 ]
+#             StationEngineer: [ 3, 4 ]
+#             TechnicalAssistant: [ 2, 2 ] #intern, not counted
+#             #medical (6 - 7)
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 2, 3 ]
+#             MedicalIntern: [ 2, 2 ] #intern, not counted
+#             Paramedic: [ 1, 1 ]
+#             Psychologist: [ 1, 1 ]
+#             #science (3 - 4)
+#             Scientist: [ 3, 4 ]
+#             ResearchAssistant: [ 2, 2 ] #intern, not counted
+#             #security (6 - 7)
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 3, 4 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 2, 2 ] #intern, not counted
+#             Lawyer: [ 1, 1 ]
+#             #supply (4 - 5)
+#             SalvageSpecialist: [ 2, 2 ]
+#             CargoTechnician: [ 2, 3 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon (3)
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/exo.yml
+++ b/Resources/Prototypes/Maps/exo.yml
@@ -1,66 +1,67 @@
-- type: gameMap
-  id: Exo
-  mapName: 'Exo'
-  mapPath: /Maps/exo.yml
-  minPlayers: 40
-  maxPlayers: 80
-  stations:
-    Exo:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: 'Exomorph Vessel "Conquest" EXO-{1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_exo.yml
-        - type: StationCargoShuttle
-          path: /Maps/Shuttles/cargo_exo.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 3, 3 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
-            MedicalIntern: [ 3, 3 ]
-            Paramedic: [ 1, 1 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 3, 3 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
-            Lawyer: [ 2, 2 ]
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 4, 4 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            Reporter: [ 2, 2 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: Exo
+#   mapName: 'Exo'
+#   mapPath: /Maps/exo.yml
+#   minPlayers: 40
+#   maxPlayers: 80
+#   stations:
+#     Exo:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: 'Exomorph Vessel "Conquest" EXO-{1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_exo.yml
+#         - type: StationCargoShuttle
+#           path: /Maps/Shuttles/cargo_exo.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 2, 2 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 2, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 4, 4 ]
+#             TechnicalAssistant: [ 3, 3 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 4, 4 ]
+#             MedicalIntern: [ 3, 3 ]
+#             Paramedic: [ 1, 1 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 4, 4 ]
+#             ResearchAssistant: [ 3, 3 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 4, 4 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 4 ]
+#             Lawyer: [ 2, 2 ]
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 4, 4 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             Reporter: [ 2, 2 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -1,66 +1,67 @@
-- type: gameMap
-  id: Fland
-  mapName: 'Fland Installation'
-  mapPath: /Maps/fland.yml
-  minPlayers: 70
-  stations:
-    Fland:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Fland Installation {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'B'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_delta.yml
-        - type: StationCargoShuttle
-          path: /Maps/Shuttles/cargo_fland.yml
-        - type: StationJobs
-          availableJobs: # 81 jobs total w/o latejoins & interns, 101 jobs total w/ latejoins & interns
-            #command (7)
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            HeadOfSecurity: [ 1, 1 ]
-            ChiefMedicalOfficer: [ 1, 1 ]
-            ChiefEngineer: [ 1, 1 ]
-            ResearchDirector: [ 1, 1 ]
-            Quartermaster: [ 1, 1 ]
-            #service (17)
-            Bartender: [ 2, 2 ]
-            Botanist: [ 3, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 4, 4 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            Reporter: [ 2, 2 ]
-            #engineering (9)
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 6, 6 ]
-            TechnicalAssistant: [ 4, 4 ] #intern, not counted
-            #medical (11)
-            Chemist: [ 3, 3 ]
-            MedicalDoctor: [ 6, 6 ]
-            Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 4, 4 ] #intern, not counted
-            #science (5)
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 6, 6 ] #intern, not counted
-            #security (14)
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 10, 10 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 6, 6 ] #intern, not counted
-            Lawyer: [ 2, 2 ]
-            #supply (9)
-            SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 6, 6 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon (6)
-            StationAi: [ 1, 1 ]
-            Borg: [ 5, 5 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: Fland
+#   mapName: 'Fland Installation'
+#   mapPath: /Maps/fland.yml
+#   minPlayers: 70
+#   stations:
+#     Fland:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Fland Installation {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'B'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_delta.yml
+#         - type: StationCargoShuttle
+#           path: /Maps/Shuttles/cargo_fland.yml
+#         - type: StationJobs
+#           availableJobs: # 81 jobs total w/o latejoins & interns, 101 jobs total w/ latejoins & interns
+#             #command (7)
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             HeadOfSecurity: [ 1, 1 ]
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             ChiefEngineer: [ 1, 1 ]
+#             ResearchDirector: [ 1, 1 ]
+#             Quartermaster: [ 1, 1 ]
+#             #service (17)
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 3, 3 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 4, 4 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             Reporter: [ 2, 2 ]
+#             #engineering (9)
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 6, 6 ]
+#             TechnicalAssistant: [ 4, 4 ] #intern, not counted
+#             #medical (11)
+#             Chemist: [ 3, 3 ]
+#             MedicalDoctor: [ 6, 6 ]
+#             Paramedic: [ 2, 2 ]
+#             MedicalIntern: [ 4, 4 ] #intern, not counted
+#             #science (5)
+#             Scientist: [ 5, 5 ]
+#             ResearchAssistant: [ 6, 6 ] #intern, not counted
+#             #security (14)
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 10, 10 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 6, 6 ] #intern, not counted
+#             Lawyer: [ 2, 2 ]
+#             #supply (9)
+#             SalvageSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 6, 6 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon (6)
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 5, 5 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -1,65 +1,66 @@
-- type: gameMap
-  id: Marathon
-  mapName: 'Marathon Station'
-  mapPath: /Maps/marathon.yml
-  minPlayers: 35
-  maxPlayers: 70
-  stations:
-    Marathon:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Marathon Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_rod.yml
-        - type: StationJobs
-          availableJobs: # 61 jobs total w/o latejoins & interns, 76 jobs total w/ latejoins & interns
-            #command (7)
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            HeadOfSecurity: [ 1, 1 ]
-            ChiefMedicalOfficer: [ 1, 1 ]
-            ChiefEngineer: [ 1, 1 ]
-            ResearchDirector: [ 1, 1 ]
-            Quartermaster: [ 1, 1 ]
-            #service (11 - 13)
-            Bartender: [ 2, 2 ]
-            Botanist: [ 2, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 1, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            #engineering (7)
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 3, 3 ] #intern, not counted
-            #medical (8)
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
-            MedicalIntern: [ 3, 3 ] #intern, not counted
-            Psychologist: [ 1, 1 ]
-            Paramedic: [ 1, 1 ]
-            #science (4)
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 3, 3 ] #intern, not counted
-            #security (12)
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 8, 8 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ] #intern, not counted
-            Lawyer: [ 2, 2 ]
-            #supply
-            SalvageSpecialist: [ 6, 6 ]
-            CargoTechnician: [ 3, 3 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon (3)
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: Marathon
+#   mapName: 'Marathon Station'
+#   mapPath: /Maps/marathon.yml
+#   minPlayers: 35
+#   maxPlayers: 70
+#   stations:
+#     Marathon:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Marathon Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_rod.yml
+#         - type: StationJobs
+#           availableJobs: # 61 jobs total w/o latejoins & interns, 76 jobs total w/ latejoins & interns
+#             #command (7)
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             HeadOfSecurity: [ 1, 1 ]
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             ChiefEngineer: [ 1, 1 ]
+#             ResearchDirector: [ 1, 1 ]
+#             Quartermaster: [ 1, 1 ]
+#             #service (11 - 13)
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 2, 3 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 1, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             #engineering (7)
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 4, 4 ]
+#             TechnicalAssistant: [ 3, 3 ] #intern, not counted
+#             #medical (8)
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 4, 4 ]
+#             MedicalIntern: [ 3, 3 ] #intern, not counted
+#             Psychologist: [ 1, 1 ]
+#             Paramedic: [ 1, 1 ]
+#             #science (4)
+#             Scientist: [ 4, 4 ]
+#             ResearchAssistant: [ 3, 3 ] #intern, not counted
+#             #security (12)
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 8, 8 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 4 ] #intern, not counted
+#             Lawyer: [ 2, 2 ]
+#             #supply
+#             SalvageSpecialist: [ 6, 6 ]
+#             CargoTechnician: [ 3, 3 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon (3)
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -1,66 +1,67 @@
-- type: gameMap
-  id: Oasis
-  mapName: 'Oasis'
-  mapPath: /Maps/oasis.yml
-  minPlayers: 70
-  stations:
-    Oasis:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Oasis {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'B'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_accordia.yml
-        - type: StationJobs
-          availableJobs: # 72 jobs total w/o latejoins & interns, 91 jobs total w/ latejoins & interns
-            #command (7)
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            HeadOfSecurity: [ 1, 1 ]
-            ChiefMedicalOfficer: [ 1, 1 ]
-            ChiefEngineer: [ 1, 1 ]
-            ResearchDirector: [ 1, 1 ]
-            Quartermaster: [ 1, 1 ]
-            #service (15 - 16)
-            Bartender: [ 2, 2 ]
-            Botanist: [ 2, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 3, 3 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            Reporter: [ 1, 1 ]
-            #engineering (8)
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 4, 4 ] #intern, not counted
-            #medical (11)
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 6, 6 ]
-            Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 4, 4 ] #intern, not counted
-            Psychologist: [ 1, 1 ]
-            #science (5)
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 6, 6 ] #intern, not counted
-            #security (13)
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 8, 8 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ] #intern, not counted
-            Lawyer: [ 3, 3 ]
-            #Brigmedic: [ 1, 1 ]
-            #supply
-            SalvageSpecialist: [ 6, 6 ]
-            CargoTechnician: [ 4, 4 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon (3)
-            Borg: [ 2, 2 ]
-            StationAi: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: Oasis
+#   mapName: 'Oasis'
+#   mapPath: /Maps/oasis.yml
+#   minPlayers: 70
+#   stations:
+#     Oasis:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Oasis {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'B'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_accordia.yml
+#         - type: StationJobs
+#           availableJobs: # 72 jobs total w/o latejoins & interns, 91 jobs total w/ latejoins & interns
+#             #command (7)
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             HeadOfSecurity: [ 1, 1 ]
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             ChiefEngineer: [ 1, 1 ]
+#             ResearchDirector: [ 1, 1 ]
+#             Quartermaster: [ 1, 1 ]
+#             #service (15 - 16)
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 2, 3 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 3, 3 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             Reporter: [ 1, 1 ]
+#             #engineering (8)
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 5, 5 ]
+#             TechnicalAssistant: [ 4, 4 ] #intern, not counted
+#             #medical (11)
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 6, 6 ]
+#             Paramedic: [ 2, 2 ]
+#             MedicalIntern: [ 4, 4 ] #intern, not counted
+#             Psychologist: [ 1, 1 ]
+#             #science (5)
+#             Scientist: [ 5, 5 ]
+#             ResearchAssistant: [ 6, 6 ] #intern, not counted
+#             #security (13)
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 8, 8 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 4 ] #intern, not counted
+#             Lawyer: [ 3, 3 ]
+#             #Brigmedic: [ 1, 1 ]
+#             #supply
+#             SalvageSpecialist: [ 6, 6 ]
+#             CargoTechnician: [ 4, 4 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon (3)
+#             Borg: [ 2, 2 ]
+#             StationAi: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -1,65 +1,65 @@
-
-- type: gameMap
-  id: Packed
-  mapName: 'Packed'
-  mapPath: /Maps/packed.yml
-  minPlayers: 7
-  maxPlayers: 35
-  stations:
-    Packed:
-      stationProto: StandardNanotrasenStation
-      components:
-      - type: StationNameSetup
-        mapNameTemplate: '{0} Packed {1}'
-        nameGenerator:
-          !type:NanotrasenNameGenerator
-          prefixCreator: 'VG'
-      - type: StationEmergencyShuttle
-        emergencyShuttlePath: /Maps/Shuttles/emergency_crimson.yml
-      - type: StationJobs
-        availableJobs: # 47 jobs total w/o latejoins & interns, 58 jobs total w/ latejoins & interns
-          #command (7)
-          Captain: [ 1, 1 ]
-          HeadOfPersonnel: [ 1, 1 ]
-          HeadOfSecurity: [ 1, 1 ]
-          ChiefMedicalOfficer: [ 1, 1 ]
-          ChiefEngineer: [ 1, 1 ]
-          ResearchDirector: [ 1, 1 ]
-          Quartermaster: [ 1, 1 ]
-          #service (8 - 10)
-          Bartender: [ 1, 1 ]
-          Botanist: [ 1, 2 ]
-          Chef: [ 1, 1 ]
-          Janitor: [ 1, 2 ]
-          Chaplain: [ 1, 1 ]
-          Librarian: [ 1, 1 ]
-          ServiceWorker: [ 2, 2 ]
-          #engineering (6)
-          AtmosphericTechnician: [ 2, 2 ]
-          StationEngineer: [ 4, 4 ]
-          TechnicalAssistant: [ 3, 3 ] #intern, not counted
-          #medical (6)
-          Chemist: [ 2, 2 ]
-          MedicalDoctor: [ 3, 3 ]
-          MedicalIntern: [ 2, 2 ] #intern, not counted
-          Paramedic: [ 1, 1 ]
-          #science (4)
-          Scientist: [ 4, 4 ]
-          ResearchAssistant: [ 2, 2 ] #intern, not counted
-          #security (6)
-          Warden: [ 1, 1 ]
-          SecurityOfficer: [ 3, 3 ]
-          Detective: [ 1, 1 ]
-          SecurityCadet: [ 2, 2 ] #intern, not counted
-          Lawyer: [ 1, 1 ]
-          #supply (4)
-          SalvageSpecialist: [ 2, 2 ]
-          CargoTechnician: [ 2, 2 ]
-          #civilian (3+)
-          Assistant: [ -1, -1 ] #infinite, not counted
-          Clown: [ 1, 1 ]
-          Mime: [ 1, 1 ]
-          Musician: [ 1, 1 ]
-          #silicon (3)
-          StationAi: [ 1, 1 ]
-          Borg: [ 2, 2 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: Packed
+#   mapName: 'Packed'
+#   mapPath: /Maps/packed.yml
+#   minPlayers: 7
+#   maxPlayers: 35
+#   stations:
+#     Packed:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#       - type: StationNameSetup
+#         mapNameTemplate: '{0} Packed {1}'
+#         nameGenerator:
+#           !type:NanotrasenNameGenerator
+#           prefixCreator: 'VG'
+#       - type: StationEmergencyShuttle
+#         emergencyShuttlePath: /Maps/Shuttles/emergency_crimson.yml
+#       - type: StationJobs
+#         availableJobs: # 47 jobs total w/o latejoins & interns, 58 jobs total w/ latejoins & interns
+#           #command (7)
+#           Captain: [ 1, 1 ]
+#           HeadOfPersonnel: [ 1, 1 ]
+#           HeadOfSecurity: [ 1, 1 ]
+#           ChiefMedicalOfficer: [ 1, 1 ]
+#           ChiefEngineer: [ 1, 1 ]
+#           ResearchDirector: [ 1, 1 ]
+#           Quartermaster: [ 1, 1 ]
+#           #service (8 - 10)
+#           Bartender: [ 1, 1 ]
+#           Botanist: [ 1, 2 ]
+#           Chef: [ 1, 1 ]
+#           Janitor: [ 1, 2 ]
+#           Chaplain: [ 1, 1 ]
+#           Librarian: [ 1, 1 ]
+#           ServiceWorker: [ 2, 2 ]
+#           #engineering (6)
+#           AtmosphericTechnician: [ 2, 2 ]
+#           StationEngineer: [ 4, 4 ]
+#           TechnicalAssistant: [ 3, 3 ] #intern, not counted
+#           #medical (6)
+#           Chemist: [ 2, 2 ]
+#           MedicalDoctor: [ 3, 3 ]
+#           MedicalIntern: [ 2, 2 ] #intern, not counted
+#           Paramedic: [ 1, 1 ]
+#           #science (4)
+#           Scientist: [ 4, 4 ]
+#           ResearchAssistant: [ 2, 2 ] #intern, not counted
+#           #security (6)
+#           Warden: [ 1, 1 ]
+#           SecurityOfficer: [ 3, 3 ]
+#           Detective: [ 1, 1 ]
+#           SecurityCadet: [ 2, 2 ] #intern, not counted
+#           Lawyer: [ 1, 1 ]
+#           #supply (4)
+#           SalvageSpecialist: [ 2, 2 ]
+#           CargoTechnician: [ 2, 2 ]
+#           #civilian (3+)
+#           Assistant: [ -1, -1 ] #infinite, not counted
+#           Clown: [ 1, 1 ]
+#           Mime: [ 1, 1 ]
+#           Musician: [ 1, 1 ]
+#           #silicon (3)
+#           StationAi: [ 1, 1 ]
+#           Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -1,68 +1,69 @@
-- type: gameMap
-  id: Plasma
-  mapName: 'Plasma'
-  mapPath: /Maps/plasma.yml
-  minPlayers: 30
-  maxPlayers: 80
-  stations:
-    Plasma:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Plasma {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_plasma.yml
-        - type: StationCargoShuttle
-          path: /Maps/Shuttles/cargo_plasma.yml
-        - type: StationJobs
-          availableJobs: # 66 jobs total w/o latejoins & interns, 91 jobs total w/ latejoins & interns
-            #command (7)
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            ChiefEngineer: [ 1, 1 ]
-            ChiefMedicalOfficer: [ 1, 1 ]
-            ResearchDirector: [ 1, 1 ]
-            HeadOfSecurity: [ 1, 1 ]
-            Quartermaster: [ 1, 1 ]
-            #service (15 - 17)
-            Bartender: [ 2, 2 ]
-            Botanist: [ 2, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 3, 3 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            Reporter: [ 2, 3 ]
-            #engineering (8)
-            AtmosphericTechnician: [ 4, 4 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 4, 4 ] #intern, not counted
-            #medical (9)
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
-            Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 4, 4 ] #intern, not counted
-            Psychologist: [ 1, 1 ]
-            #science (4)
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 4, 4 ] #intern, not counted
-            #security (9 - 11)
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 6, 8 ]
-            Detective: [ 1, 2 ] #good cop, bad cop
-            SecurityCadet: [ 4, 4 ] #intern, not counted
-            Lawyer: [ 1, 2 ]
-            #supply (8 - 10)
-            SalvageSpecialist: [ 4, 4 ] #the salvagers yearn for the mines
-            CargoTechnician: [ 4, 6 ]
-            #civilian (3 - 4+)
-            Assistant: [ -1, -1 ]  #infinite, the tiders yearn for the mines
-            Clown: [ 1, 2 ] # this might be fun!
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon (3 - 5)
-            Borg: [ 2, 4 ]
-            StationAi: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: Plasma
+#   mapName: 'Plasma'
+#   mapPath: /Maps/plasma.yml
+#   minPlayers: 30
+#   maxPlayers: 80
+#   stations:
+#     Plasma:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Plasma {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_plasma.yml
+#         - type: StationCargoShuttle
+#           path: /Maps/Shuttles/cargo_plasma.yml
+#         - type: StationJobs
+#           availableJobs: # 66 jobs total w/o latejoins & interns, 91 jobs total w/ latejoins & interns
+#             #command (7)
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             ChiefEngineer: [ 1, 1 ]
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             ResearchDirector: [ 1, 1 ]
+#             HeadOfSecurity: [ 1, 1 ]
+#             Quartermaster: [ 1, 1 ]
+#             #service (15 - 17)
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 2, 3 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 3, 3 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             Reporter: [ 2, 3 ]
+#             #engineering (8)
+#             AtmosphericTechnician: [ 4, 4 ]
+#             StationEngineer: [ 4, 4 ]
+#             TechnicalAssistant: [ 4, 4 ] #intern, not counted
+#             #medical (9)
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 4, 4 ]
+#             Paramedic: [ 2, 2 ]
+#             MedicalIntern: [ 4, 4 ] #intern, not counted
+#             Psychologist: [ 1, 1 ]
+#             #science (4)
+#             Scientist: [ 4, 4 ]
+#             ResearchAssistant: [ 4, 4 ] #intern, not counted
+#             #security (9 - 11)
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 6, 8 ]
+#             Detective: [ 1, 2 ] #good cop, bad cop
+#             SecurityCadet: [ 4, 4 ] #intern, not counted
+#             Lawyer: [ 1, 2 ]
+#             #supply (8 - 10)
+#             SalvageSpecialist: [ 4, 4 ] #the salvagers yearn for the mines
+#             CargoTechnician: [ 4, 6 ]
+#             #civilian (3 - 4+)
+#             Assistant: [ -1, -1 ]  #infinite, the tiders yearn for the mines
+#             Clown: [ 1, 2 ] # this might be fun!
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon (3 - 5)
+#             Borg: [ 2, 4 ]
+#             StationAi: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/reach.yml
+++ b/Resources/Prototypes/Maps/reach.yml
@@ -1,45 +1,46 @@
-- type: gameMap
-  id: Reach
-  mapName: 'Reach'
-  mapPath: /Maps/reach.yml
-  minPlayers: 0
-  maxPlayers: 7
-  stations:
-    Reach:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Reach Transport {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'SC'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency.yml
-        - type: StationJobs
-          availableJobs: # 17 jobs total w/o latejoins, 21 jobs total w/ latejoins
-            #command (2)
-            Captain: [ 1, 1 ]
-            HeadOfSecurity: [ 1, 1 ]
-            #service (4)
-            Bartender: [ 1, 1 ]
-            Botanist: [ 1, 1 ]
-            Chef: [ 1, 1 ]
-            Janitor: [ 1, 1 ]
-            #engineering (2 - 3)
-            AtmosphericTechnician: [ 1, 1 ]
-            StationEngineer: [ 1, 2 ]
-            #medical (2 - 3)
-            Chemist: [ 1, 1 ]
-            MedicalDoctor: [ 1, 2 ]
-            #science (1)
-            Scientist: [ 1, 1 ]
-            #security (1 - 3)
-            SecurityOfficer: [ 1, 3 ]
-            #supply (2)
-            CargoTechnician: [ 1, 1 ]
-            SalvageSpecialist: [ 1, 1 ]
-            #civilian (3+)
-            Assistant: [ -1, -1 ] #infinite, not counted
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: Reach
+#   mapName: 'Reach'
+#   mapPath: /Maps/reach.yml
+#   minPlayers: 0
+#   maxPlayers: 7
+#   stations:
+#     Reach:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Reach Transport {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'SC'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency.yml
+#         - type: StationJobs
+#           availableJobs: # 17 jobs total w/o latejoins, 21 jobs total w/ latejoins
+#             #command (2)
+#             Captain: [ 1, 1 ]
+#             HeadOfSecurity: [ 1, 1 ]
+#             #service (4)
+#             Bartender: [ 1, 1 ]
+#             Botanist: [ 1, 1 ]
+#             Chef: [ 1, 1 ]
+#             Janitor: [ 1, 1 ]
+#             #engineering (2 - 3)
+#             AtmosphericTechnician: [ 1, 1 ]
+#             StationEngineer: [ 1, 2 ]
+#             #medical (2 - 3)
+#             Chemist: [ 1, 1 ]
+#             MedicalDoctor: [ 1, 2 ]
+#             #science (1)
+#             Scientist: [ 1, 1 ]
+#             #security (1 - 3)
+#             SecurityOfficer: [ 1, 3 ]
+#             #supply (2)
+#             CargoTechnician: [ 1, 1 ]
+#             SalvageSpecialist: [ 1, 1 ]
+#             #civilian (3+)
+#             Assistant: [ -1, -1 ] #infinite, not counted
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/relic.yml
+++ b/Resources/Prototypes/Maps/relic.yml
@@ -1,64 +1,65 @@
-- type: gameMap
-  id: Relic
-  mapName: 'Relic'
-  mapPath: /Maps/relic.yml
-  maxRandomOffset: 0
-  randomRotation: false
-  minPlayers: 15
-  maxPlayers: 35
-  stations:
-    Relic:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Relic Station SS13'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'OG'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_relic.yml
-        - type: StationArrivals
-          shuttlePath: /Maps/Shuttles/arrivals_relic.yml
-        - type: StationCargoShuttle
-          path: /Maps/Shuttles/cargo_relic.yml
-        - type: GridSpawn
-          groups:
-            trade: !type:GridSpawnGroup
-              minCount: 0
-              maxCount: 0
-              paths:
-                - /Maps/Shuttles/trading_outpost.yml
-        - type: StationJobs
-          availableJobs:
-            #command (6)
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            HeadOfSecurity: [ 1, 1 ]
-            ChiefMedicalOfficer: [ 1, 1 ]
-            ChiefEngineer: [ 1, 1 ]
-            ResearchDirector: [ 1, 1 ]
-            #service (1)
-            Chaplain: [ 1, 1 ]
-            #engineering (4)
-            AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 2, 2 ]
-            TechnicalAssistant: [ 2, 2 ] #intern, not counted
-            #medical (4)
-            Chemist: [ 1, 1 ]
-            MedicalDoctor: [ 2, 2 ]
-            Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 2, 2 ] #intern, not counted
-            #science (1 - 2)
-            Scientist: [ 1, 2 ]
-            ResearchAssistant: [ 2, 2 ] #intern, not counted
-            #security (4 - 5)
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 1, 2 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 2, 2 ] #intern, not counted
-            Lawyer: [ 1, 1 ]
-            #supply (0)
-            #civilian (0+)
-            Assistant: [ -1, -1 ] #infinite, not counted, Starlight Assistant
-            #silicon (1)
-            StationAi: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: Relic
+#   mapName: 'Relic'
+#   mapPath: /Maps/relic.yml
+#   maxRandomOffset: 0
+#   randomRotation: false
+#   minPlayers: 15
+#   maxPlayers: 35
+#   stations:
+#     Relic:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Relic Station SS13'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'OG'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_relic.yml
+#         - type: StationArrivals
+#           shuttlePath: /Maps/Shuttles/arrivals_relic.yml
+#         - type: StationCargoShuttle
+#           path: /Maps/Shuttles/cargo_relic.yml
+#         - type: GridSpawn
+#           groups:
+#             trade: !type:GridSpawnGroup
+#               minCount: 0
+#               maxCount: 0
+#               paths:
+#                 - /Maps/Shuttles/trading_outpost.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #command (6)
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             HeadOfSecurity: [ 1, 1 ]
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             ChiefEngineer: [ 1, 1 ]
+#             ResearchDirector: [ 1, 1 ]
+#             #service (1)
+#             Chaplain: [ 1, 1 ]
+#             #engineering (4)
+#             AtmosphericTechnician: [ 2, 2 ]
+#             StationEngineer: [ 2, 2 ]
+#             TechnicalAssistant: [ 2, 2 ] #intern, not counted
+#             #medical (4)
+#             Chemist: [ 1, 1 ]
+#             MedicalDoctor: [ 2, 2 ]
+#             Paramedic: [ 1, 1 ]
+#             MedicalIntern: [ 2, 2 ] #intern, not counted
+#             #science (1 - 2)
+#             Scientist: [ 1, 2 ]
+#             ResearchAssistant: [ 2, 2 ] #intern, not counted
+#             #security (4 - 5)
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 1, 2 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 2, 2 ] #intern, not counted
+#             Lawyer: [ 1, 1 ]
+#             #supply (0)
+#             #civilian (0+)
+#             Assistant: [ -1, -1 ] #infinite, not counted, Starlight Assistant
+#             #silicon (1)
+#             StationAi: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -1,62 +1,63 @@
-- type: gameMap
-  id: Saltern
-  mapName: 'Saltern'
-  mapPath: /Maps/saltern.yml
-  minPlayers: 0
-  maxPlayers: 35
-  fallback: true
-  stations:
-    Saltern:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Saltern {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationJobs
-          availableJobs: # 45 jobs total w/o latejoins & interns, 62 jobs total w/ latejoins & interns
-            #command (7)
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            HeadOfSecurity: [ 1, 1 ]
-            ChiefMedicalOfficer: [ 1, 1 ]
-            ChiefEngineer: [ 1, 1 ]
-            ResearchDirector: [ 1, 1 ]
-            Quartermaster: [ 1, 1 ]
-            #service (8 - 9)
-            Bartender: [ 1, 1 ]
-            Botanist: [ 1, 2 ]
-            Chef: [ 1, 1 ]
-            Janitor: [ 1, 1 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            #engineering (6)
-            AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 4, 4 ] #intern, not counted
-            #medical (6)
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 3 ]
-            MedicalIntern: [ 4, 4 ] #intern, not counted
-            Paramedic: [ 1, 1 ]
-            #science (4)
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 2, 2 ] #intern, not counted
-            #security (6)
-            Warden: [ 1, 1 ]
-            Detective: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
-            SecurityCadet: [ 4, 4 ]
-            #Brigmedic: [ 1, 1 ]
-            #supply
-            SalvageSpecialist: [ 6, 6 ]
-            CargoTechnician: [ 2, 2 ]
-            #civillian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon (2)
-            Borg: [ 2, 2 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: Saltern
+#   mapName: 'Saltern'
+#   mapPath: /Maps/saltern.yml
+#   minPlayers: 0
+#   maxPlayers: 35
+#   fallback: true
+#   stations:
+#     Saltern:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Saltern {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14'
+#         - type: StationJobs
+#           availableJobs: # 45 jobs total w/o latejoins & interns, 62 jobs total w/ latejoins & interns
+#             #command (7)
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             HeadOfSecurity: [ 1, 1 ]
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             ChiefEngineer: [ 1, 1 ]
+#             ResearchDirector: [ 1, 1 ]
+#             Quartermaster: [ 1, 1 ]
+#             #service (8 - 9)
+#             Bartender: [ 1, 1 ]
+#             Botanist: [ 1, 2 ]
+#             Chef: [ 1, 1 ]
+#             Janitor: [ 1, 1 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             #engineering (6)
+#             AtmosphericTechnician: [ 2, 2 ]
+#             StationEngineer: [ 4, 4 ]
+#             TechnicalAssistant: [ 4, 4 ] #intern, not counted
+#             #medical (6)
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 3, 3 ]
+#             MedicalIntern: [ 4, 4 ] #intern, not counted
+#             Paramedic: [ 1, 1 ]
+#             #science (4)
+#             Scientist: [ 4, 4 ]
+#             ResearchAssistant: [ 2, 2 ] #intern, not counted
+#             #security (6)
+#             Warden: [ 1, 1 ]
+#             Detective: [ 1, 1 ]
+#             SecurityOfficer: [ 4, 4 ]
+#             SecurityCadet: [ 4, 4 ]
+#             #Brigmedic: [ 1, 1 ]
+#             #supply
+#             SalvageSpecialist: [ 6, 6 ]
+#             CargoTechnician: [ 2, 2 ]
+#             #civillian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon (2)
+#             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/snowball.yml
+++ b/Resources/Prototypes/Maps/snowball.yml
@@ -1,64 +1,65 @@
-- type: gameMap
-  id: Snowball
-  mapName: 'Snowball Station'
-  mapPath: /Maps/snowball.yml
-  minPlayers: 15
-  maxPlayers: 50
-  stations:
-    Snowball:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Snowball Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_rod.yml
-        - type: StationJobs
-          availableJobs: # 49 roundstart jobs without interns,  75 total jobs including interns
-            #command (7)
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            HeadOfSecurity: [ 1, 1 ]
-            ChiefMedicalOfficer: [ 1, 1 ]
-            ChiefEngineer: [ 1, 1 ]
-            ResearchDirector: [ 1, 1 ]
-            Quartermaster: [ 1, 1 ]
-            #service (10 - 13)
-            Bartender: [ 1, 2 ]
-            Botanist: [ 2, 2 ]
-            Chef: [ 2, 3 ]
-            Janitor: [ 1, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            #engineering (5 - 7)
-            AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 3, 5 ]
-            TechnicalAssistant: [ 3, 3 ] #intern, not counted
-            #medical (6 - 8)
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 5 ]
-            MedicalIntern: [ 3, 3 ] #intern, not counted
-            Paramedic: [ 1, 1 ]
-            #science (3 - 5)
-            Scientist: [ 3, 5 ]
-            ResearchAssistant: [ 3, 3 ] #intern, not counted
-            #security (6 - 8)
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 3, 5 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ] #intern, not counted
-            Lawyer: [ 1, 1 ]
-            #supply (6-8)
-            SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 3, 5 ]
-            #civilian (3+)
-            Assistant: [ -1, -1 ] #infinite, not counted #Starlight, assistant change
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon (3)
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: Snowball
+#   mapName: 'Snowball Station'
+#   mapPath: /Maps/snowball.yml
+#   minPlayers: 15
+#   maxPlayers: 50
+#   stations:
+#     Snowball:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Snowball Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_rod.yml
+#         - type: StationJobs
+#           availableJobs: # 49 roundstart jobs without interns,  75 total jobs including interns
+#             #command (7)
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             HeadOfSecurity: [ 1, 1 ]
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             ChiefEngineer: [ 1, 1 ]
+#             ResearchDirector: [ 1, 1 ]
+#             Quartermaster: [ 1, 1 ]
+#             #service (10 - 13)
+#             Bartender: [ 1, 2 ]
+#             Botanist: [ 2, 2 ]
+#             Chef: [ 2, 3 ]
+#             Janitor: [ 1, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             #engineering (5 - 7)
+#             AtmosphericTechnician: [ 2, 2 ]
+#             StationEngineer: [ 3, 5 ]
+#             TechnicalAssistant: [ 3, 3 ] #intern, not counted
+#             #medical (6 - 8)
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 3, 5 ]
+#             MedicalIntern: [ 3, 3 ] #intern, not counted
+#             Paramedic: [ 1, 1 ]
+#             #science (3 - 5)
+#             Scientist: [ 3, 5 ]
+#             ResearchAssistant: [ 3, 3 ] #intern, not counted
+#             #security (6 - 8)
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 3, 5 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 4 ] #intern, not counted
+#             Lawyer: [ 1, 1 ]
+#             #supply (6-8)
+#             SalvageSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 3, 5 ]
+#             #civilian (3+)
+#             Assistant: [ -1, -1 ] #infinite, not counted #Starlight, assistant change
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon (3)
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Roles/Antags/wizard.yml
+++ b/Resources/Prototypes/Roles/Antags/wizard.yml
@@ -10,7 +10,7 @@
   id: Wizard
   name: roles-antag-wizard-name
   antagonist: true
-  # setPreference: true # Disabled as roundstart gamemode until reworked
+  setPreference: true # Far Horizons - reenabled
   objective: roles-antag-wizard-objective # TODO: maybe give random objs and stationary ones from AntagObjectives and AntagRandomObjectives
   requirements: # I hate time locked roles but this should be enough time for someone to be acclimated
     - !type:OverallPlaytimeRequirement

--- a/Resources/Prototypes/_FarHorizons/Body/Species/resomi.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/resomi.yml
@@ -97,6 +97,11 @@
           32:
             sprite: Mobs/Species/Resomi/displacement.rsi
             state: belt
+      rig:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Resomi/displacement.rsi
+            state: belt
     femaleDisplacements:
       jumpsuit:
         sizeMaps:
@@ -154,6 +159,11 @@
             sprite: Mobs/Species/Resomi/displacement.rsi
             state: suitStorage
       belt:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Resomi/displacement.rsi
+            state: belt
+      rig:
         sizeMaps:
           32:
             sprite: Mobs/Species/Resomi/displacement.rsi

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
@@ -1005,6 +1005,11 @@
           32:
             sprite: Mobs/Species/Resomi/displacement.rsi
             state: belt
+      rig:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Resomi/displacement.rsi
+            state: belt
     femaleDisplacements:
       jumpsuit:
         sizeMaps:
@@ -1062,6 +1067,11 @@
             sprite: Mobs/Species/Resomi/displacement.rsi
             state: suitStorage
       belt:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Resomi/displacement.rsi
+            state: belt
+      rig:
         sizeMaps:
           32:
             sprite: Mobs/Species/Resomi/displacement.rsi
@@ -1843,6 +1853,11 @@
             sprite: _Starlight/Mobs/Species/Cyclorite/displacement.rsi
             state: neck
       belt:
+        sizeMaps:
+          32:
+            sprite: _Starlight/Mobs/Species/Cyclorite/displacement.rsi
+            state: belt
+      rig:
         sizeMaps:
           32:
             sprite: _Starlight/Mobs/Species/Cyclorite/displacement.rsi

--- a/Resources/Prototypes/_FarHorizons/Maps/fland.yml
+++ b/Resources/Prototypes/_FarHorizons/Maps/fland.yml
@@ -2,7 +2,7 @@
   id: FHFland
   mapName: 'Fland Installation'
   mapPath: /Maps/_FarHorizons/Stations/fland.yml
-  minPlayers: 60
+  minPlayers: 20 # Adjusting for it to appear in voting
 # maxplayers: 80 - Balanced for 80pop
   stations:
     FHFland:

--- a/Resources/Prototypes/_FarHorizons/Maps/manor.yml
+++ b/Resources/Prototypes/_FarHorizons/Maps/manor.yml
@@ -2,7 +2,7 @@
   id: FHManor
   mapName: 'Manor Station'
   mapPath: /Maps/_FarHorizons/Stations/Manor.yml
-  minPlayers: 50
+  minPlayers: 30 # Adjusting for it to appear in voting
   stations:
     Manor:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_FarHorizons/Maps/meta.yml
+++ b/Resources/Prototypes/_FarHorizons/Maps/meta.yml
@@ -2,7 +2,7 @@
   id: FHMeta
   mapName: 'Meta Station'
   mapPath: /Maps/_FarHorizons/Stations/meta.yml
-  minPlayers: 50
+  minPlayers: 40 # Adjusting for it to appear in voting
 # maxplayers: 80 - Balanced for 80pop
   stations:
     FHMeta:

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/cyclorites.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/cyclorites.yml
@@ -122,6 +122,13 @@
           32:
             sprite: _Starlight/Mobs/Species/Cyclorite/displacement.rsi
             state: belt
+      # Far Horizons start
+      rig:
+        sizeMaps:
+          32:
+            sprite: _Starlight/Mobs/Species/Cyclorite/displacement.rsi
+            state: belt
+      # Far Horizons end
       outerClothing:
         sizeMaps:
           32:

--- a/Resources/Prototypes/_StarLight/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_StarLight/Maps/Pools/default.yml
@@ -1,31 +1,32 @@
-- type: gameMapPool
-  id: DefaultStarlightMapPool
-  maps:
-  - StarlightBagel
-  - StarlightCog
-  - StarlightCork
-  - StarlightHotel
-  - StarlightLagan
-  - StarlightLeth
-  - StarlightLobster
-  - StarlightManor
-  - StarlightMing
-  - StarlightOasis
-  - StarlightOmega
-  - StarlightOrigin
-  - StarlightOrwell
-  - StarlightReach
-  - StarlightSaltern
-  - StarlightStarboard
-  - StarlightKiloton
-  - StarlightElkridge
-  - StarlightPrism
-  - StarlightSilica
-  - StarlightCluster
-  - StarlightBox
-# - StarlightBarratry
-# - StarlightExo
-# - StarlightMarathon
-# - StarlightMeta
-# - StarlightPacked
-# - StarlightFland
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMapPool
+#   id: DefaultStarlightMapPool
+#   maps:
+#   - StarlightBagel
+#   - StarlightCog
+#   - StarlightCork
+#   - StarlightHotel
+#   - StarlightLagan
+#   - StarlightLeth
+#   - StarlightLobster
+#   - StarlightManor
+#   - StarlightMing
+#   - StarlightOasis
+#   - StarlightOmega
+#   - StarlightOrigin
+#   - StarlightOrwell
+#   - StarlightReach
+#   - StarlightSaltern
+#   - StarlightStarboard
+#   - StarlightKiloton
+#   - StarlightElkridge
+#   - StarlightPrism
+#   - StarlightSilica
+#   - StarlightCluster
+#   - StarlightBox
+# # - StarlightBarratry
+# # - StarlightExo
+# # - StarlightMarathon
+# # - StarlightMeta
+# # - StarlightPacked
+# # - StarlightFland

--- a/Resources/Prototypes/_StarLight/Maps/Prism.yml
+++ b/Resources/Prototypes/_StarLight/Maps/Prism.yml
@@ -1,81 +1,82 @@
-- type: gameMap
-  id: StarlightPrism
-  mapName: 'Prism Station'
-  mapPath: /Maps/_Starlight/Stations/Prism.yml
-  minPlayers: 25
-  maxPlayers: 80
-  stations:
-    StarlightPrism:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Prism Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'SR'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_prism.yml
-        - type: StationCargoShuttle
-          path: /Maps/_Starlight/Shuttles/cargo_prism.yml
-        - type: StationJobs
-          availableJobs: 
-            #command
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            HeadOfSecurity: [ 1, 1 ]
-            ChiefMedicalOfficer: [ 1, 1 ]
-            ChiefEngineer: [ 1, 1 ]
-            ResearchDirector: [ 1, 1 ]
-            Quartermaster: [ 1, 1 ]
-            #service
-            Bartender: [ 1, 2]
-            Botanist: [ 1, 2 ]
-            Chef: [ 1, 2 ]
-            Janitor: [ 1, 1] 
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            Reporter: [ 1, 1 ]
-            ServiceWorker: [ 5, 5 ]
-            #engineering
-            AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 2, 3 ] 
-            #medical 
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
-            MedicalIntern: [ 3, 4 ] 
-            Paramedic: [ 2, 2 ]
-            Psychologist: [ 1, 1 ]
-            Surgeon: [ 1, 1 ]
-            #science 
-            Scientist: [ 3, 4 ]
-            ResearchAssistant: [ 2, 3 ] 
-            Roboticist: [ 2, 2 ]
-            #security 
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 5 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ] 
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply (4 - 5)
-            SalvageSpecialist: [ 4, 4 ]
-            MiningSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 4, 4 ]
-            MailTech: [ 2, 2 ]
-            SalvageLead: [ 1, 1 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon (3)
-            StationAi: [ 1, 1 ]
-            Borg: [ 4, 4 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightPrism
+#   mapName: 'Prism Station'
+#   mapPath: /Maps/_Starlight/Stations/Prism.yml
+#   minPlayers: 25
+#   maxPlayers: 80
+#   stations:
+#     StarlightPrism:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Prism Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'SR'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_prism.yml
+#         - type: StationCargoShuttle
+#           path: /Maps/_Starlight/Shuttles/cargo_prism.yml
+#         - type: StationJobs
+#           availableJobs: 
+#             #command
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             HeadOfSecurity: [ 1, 1 ]
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             ChiefEngineer: [ 1, 1 ]
+#             ResearchDirector: [ 1, 1 ]
+#             Quartermaster: [ 1, 1 ]
+#             #service
+#             Bartender: [ 1, 2]
+#             Botanist: [ 1, 2 ]
+#             Chef: [ 1, 2 ]
+#             Janitor: [ 1, 1] 
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             Reporter: [ 1, 1 ]
+#             ServiceWorker: [ 5, 5 ]
+#             #engineering
+#             AtmosphericTechnician: [ 2, 2 ]
+#             StationEngineer: [ 4, 4 ]
+#             TechnicalAssistant: [ 2, 3 ] 
+#             #medical 
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 4, 4 ]
+#             MedicalIntern: [ 3, 4 ] 
+#             Paramedic: [ 2, 2 ]
+#             Psychologist: [ 1, 1 ]
+#             Surgeon: [ 1, 1 ]
+#             #science 
+#             Scientist: [ 3, 4 ]
+#             ResearchAssistant: [ 2, 3 ] 
+#             Roboticist: [ 2, 2 ]
+#             #security 
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 4, 5 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 4 ] 
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply (4 - 5)
+#             SalvageSpecialist: [ 4, 4 ]
+#             MiningSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 4, 4 ]
+#             MailTech: [ 2, 2 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon (3)
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 4, 4 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/amber.yml
+++ b/Resources/Prototypes/_StarLight/Maps/amber.yml
@@ -1,74 +1,75 @@
-- type: gameMap
-  id: StarlightAmber
-  mapName: 'Amber'
-  mapPath: /Maps/_Starlight/Stations/Amber.yml
-  minPlayers: 7
-  maxPlayers: 50
-  stations:
-    StarlightAmber:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Amber Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14-SB'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_amber.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 1, 1 ]
-            Botanist: [ 2, 2 ]
-            Chef: [ 1, 1 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 1, 3 ]
-            Reporter: [ 1, 1 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 2, 4 ]
-            TechnicalAssistant: [ 1, 1 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 2, 4 ]
-            Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 1, 2 ]
-            Psychologist: [ 1, 1 ]
-            #Surgeon: [ 2, 2 ]  
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 1, 2 ]
-            Roboticist: [ 1, 1 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 1, 1 ]
-            #Lawyer: [ 1, 1 ]
-            #SecBorg: [1,1] #Far Horizons=
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 2, 3 ]
-            CargoTechnician: [ 2, 3 ]
-            #MailTech: [ 1, 2 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
-            #law
-            IAA: [ 2, 2 ]
-            #Representives
-            #BlueShield: [ 1, 1 ]
-            #NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightAmber
+#   mapName: 'Amber'
+#   mapPath: /Maps/_Starlight/Stations/Amber.yml
+#   minPlayers: 7
+#   maxPlayers: 50
+#   stations:
+#     StarlightAmber:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Amber Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14-SB'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_amber.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 1, 1 ]
+#             Botanist: [ 2, 2 ]
+#             Chef: [ 1, 1 ]
+#             Janitor: [ 2, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 1, 3 ]
+#             Reporter: [ 1, 1 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 2, 2 ]
+#             StationEngineer: [ 2, 4 ]
+#             TechnicalAssistant: [ 1, 1 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 2, 4 ]
+#             Paramedic: [ 2, 2 ]
+#             MedicalIntern: [ 1, 2 ]
+#             Psychologist: [ 1, 1 ]
+#             #Surgeon: [ 2, 2 ]  
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 4, 4 ]
+#             ResearchAssistant: [ 1, 2 ]
+#             Roboticist: [ 1, 1 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 4, 4 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 1, 1 ]
+#             #Lawyer: [ 1, 1 ]
+#             #SecBorg: [1,1] #Far Horizons=
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 2, 3 ]
+#             CargoTechnician: [ 2, 3 ]
+#             #MailTech: [ 1, 2 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 2 ]
+#             #law
+#             IAA: [ 2, 2 ]
+#             #Representives
+#             #BlueShield: [ 1, 1 ]
+#             #NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/bagel.yml
+++ b/Resources/Prototypes/_StarLight/Maps/bagel.yml
@@ -1,78 +1,79 @@
-- type: gameMap
-  id: StarlightBagel
-  mapName: 'Bagel Station'
-  mapPath: /Maps/_Starlight/Stations/Bagel.yml
-  minPlayers: 35
-  maxPlayers: 140
-  stations:
-    StarlightBagel:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Bagel Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_lox.yml
-        - type: StationJobs
-          availableJobs:
-            #command
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            HeadOfSecurity: [ 1, 1 ]
-            ChiefMedicalOfficer: [ 1, 1 ]
-            ChiefEngineer: [ 1, 1 ]
-            ResearchDirector: [ 1, 1 ]
-            Quartermaster: [ 1, 1 ]
-            #service 
-            Bartender: [ 1, 2 ]
-            Botanist: [ 2, 2 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            Reporter: [ 2, 2 ]
-            #engineering 
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 4, 4 ]
-            #medical 
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 3 ]
-            Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 4, 4 ]
-            Surgeon: [ 1, 2 ]
-            #science 
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 4, 4 ]
-            Roboticist: [ 2, 2 ]
-            #security 
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 8, 10 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 6 ] 
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            SalvageSpecialist: [ 6, 6 ]
-            CargoTechnician: [ 3, 3 ]
-            MiningSpecialist: [ 3, 3 ]
-            SalvageLead: [ 1, 1 ]
-            MailTech: [ 1, 2 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]      
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightBagel
+#   mapName: 'Bagel Station'
+#   mapPath: /Maps/_Starlight/Stations/Bagel.yml
+#   minPlayers: 35
+#   maxPlayers: 140
+#   stations:
+#     StarlightBagel:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Bagel Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_lox.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #command
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             HeadOfSecurity: [ 1, 1 ]
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             ChiefEngineer: [ 1, 1 ]
+#             ResearchDirector: [ 1, 1 ]
+#             Quartermaster: [ 1, 1 ]
+#             #service 
+#             Bartender: [ 1, 2 ]
+#             Botanist: [ 2, 2 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 2, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             Reporter: [ 2, 2 ]
+#             #engineering 
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 4, 4 ]
+#             TechnicalAssistant: [ 4, 4 ]
+#             #medical 
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 3, 3 ]
+#             Paramedic: [ 1, 1 ]
+#             MedicalIntern: [ 4, 4 ]
+#             Surgeon: [ 1, 2 ]
+#             #science 
+#             Scientist: [ 5, 5 ]
+#             ResearchAssistant: [ 4, 4 ]
+#             Roboticist: [ 2, 2 ]
+#             #security 
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 8, 10 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 6 ] 
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             SalvageSpecialist: [ 6, 6 ]
+#             CargoTechnician: [ 3, 3 ]
+#             MiningSpecialist: [ 3, 3 ]
+#             SalvageLead: [ 1, 1 ]
+#             MailTech: [ 1, 2 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 2 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]      
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/barratry.yml
+++ b/Resources/Prototypes/_StarLight/Maps/barratry.yml
@@ -1,78 +1,79 @@
-- type: gameMap
-  id: StarlightBarratry
-  mapName: 'Barratry'
-  mapPath: /Maps/_Starlight/Stations/Barratry.yml
-  minPlayers: 40
-  maxPlayers: 130
-  stations:
-    StarlightBarratry:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Barratry {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_raven.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 3, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 1, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 3, 3 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 3, 3 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
-            MedicalIntern: [ 3, 3 ]
-            Paramedic: [ 1, 1 ]
-            Surgeon: [ 2, 2 ]  
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 3, 3 ]
-            Roboticist: [ 1, 1 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 5 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 4, 4 ]
-            MailTech: [ 1, 2 ]
-            MiningSpecialist: [ 3, 3 ]
-            SalvageLead: [ 1, 1 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            Boxer: [ 2, 2]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 3, 3 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightBarratry
+#   mapName: 'Barratry'
+#   mapPath: /Maps/_Starlight/Stations/Barratry.yml
+#   minPlayers: 40
+#   maxPlayers: 130
+#   stations:
+#     StarlightBarratry:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Barratry {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_raven.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 3, 3 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 1, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 3, 3 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 4, 4 ]
+#             TechnicalAssistant: [ 3, 3 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 4, 4 ]
+#             MedicalIntern: [ 3, 3 ]
+#             Paramedic: [ 1, 1 ]
+#             Surgeon: [ 2, 2 ]  
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 5, 5 ]
+#             ResearchAssistant: [ 3, 3 ]
+#             Roboticist: [ 1, 1 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 4, 5 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 4 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 4, 4 ]
+#             MailTech: [ 1, 2 ]
+#             MiningSpecialist: [ 3, 3 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             Boxer: [ 2, 2]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 3, 3 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]
 

--- a/Resources/Prototypes/_StarLight/Maps/box.yml
+++ b/Resources/Prototypes/_StarLight/Maps/box.yml
@@ -1,78 +1,79 @@
-- type: gameMap
-  id: StarlightBox
-  mapName: 'Box Station'
-  mapPath: /Maps/_Starlight/Stations/Box.yml
-  minPlayers: 50
-  maxPlayers: 120
-  stations:
-    StarlightBox:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Box Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'TG'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_box.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 3, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 3 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 3 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 4, 4 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 5 ]
-            Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 4, 4 ]
-            Psychologist: [ 1, 1 ]
-            Surgeon: [ 2, 2 ]  
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 4, 4 ]
-            Roboticist: [ 2, 3 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 7, 8 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 4, 4 ]
-            CargoTechnician: [ 3, 3 ]
-            MiningSpecialist: [ 3, 3 ]
-            SalvageLead: [ 1, 1 ]
-            MailTech: [ 1, 2 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 2 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 3, 4 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightBox
+#   mapName: 'Box Station'
+#   mapPath: /Maps/_Starlight/Stations/Box.yml
+#   minPlayers: 50
+#   maxPlayers: 120
+#   stations:
+#     StarlightBox:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Box Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'TG'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_box.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 3, 3 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 2, 3 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 3 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 5, 5 ]
+#             TechnicalAssistant: [ 4, 4 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 4, 5 ]
+#             Paramedic: [ 1, 1 ]
+#             MedicalIntern: [ 4, 4 ]
+#             Psychologist: [ 1, 1 ]
+#             Surgeon: [ 2, 2 ]  
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 5, 5 ]
+#             ResearchAssistant: [ 4, 4 ]
+#             Roboticist: [ 2, 3 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 7, 8 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 4 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 4, 4 ]
+#             CargoTechnician: [ 3, 3 ]
+#             MiningSpecialist: [ 3, 3 ]
+#             SalvageLead: [ 1, 1 ]
+#             MailTech: [ 1, 2 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 2 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 3, 4 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]
 

--- a/Resources/Prototypes/_StarLight/Maps/cluster.yml
+++ b/Resources/Prototypes/_StarLight/Maps/cluster.yml
@@ -1,75 +1,76 @@
-- type: gameMap
-  id: StarlightCluster
-  mapName: 'Cluster'
-  mapPath: /Maps/_Starlight/Stations/Cluster.yml
-  minPlayers: 0
-  maxPlayers: 35
-  stations:
-    StarlightCluster:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Cluster Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'CW'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_cluster.yml
-        - type: StationJobs
-          availableJobs:
-            # 54 jobs (not counting interns)
-            #service (10-12)
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 1, 2 ]
-            Botanist: [ 1, 1 ]
-            Chef: [ 1, 1 ]
-            Janitor: [ 1, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            #engineering (6)
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 3, 3 ]
-            TechnicalAssistant: [ 2, 2 ]
-            #medical (8)
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 3 ]
-            Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 2, 2 ]
-            Surgeon: [ 1, 1 ]
-            #science (5)
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 3, 3 ]
-            ResearchAssistant: [ 2, 2 ]
-            Roboticist: [ 1, 1 ]
-            #security (7)
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 3, 3 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 2, 2 ]
-            Brigmedic: [ 1, 1 ]
-            #supply (8)
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 2, 2 ]
-            MailTech: [ 1, 1 ]
-            MiningSpecialist: [ 1, 2 ]
-            SalvageLead: [ 1, 1 ]
-            #civilian (3+)
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon (3)
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
-            #law (3)
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]
-            #Representives (2)
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightCluster
+#   mapName: 'Cluster'
+#   mapPath: /Maps/_Starlight/Stations/Cluster.yml
+#   minPlayers: 0
+#   maxPlayers: 35
+#   stations:
+#     StarlightCluster:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Cluster Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'CW'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_cluster.yml
+#         - type: StationJobs
+#           availableJobs:
+#             # 54 jobs (not counting interns)
+#             #service (10-12)
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 1, 2 ]
+#             Botanist: [ 1, 1 ]
+#             Chef: [ 1, 1 ]
+#             Janitor: [ 1, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             #engineering (6)
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 2, 2 ]
+#             StationEngineer: [ 3, 3 ]
+#             TechnicalAssistant: [ 2, 2 ]
+#             #medical (8)
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 3, 3 ]
+#             Paramedic: [ 1, 1 ]
+#             MedicalIntern: [ 2, 2 ]
+#             Surgeon: [ 1, 1 ]
+#             #science (5)
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 3, 3 ]
+#             ResearchAssistant: [ 2, 2 ]
+#             Roboticist: [ 1, 1 ]
+#             #security (7)
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 3, 3 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 2, 2 ]
+#             Brigmedic: [ 1, 1 ]
+#             #supply (8)
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 2, 2 ]
+#             MailTech: [ 1, 1 ]
+#             MiningSpecialist: [ 1, 2 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civilian (3+)
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon (3)
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 2 ]
+#             #law (3)
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]
+#             #Representives (2)
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/cog.yml
+++ b/Resources/Prototypes/_StarLight/Maps/cog.yml
@@ -1,80 +1,81 @@
-- type: gameMap
-  id: StarlightCog
-  mapName: 'Cog'
-  mapPath: /Maps/_Starlight/Stations/Cog.yml
-  minPlayers: 40
-  maxPlayers: 150 #big map
-  stations:
-    StarlightCog:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Cog {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'R4' # R4407/Goon. GS isn't as cool sounding.
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_wode.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 3, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 3, 3 ]
-            Chaplain: [ 1, 1 ]
-            Reporter: [ 2, 2 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 3, 3 ]
-            Zookeeper: [ 1, 1 ] 
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 3, 3 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 3, 3 ]
-            MedicalDoctor: [ 4, 4 ]
-            MedicalIntern: [ 3, 3 ]
-            Psychologist: [ 1, 1 ]
-            Paramedic: [ 2, 2 ]
-            Surgeon: [ 2, 2 ]  
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 3, 3 ]
-            Roboticist: [ 1, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 6, 6 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 4, 4 ]
-            MailTech: [ 1, 2 ]
-            MiningSpecialist: [ 3, 3 ]
-            SalvageLead: [ 1, 1 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 2 ]
-            Boxer: [ 2, 2]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 4, 5 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightCog
+#   mapName: 'Cog'
+#   mapPath: /Maps/_Starlight/Stations/Cog.yml
+#   minPlayers: 40
+#   maxPlayers: 150 #big map
+#   stations:
+#     StarlightCog:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Cog {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'R4' # R4407/Goon. GS isn't as cool sounding.
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_wode.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 3, 3 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 3, 3 ]
+#             Chaplain: [ 1, 1 ]
+#             Reporter: [ 2, 2 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 3, 3 ]
+#             Zookeeper: [ 1, 1 ] 
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 4, 4 ]
+#             TechnicalAssistant: [ 3, 3 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 3, 3 ]
+#             MedicalDoctor: [ 4, 4 ]
+#             MedicalIntern: [ 3, 3 ]
+#             Psychologist: [ 1, 1 ]
+#             Paramedic: [ 2, 2 ]
+#             Surgeon: [ 2, 2 ]  
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 5, 5 ]
+#             ResearchAssistant: [ 3, 3 ]
+#             Roboticist: [ 1, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 6, 6 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 4 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 4, 4 ]
+#             MailTech: [ 1, 2 ]
+#             MiningSpecialist: [ 3, 3 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 2 ]
+#             Boxer: [ 2, 2]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 4, 5 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/core.yml
+++ b/Resources/Prototypes/_StarLight/Maps/core.yml
@@ -1,76 +1,77 @@
-- type: gameMap
-  id: StarlightCore
-  mapName: 'Core'
-  mapPath: /Maps/_Starlight/Stations/Core.yml
-  minPlayers: 35
-  maxPlayers: 80
-  stations:
-    StarlightCore:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Core {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_rod.yml
-        - type: StationCargoShuttle
-          path: /Maps/Shuttles/cargo_core.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2]
-            Chef: [ 1, 1 ]
-            Janitor: [ 2, 2 ]
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 3, 3 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            StationEngineer: [ 4, 4 ]
-            AtmosphericTechnician: [ 2, 2 ]
-            TechnicalAssistant: [ 2, 2 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            MedicalDoctor: [ 3, 4 ]
-            Chemist: [ 2, 2 ]
-            MedicalIntern: [ 3, 3 ]
-            Paramedic: [ 1, 2 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 3, 3 ]
-            ResearchAssistant: [ 2, 2 ]
-            Roboticist: [ 2, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            SecurityOfficer: [ 5, 5 ]
-            Warden: [ 1, 1 ]
-            SecurityCadet: [ 2, 2 ]
-            Detective: [ 1, 1 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            CargoTechnician: [ 3, 3 ]
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 5, 5 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            Boxer: [ 2, 2 ]
-            Reporter: [ 2, 2 ]
-            # silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightCore
+#   mapName: 'Core'
+#   mapPath: /Maps/_Starlight/Stations/Core.yml
+#   minPlayers: 35
+#   maxPlayers: 80
+#   stations:
+#     StarlightCore:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Core {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_rod.yml
+#         - type: StationCargoShuttle
+#           path: /Maps/Shuttles/cargo_core.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 2, 2]
+#             Chef: [ 1, 1 ]
+#             Janitor: [ 2, 2 ]
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 3, 3 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             StationEngineer: [ 4, 4 ]
+#             AtmosphericTechnician: [ 2, 2 ]
+#             TechnicalAssistant: [ 2, 2 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             MedicalDoctor: [ 3, 4 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalIntern: [ 3, 3 ]
+#             Paramedic: [ 1, 2 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 3, 3 ]
+#             ResearchAssistant: [ 2, 2 ]
+#             Roboticist: [ 2, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             SecurityOfficer: [ 5, 5 ]
+#             Warden: [ 1, 1 ]
+#             SecurityCadet: [ 2, 2 ]
+#             Detective: [ 1, 1 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             CargoTechnician: [ 3, 3 ]
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 5, 5 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             Boxer: [ 2, 2 ]
+#             Reporter: [ 2, 2 ]
+#             # silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 2 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/cork.yml
+++ b/Resources/Prototypes/_StarLight/Maps/cork.yml
@@ -1,70 +1,71 @@
-- type: gameMap
-  id: StarlightCork
-  mapName: 'Cork Outpost'
-  mapPath: /Maps/_Starlight/Stations/Cork.yml
-  maxRandomOffset: 0
-  randomRotation: false
-  minPlayers: 0
-  maxPlayers: 15
-  stations:
-    StarlightCork:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Cork {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'VRS'
-        - type: StationJobs
-          availableJobs:
-            # command
-            Captain: [ 1, 1 ]
-            Magistrate: [ 1, 1 ]
-            # cargo
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 3, 3 ]
-            MailTech: [ 1, 1 ]
-            SalvageLead: [ 1, 1 ]
-            # engineering
-            ChiefEngineer: [ 1, 1 ]
-            StationEngineer: [ 2, 2 ]
-            AtmosphericTechnician: [ 1, 1 ]
-            TechnicalAssistant: [ 2, 2 ]
-            # medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            MedicalDoctor: [ 2, 2 ]
-            MedicalIntern: [ 2, 2 ]
-            Psychologist: [ 1, 1 ]
-            Paramedic: [ 1, 1 ]
-            Chemist: [ 1, 1 ]
-            # science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 2, 2 ]
-            ResearchAssistant: [ 2, 2 ]
-            # security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 2, 2 ]
-            SecurityCadet: [ 2, 2 ]
-            Detective: [ 1, 1 ]
-            #SecBorg: [1,1] #Far Horizons
-            # service
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 1, 1 ]
-            Botanist: [ 1, 1 ]
-            Chaplain: [ 1, 1 ]
-            Chef: [ 1, 1 ]
-            Clown: [ 1, 1 ]
-            Janitor: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            Reporter: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            Assistant: [ -1, -1 ]
-            # silicon
-            Borg: [ 1, 1 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightCork
+#   mapName: 'Cork Outpost'
+#   mapPath: /Maps/_Starlight/Stations/Cork.yml
+#   maxRandomOffset: 0
+#   randomRotation: false
+#   minPlayers: 0
+#   maxPlayers: 15
+#   stations:
+#     StarlightCork:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Cork {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'VRS'
+#         - type: StationJobs
+#           availableJobs:
+#             # command
+#             Captain: [ 1, 1 ]
+#             Magistrate: [ 1, 1 ]
+#             # cargo
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 3, 3 ]
+#             MailTech: [ 1, 1 ]
+#             SalvageLead: [ 1, 1 ]
+#             # engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             StationEngineer: [ 2, 2 ]
+#             AtmosphericTechnician: [ 1, 1 ]
+#             TechnicalAssistant: [ 2, 2 ]
+#             # medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             MedicalDoctor: [ 2, 2 ]
+#             MedicalIntern: [ 2, 2 ]
+#             Psychologist: [ 1, 1 ]
+#             Paramedic: [ 1, 1 ]
+#             Chemist: [ 1, 1 ]
+#             # science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 2, 2 ]
+#             ResearchAssistant: [ 2, 2 ]
+#             # security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 2, 2 ]
+#             SecurityCadet: [ 2, 2 ]
+#             Detective: [ 1, 1 ]
+#             #SecBorg: [1,1] #Far Horizons
+#             # service
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 1, 1 ]
+#             Botanist: [ 1, 1 ]
+#             Chaplain: [ 1, 1 ]
+#             Chef: [ 1, 1 ]
+#             Clown: [ 1, 1 ]
+#             Janitor: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             Reporter: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             Assistant: [ -1, -1 ]
+#             # silicon
+#             Borg: [ 1, 1 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/crescent.yml
+++ b/Resources/Prototypes/_StarLight/Maps/crescent.yml
@@ -1,76 +1,77 @@
-- type: gameMap
-  id: StarlightCrescent
-  mapName: 'Crescent'
-  mapPath: /Maps/_Starlight/Stations/Crescent.yml
-  minPlayers: 40
-  maxPlayers: 95
-  stations:
-    StarlightCrescent:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Crescent {1}' 
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'R4'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_raven.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ] 
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 3, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 3, 3 ]
-            Chaplain: [ 1, 1 ]
-            Reporter: [ 3, 3 ]
-            Librarian: [ 1, 1 ]
-            #ServiceWorker: [ 3, 3 ] #MISSING! FIX!
-            #engineering
-            ChiefEngineer: [ 1, 1 ] 
-            #AtmosphericTechnician: [ 3, 3 ] #MISSING! FIX!
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 4, 4 ] 
-            #medicalw
-            ChiefMedicalOfficer: [ 1, 1 ] 
-            Chemist: [ 1, 1 ] 
-            MedicalDoctor: [ 4, 4 ] 
-            MedicalIntern: [ 4, 4 ] 
-            Psychologist: [ 1, 1 ] 
-            Paramedic: [ 1, 1 ] 
-            #Surgeon: [ 1, 1 ] #MISSING! FIX!
-            #science
-            ResearchDirector: [ 1, 1 ] 
-            #Scientist: [ 5, 5 ] #MISSING! FIX!
-            #ResearchAssistant: [ 3, 3 ] #MISSING! FIX!
-            Roboticist: [ 2, 2 ] 
-            #security
-            HeadOfSecurity: [ 1, 1 ] 
-            Warden: [ 1, 1 ] 
-            SecurityOfficer: [ 6, 6 ] 
-            Detective: [ 1, 1 ] 
-            SecurityCadet: [ 6, 6 ] 
-            Brigmedic: [ 1, 1 ] 
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ] 
-            SalvageSpecialist: [ 4, 4 ] 
-            CargoTechnician: [ 5, 5 ]
-            #MailTech: [ 1, 2 ] #MISSING! FIX!
-            #civilian
-            #Assistant: [ -1, -1 ] #MISSING! FIX!
-            Clown: [ 1, 1 ] 
-            Mime: [ 1, 1 ] 
-            Musician: [ 1, 1 ] 
-            Boxer: [ 2, 2] 
-            #silicon
-            StationAi: [ 1, 1 ] 
-            Borg: [ 3, 3 ] 
-            #law
-            Magistrate: [ 1, 1 ] 
-            IAA: [ 1, 1 ] 
-            #Representives
-            BlueShield: [ 1, 1 ] 
-            NanoTrasenRepresentative: [ 1, 1 ] 
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightCrescent
+#   mapName: 'Crescent'
+#   mapPath: /Maps/_Starlight/Stations/Crescent.yml
+#   minPlayers: 40
+#   maxPlayers: 95
+#   stations:
+#     StarlightCrescent:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Crescent {1}' 
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'R4'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_raven.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ] 
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 3, 3 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 3, 3 ]
+#             Chaplain: [ 1, 1 ]
+#             Reporter: [ 3, 3 ]
+#             Librarian: [ 1, 1 ]
+#             #ServiceWorker: [ 3, 3 ] #MISSING! FIX!
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ] 
+#             #AtmosphericTechnician: [ 3, 3 ] #MISSING! FIX!
+#             StationEngineer: [ 4, 4 ]
+#             TechnicalAssistant: [ 4, 4 ] 
+#             #medicalw
+#             ChiefMedicalOfficer: [ 1, 1 ] 
+#             Chemist: [ 1, 1 ] 
+#             MedicalDoctor: [ 4, 4 ] 
+#             MedicalIntern: [ 4, 4 ] 
+#             Psychologist: [ 1, 1 ] 
+#             Paramedic: [ 1, 1 ] 
+#             #Surgeon: [ 1, 1 ] #MISSING! FIX!
+#             #science
+#             ResearchDirector: [ 1, 1 ] 
+#             #Scientist: [ 5, 5 ] #MISSING! FIX!
+#             #ResearchAssistant: [ 3, 3 ] #MISSING! FIX!
+#             Roboticist: [ 2, 2 ] 
+#             #security
+#             HeadOfSecurity: [ 1, 1 ] 
+#             Warden: [ 1, 1 ] 
+#             SecurityOfficer: [ 6, 6 ] 
+#             Detective: [ 1, 1 ] 
+#             SecurityCadet: [ 6, 6 ] 
+#             Brigmedic: [ 1, 1 ] 
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ] 
+#             SalvageSpecialist: [ 4, 4 ] 
+#             CargoTechnician: [ 5, 5 ]
+#             #MailTech: [ 1, 2 ] #MISSING! FIX!
+#             #civilian
+#             #Assistant: [ -1, -1 ] #MISSING! FIX!
+#             Clown: [ 1, 1 ] 
+#             Mime: [ 1, 1 ] 
+#             Musician: [ 1, 1 ] 
+#             Boxer: [ 2, 2] 
+#             #silicon
+#             StationAi: [ 1, 1 ] 
+#             Borg: [ 3, 3 ] 
+#             #law
+#             Magistrate: [ 1, 1 ] 
+#             IAA: [ 1, 1 ] 
+#             #Representives
+#             BlueShield: [ 1, 1 ] 
+#             NanoTrasenRepresentative: [ 1, 1 ] 

--- a/Resources/Prototypes/_StarLight/Maps/elkridge.yml
+++ b/Resources/Prototypes/_StarLight/Maps/elkridge.yml
@@ -1,80 +1,81 @@
-- type: gameMap
-  id: StarlightElkridge
-  mapName: 'Elkridge Depot'
-  mapPath: /Maps/_Starlight/Stations/Elkridge.yml
-  minPlayers: 15
-  maxPlayers: 75
-  stations:
-    StarlightElkridge:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Elkridge Depot {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'DS'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_elkridge.yml
-        - type: StationCargoShuttle
-          path: /Maps/Shuttles/cargo_elkridge.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 1, 2 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            Reporter: [ 1, 2 ]
-            ServiceWorker: [ 2, 3 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 2, 3 ]
-            StationEngineer: [ 4, 5 ]
-            TechnicalAssistant: [ 2, 2 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 5 ]
-            MedicalIntern: [ 2, 2 ]
-            Paramedic: [ 2, 2 ]
-            Surgeon: [ 1, 1 ]
-            Psychologist: [ 1, 1 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 3, 4 ]
-            ResearchAssistant: [ 2, 2 ]
-            Roboticist: [ 2, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 5, 6 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 3, 4 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
-            MiningSpecialist: [ 2, 3 ]
-            CargoTechnician: [ 2, 3 ]
-            MailTech: [ 1, 2 ]
-            SalvageLead: [ 1, 1 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 3 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightElkridge
+#   mapName: 'Elkridge Depot'
+#   mapPath: /Maps/_Starlight/Stations/Elkridge.yml
+#   minPlayers: 15
+#   maxPlayers: 75
+#   stations:
+#     StarlightElkridge:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Elkridge Depot {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'DS'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_elkridge.yml
+#         - type: StationCargoShuttle
+#           path: /Maps/Shuttles/cargo_elkridge.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 1, 2 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 2, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             Reporter: [ 1, 2 ]
+#             ServiceWorker: [ 2, 3 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 2, 3 ]
+#             StationEngineer: [ 4, 5 ]
+#             TechnicalAssistant: [ 2, 2 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 4, 5 ]
+#             MedicalIntern: [ 2, 2 ]
+#             Paramedic: [ 2, 2 ]
+#             Surgeon: [ 1, 1 ]
+#             Psychologist: [ 1, 1 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 3, 4 ]
+#             ResearchAssistant: [ 2, 2 ]
+#             Roboticist: [ 2, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 5, 6 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 3, 4 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 3 ]
+#             MiningSpecialist: [ 2, 3 ]
+#             CargoTechnician: [ 2, 3 ]
+#             MailTech: [ 1, 2 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 3 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/exo.yml
+++ b/Resources/Prototypes/_StarLight/Maps/exo.yml
@@ -1,79 +1,80 @@
-- type: gameMap
-  id: StarlightExo
-  mapName: 'Exo'
-  mapPath: /Maps/_Starlight/Stations/Exo.yml
-  minPlayers: 40
-  maxPlayers: 130
-  stations:
-    StarlightExo:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: 'Exomorph Vessel "Conquest" EXO-{1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_exo.yml
-        - type: StationCargoShuttle
-          path: /Maps/Shuttles/cargo_exo.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 3, 3 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
-            MedicalIntern: [ 3, 3 ]
-            Paramedic: [ 1, 1 ]
-            Surgeon: [ 1 , 1 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 3, 3 ]
-            Roboticist: [ 2, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 6, 8 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 6 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 4, 4 ]
-            MiningSpecialist: [ 2, 2 ]
-            MailTech: [ 1, 1 ]
-            SalvageLead: [ 1, 1 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            Reporter: [ 2, 2 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]      
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightExo
+#   mapName: 'Exo'
+#   mapPath: /Maps/_Starlight/Stations/Exo.yml
+#   minPlayers: 40
+#   maxPlayers: 130
+#   stations:
+#     StarlightExo:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: 'Exomorph Vessel "Conquest" EXO-{1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_exo.yml
+#         - type: StationCargoShuttle
+#           path: /Maps/Shuttles/cargo_exo.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 2, 2 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 2, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 4, 4 ]
+#             TechnicalAssistant: [ 3, 3 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 4, 4 ]
+#             MedicalIntern: [ 3, 3 ]
+#             Paramedic: [ 1, 1 ]
+#             Surgeon: [ 1 , 1 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 4, 4 ]
+#             ResearchAssistant: [ 3, 3 ]
+#             Roboticist: [ 2, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 6, 8 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 6 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 4, 4 ]
+#             MiningSpecialist: [ 2, 2 ]
+#             MailTech: [ 1, 1 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             Reporter: [ 2, 2 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 2 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]      
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/fland.yml
+++ b/Resources/Prototypes/_StarLight/Maps/fland.yml
@@ -1,76 +1,77 @@
-- type: gameMap
-  id: StarlightFland
-  mapName: 'Fland Installation'
-  mapPath: /Maps/_Starlight/Stations/Fland.yml
-  minPlayers: 65
-  stations:
-    StarlightFland:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Fland Installation {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'B'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_delta.yml
-        - type: StationCargoShuttle
-          path: /Maps/Shuttles/cargo_fland.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 3, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 3, 3 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 3 ]
-            Reporter: [ 1, 2 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 4, 4 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 3, 3 ]
-            MedicalDoctor: [ 6, 6 ]
-            Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 4, 4 ]
-            Surgeon: [ 2, 2 ]  
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 6, 6 ]
-            Roboticist: [ 1, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 9, 9 ]
-            Detective: [ 2, 2 ]
-            SecurityCadet: [ 4, 4 ]
-            Brigmedic: [ 1, 1 ]
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 5, 5 ]
-            CargoTechnician: [ 4, 4 ]
-            MailTech: [ 1, 2 ]
-            MiningSpecialist: [ 3, 3 ]
-            SalvageLead: [ 1, 1 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 2 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 3, 4 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightFland
+#   mapName: 'Fland Installation'
+#   mapPath: /Maps/_Starlight/Stations/Fland.yml
+#   minPlayers: 65
+#   stations:
+#     StarlightFland:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Fland Installation {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'B'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_delta.yml
+#         - type: StationCargoShuttle
+#           path: /Maps/Shuttles/cargo_fland.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 3, 3 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 3, 3 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 3 ]
+#             Reporter: [ 1, 2 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 5, 5 ]
+#             TechnicalAssistant: [ 4, 4 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 3, 3 ]
+#             MedicalDoctor: [ 6, 6 ]
+#             Paramedic: [ 2, 2 ]
+#             MedicalIntern: [ 4, 4 ]
+#             Surgeon: [ 2, 2 ]  
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 5, 5 ]
+#             ResearchAssistant: [ 6, 6 ]
+#             Roboticist: [ 1, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 9, 9 ]
+#             Detective: [ 2, 2 ]
+#             SecurityCadet: [ 4, 4 ]
+#             Brigmedic: [ 1, 1 ]
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 5, 5 ]
+#             CargoTechnician: [ 4, 4 ]
+#             MailTech: [ 1, 2 ]
+#             MiningSpecialist: [ 3, 3 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 2 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 3, 4 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/gateway.yml
+++ b/Resources/Prototypes/_StarLight/Maps/gateway.yml
@@ -1,28 +1,29 @@
-﻿- type: gameMap
-  id: Gateway
-  mapName: 'Gateway'
-  mapPath: /Maps/_Starlight/Stations/Gateway.yml
-  minPlayers: 1
-  stations:
-    Gateway:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Gate Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'ST'
-        - type: StationJobs
-          availableJobs:
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 20 ]
-            MiningSpecialist: [ 3, 10 ]
-            CargoTechnician: [ 5, 20 ]
-            MailTech: [ 1, 20 ]
-            #civilian
-            #Assistant: [-1, -1]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            #silicon
-            #Borg: [ 3, 10 ]
+﻿# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: Gateway
+#   mapName: 'Gateway'
+#   mapPath: /Maps/_Starlight/Stations/Gateway.yml
+#   minPlayers: 1
+#   stations:
+#     Gateway:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Gate Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'ST'
+#         - type: StationJobs
+#           availableJobs:
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 20 ]
+#             MiningSpecialist: [ 3, 10 ]
+#             CargoTechnician: [ 5, 20 ]
+#             MailTech: [ 1, 20 ]
+#             #civilian
+#             #Assistant: [-1, -1]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             #silicon
+#             #Borg: [ 3, 10 ]

--- a/Resources/Prototypes/_StarLight/Maps/hotel.yml
+++ b/Resources/Prototypes/_StarLight/Maps/hotel.yml
@@ -1,76 +1,77 @@
-- type: gameMap
-  id: StarlightHotel
-  mapName: 'Hotel'
-  mapPath: /Maps/_Starlight/Stations/Hotel.yml
-  minPlayers: 7
-  maxPlayers: 55
-  stations:
-    StarlightHotel:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Hotel {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_hotel.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            ServiceWorker: [ 2, 4 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 4, 6 ]
-            TechnicalAssistant: [ 3, 5 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 6 ]
-            MedicalIntern: [ 3, 6 ]
-            Paramedic: [ 2, 2 ]
-            Surgeon: [ 2, 2 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 3, 6 ]
-            ResearchAssistant: [ 3, 5 ]
-            Roboticist: [ 2, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 7 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 5 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 6, 6 ]
-            CargoTechnician: [ 6, 8 ]
-            MailTech: [ 1, 2 ]
-            MiningSpecialist: [ 2, 2 ]
-            SalvageLead: [ 1, 1 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 2, 2 ]
-            Reporter: [ 1, 2 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 3, 6 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 1, 1 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightHotel
+#   mapName: 'Hotel'
+#   mapPath: /Maps/_Starlight/Stations/Hotel.yml
+#   minPlayers: 7
+#   maxPlayers: 55
+#   stations:
+#     StarlightHotel:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Hotel {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_hotel.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 2, 2 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 2, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             ServiceWorker: [ 2, 4 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 2, 2 ]
+#             StationEngineer: [ 4, 6 ]
+#             TechnicalAssistant: [ 3, 5 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 4, 6 ]
+#             MedicalIntern: [ 3, 6 ]
+#             Paramedic: [ 2, 2 ]
+#             Surgeon: [ 2, 2 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 3, 6 ]
+#             ResearchAssistant: [ 3, 5 ]
+#             Roboticist: [ 2, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 4, 7 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 5 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 6, 6 ]
+#             CargoTechnician: [ 6, 8 ]
+#             MailTech: [ 1, 2 ]
+#             MiningSpecialist: [ 2, 2 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 2, 2 ]
+#             Reporter: [ 1, 2 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 3, 6 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 1, 1 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/kiloton.yml
+++ b/Resources/Prototypes/_StarLight/Maps/kiloton.yml
@@ -1,79 +1,80 @@
-- type: gameMap
-  id: StarlightKiloton
-  mapName: 'Kiloton Station'
-  mapPath: /Maps/_Starlight/Stations/Kiloton.yml
-  minPlayers: 50
-  maxPlayers: 200
-  stations:
-    StarlightKiloton:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Kiloton Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'ST'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_plasma.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 3 ]
-            Botanist: [ 2, 3 ]
-            Chef: [ 2, 3 ]
-            Janitor: [ 2, 3 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 2 ]
-            ServiceWorker: [ 4, 5 ]
-            Reporter: [ 2, 2 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 3, 4 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 6 ]
-            Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 3, 3 ]
-            Psychologist: [ 1, 1 ]
-            Surgeon: [ 2, 2 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 3, 4 ]
-            Roboticist: [ 2, 3 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 9, 12 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
-            Brigmedic: [1,1] #Far Horizons
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 4 ]
-            MiningSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 5, 6 ]
-            MailTech: [ 1, 2 ]
-            SalvageLead: [ 1, 1 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 2, 3 ]
-            Boxer: [ 2, 3 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 3, 5 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 1, 2 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightKiloton
+#   mapName: 'Kiloton Station'
+#   mapPath: /Maps/_Starlight/Stations/Kiloton.yml
+#   minPlayers: 50
+#   maxPlayers: 200
+#   stations:
+#     StarlightKiloton:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Kiloton Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'ST'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_plasma.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 3 ]
+#             Botanist: [ 2, 3 ]
+#             Chef: [ 2, 3 ]
+#             Janitor: [ 2, 3 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 2 ]
+#             ServiceWorker: [ 4, 5 ]
+#             Reporter: [ 2, 2 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 5, 5 ]
+#             TechnicalAssistant: [ 3, 4 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 4, 6 ]
+#             Paramedic: [ 2, 2 ]
+#             MedicalIntern: [ 3, 3 ]
+#             Psychologist: [ 1, 1 ]
+#             Surgeon: [ 2, 2 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 5, 5 ]
+#             ResearchAssistant: [ 3, 4 ]
+#             Roboticist: [ 2, 3 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 9, 12 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 4 ]
+#             Brigmedic: [1,1] #Far Horizons
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 4 ]
+#             MiningSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 5, 6 ]
+#             MailTech: [ 1, 2 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 2, 3 ]
+#             Boxer: [ 2, 3 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 3, 5 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 1, 2 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/lagan.yml
+++ b/Resources/Prototypes/_StarLight/Maps/lagan.yml
@@ -1,77 +1,78 @@
-- type: gameMap
-  id: StarlightLagan
-  mapName: 'Lagan'
-  mapPath: /Maps/_Starlight/Stations/Lagan.yml
-  minPlayers: 50
-  stations:
-    StarlightLagan:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Lagan {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_raven.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 3, 3 ]
-            Botanist: [ 3, 3 ]
-            Chef: [ 2, 3 ]
-            Janitor: [ 2, 3 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 7, 7 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 6, 6 ]
-            TechnicalAssistant: [ 2, 3 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 3 ]
-            Paramedic: [ 2, 2 ]
-            MedicalDoctor: [ 7, 8 ]
-            MedicalIntern: [ 3, 4 ]
-            Surgeon: [ 2, 2 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 6, 7 ]
-            ResearchAssistant: [ 4, 4 ]
-            Roboticist: [ 2, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            Detective: [ 1, 1 ]
-            SecurityOfficer: [ 10, 14 ]
-            SecurityCadet: [ 4, 6 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 6, 6 ]
-            CargoTechnician: [ 5, 7 ]
-            MiningSpecialist: [ 3, 3]
-            MailTech: [ 2, 2 ]
-            SalvageLead: [ 1, 1 ]
-            #civillian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 2, 2 ]
-            Reporter: [ 2, 2 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 4 ]  
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]      
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightLagan
+#   mapName: 'Lagan'
+#   mapPath: /Maps/_Starlight/Stations/Lagan.yml
+#   minPlayers: 50
+#   stations:
+#     StarlightLagan:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Lagan {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_raven.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 3, 3 ]
+#             Botanist: [ 3, 3 ]
+#             Chef: [ 2, 3 ]
+#             Janitor: [ 2, 3 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 7, 7 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 6, 6 ]
+#             TechnicalAssistant: [ 2, 3 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 3 ]
+#             Paramedic: [ 2, 2 ]
+#             MedicalDoctor: [ 7, 8 ]
+#             MedicalIntern: [ 3, 4 ]
+#             Surgeon: [ 2, 2 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 6, 7 ]
+#             ResearchAssistant: [ 4, 4 ]
+#             Roboticist: [ 2, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             Detective: [ 1, 1 ]
+#             SecurityOfficer: [ 10, 14 ]
+#             SecurityCadet: [ 4, 6 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 6, 6 ]
+#             CargoTechnician: [ 5, 7 ]
+#             MiningSpecialist: [ 3, 3]
+#             MailTech: [ 2, 2 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civillian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 2, 2 ]
+#             Reporter: [ 2, 2 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 4 ]  
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]      
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]
 

--- a/Resources/Prototypes/_StarLight/Maps/leth.yml
+++ b/Resources/Prototypes/_StarLight/Maps/leth.yml
@@ -1,76 +1,77 @@
-- type: gameMap
-  id: StarlightLeth
-  mapName: 'Leth Vessel'
-  mapPath: /Maps/_Starlight/Stations/Leth.yml
-  minPlayers: 15
-  maxPlayers: 65
-  stations:
-    StarlightLeth:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: 'Leth Vessel {0}-{1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'LV'
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 1, 2 ]
-            Botanist: [ 1, 2 ]
-            Chef: [ 1, 2 ]
-            Janitor: [ 1, 1 ]
-            Chaplain: [ 1, 1 ]
-            ServiceWorker: [ 1, 1 ]
-            Reporter: [ 1, 1 ]
-            #Boxer: [ 1, 2 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 1, 2 ]
-            StationEngineer: [ 2, 4 ]
-            TechnicalAssistant: [ 0, 6 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 1, 2 ]
-            MedicalDoctor: [ 3, 6 ]
-            MedicalIntern: [ 0, 3 ]
-            Paramedic: [ 1, 2 ]
-            Surgeon: [ 1, 1 ]
-            #Psychologist: [ 1, 1 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 2, 6 ]
-            ResearchAssistant: [ 0, 3 ]
-            Roboticist: [ 1, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 8 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 0, 4 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 6 ]
-            CargoTechnician: [ 3, 6 ]
-            MailTech: [ 1, 2 ]
-            MiningSpecialist: [ 1, 3 ]
-            SalvageLead: [ 1, 1 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 3, 6 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 1, 2 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightLeth
+#   mapName: 'Leth Vessel'
+#   mapPath: /Maps/_Starlight/Stations/Leth.yml
+#   minPlayers: 15
+#   maxPlayers: 65
+#   stations:
+#     StarlightLeth:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: 'Leth Vessel {0}-{1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'LV'
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 1, 2 ]
+#             Botanist: [ 1, 2 ]
+#             Chef: [ 1, 2 ]
+#             Janitor: [ 1, 1 ]
+#             Chaplain: [ 1, 1 ]
+#             ServiceWorker: [ 1, 1 ]
+#             Reporter: [ 1, 1 ]
+#             #Boxer: [ 1, 2 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 1, 2 ]
+#             StationEngineer: [ 2, 4 ]
+#             TechnicalAssistant: [ 0, 6 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 1, 2 ]
+#             MedicalDoctor: [ 3, 6 ]
+#             MedicalIntern: [ 0, 3 ]
+#             Paramedic: [ 1, 2 ]
+#             Surgeon: [ 1, 1 ]
+#             #Psychologist: [ 1, 1 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 2, 6 ]
+#             ResearchAssistant: [ 0, 3 ]
+#             Roboticist: [ 1, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 4, 8 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 0, 4 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 6 ]
+#             CargoTechnician: [ 3, 6 ]
+#             MailTech: [ 1, 2 ]
+#             MiningSpecialist: [ 1, 3 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 3, 6 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 1, 2 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/lobster.yml
+++ b/Resources/Prototypes/_StarLight/Maps/lobster.yml
@@ -1,77 +1,78 @@
-- type: gameMap
-  id: StarlightLobster
-  mapName: 'Lobster Station'
-  mapPath: /Maps/_Starlight/Stations/Lobster.yml
-  minPlayers: 40
-  maxPlayers: 150
-  stations:
-    StarlightLobster:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Lobster Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'LS'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_hotel.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 3 ]
-            Botanist: [ 2, 2 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            ServiceWorker: [ 4, 5 ]
-            Boxer: [ 2, 2 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 6, 7 ]
-            TechnicalAssistant: [ 3, 5 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 3 ]
-            MedicalDoctor: [ 7, 12 ]
-            MedicalIntern: [ 6, 8 ]
-            Psychologist: [ 1, 1 ]
-            Paramedic: [ 2, 2 ]
-            Surgeon: [ 2, 2 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 10 ]
-            ResearchAssistant: [ 4, 5 ]
-            Roboticist: [ 2, 3 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 8, 14 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 5 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 6, 6 ]
-            CargoTechnician: [ 6, 8 ]
-            MailTech: [ 2, 2 ]
-            MiningSpecialist: [ 3, 3 ]
-            SalvageLead: [ 1, 1 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 2, 2 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 3, 6 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightLobster
+#   mapName: 'Lobster Station'
+#   mapPath: /Maps/_Starlight/Stations/Lobster.yml
+#   minPlayers: 40
+#   maxPlayers: 150
+#   stations:
+#     StarlightLobster:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Lobster Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'LS'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_hotel.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 3 ]
+#             Botanist: [ 2, 2 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 2, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             ServiceWorker: [ 4, 5 ]
+#             Boxer: [ 2, 2 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 2, 2 ]
+#             StationEngineer: [ 6, 7 ]
+#             TechnicalAssistant: [ 3, 5 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 3 ]
+#             MedicalDoctor: [ 7, 12 ]
+#             MedicalIntern: [ 6, 8 ]
+#             Psychologist: [ 1, 1 ]
+#             Paramedic: [ 2, 2 ]
+#             Surgeon: [ 2, 2 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 4, 10 ]
+#             ResearchAssistant: [ 4, 5 ]
+#             Roboticist: [ 2, 3 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 8, 14 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 5 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 6, 6 ]
+#             CargoTechnician: [ 6, 8 ]
+#             MailTech: [ 2, 2 ]
+#             MiningSpecialist: [ 3, 3 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 2, 2 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 3, 6 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/manor.yml
+++ b/Resources/Prototypes/_StarLight/Maps/manor.yml
@@ -1,78 +1,79 @@
-- type: gameMap
-  id: StarlightManor
-  mapName: 'Manor Station'
-  mapPath: /Maps/_Starlight/Stations/Manor.yml
-  minPlayers: 50
-  maxPlayers: 180
-  stations:
-    StarlightManor:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Manor Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'ST'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_manor.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 2, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 3 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 4, 4 ]
-            Zookeeper: [ 1, 1 ]
-            Reporter: [ 2, 2 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 4, 4 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 5 ]
-            Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 3, 3 ]
-            Psychologist: [ 1, 1 ]
-            Surgeon: [ 2, 2 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 3, 4 ]
-            Roboticist: [ 2, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 2, 2 ]
-            SecurityOfficer: [ 10, 13 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
-            Brigmedic: [1,1] #Far Horizons
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 4 ]
-            MiningSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 5, 7 ]
-            SalvageLead: [ 1, 1 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 2, 2 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 3, 5 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 1, 2 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightManor
+#   mapName: 'Manor Station'
+#   mapPath: /Maps/_Starlight/Stations/Manor.yml
+#   minPlayers: 50
+#   maxPlayers: 180
+#   stations:
+#     StarlightManor:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Manor Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'ST'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_manor.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 2, 3 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 2, 3 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 4, 4 ]
+#             Zookeeper: [ 1, 1 ]
+#             Reporter: [ 2, 2 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 5, 5 ]
+#             TechnicalAssistant: [ 4, 4 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 4, 5 ]
+#             Paramedic: [ 2, 2 ]
+#             MedicalIntern: [ 3, 3 ]
+#             Psychologist: [ 1, 1 ]
+#             Surgeon: [ 2, 2 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 5, 5 ]
+#             ResearchAssistant: [ 3, 4 ]
+#             Roboticist: [ 2, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 2, 2 ]
+#             SecurityOfficer: [ 10, 13 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 4 ]
+#             Brigmedic: [1,1] #Far Horizons
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 4 ]
+#             MiningSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 5, 7 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 2, 2 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 3, 5 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 1, 2 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/marathon.yml
+++ b/Resources/Prototypes/_StarLight/Maps/marathon.yml
@@ -1,76 +1,77 @@
-- type: gameMap
-  id: StarlightMarathon
-  mapName: 'Marathon Station'
-  mapPath: /Maps/_Starlight/Stations/Marathon.yml
-  minPlayers: 35
-  maxPlayers: 70
-  stations:
-    StarlightMarathon:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Marathon Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_rod.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 2, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 1, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 3, 3 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
-            MedicalIntern: [ 3, 3 ]
-            Psychologist: [ 1, 1 ]
-            Paramedic: [ 1, 1 ]
-            Surgeon: [ 2, 2 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 3, 3 ]
-            Roboticist: [ 1, 1 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 6, 6 ]
-            CargoTechnician: [ 3, 3 ]
-            MailTech: [ 1, 2 ]
-            MiningSpecialist: [ 3, 3 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightMarathon
+#   mapName: 'Marathon Station'
+#   mapPath: /Maps/_Starlight/Stations/Marathon.yml
+#   minPlayers: 35
+#   maxPlayers: 70
+#   stations:
+#     StarlightMarathon:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Marathon Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_rod.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 2, 3 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 1, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 4, 4 ]
+#             TechnicalAssistant: [ 3, 3 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 4, 4 ]
+#             MedicalIntern: [ 3, 3 ]
+#             Psychologist: [ 1, 1 ]
+#             Paramedic: [ 1, 1 ]
+#             Surgeon: [ 2, 2 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 4, 4 ]
+#             ResearchAssistant: [ 3, 3 ]
+#             Roboticist: [ 1, 1 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 4, 4 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 4 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 6, 6 ]
+#             CargoTechnician: [ 3, 3 ]
+#             MailTech: [ 1, 2 ]
+#             MiningSpecialist: [ 3, 3 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 2 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/ming.yml
+++ b/Resources/Prototypes/_StarLight/Maps/ming.yml
@@ -1,75 +1,76 @@
-- type: gameMap
-  id: StarlightMing
-  mapName: 'Ming "Complex" Station'
-  mapPath: /Maps/_Starlight/Stations/Ming.yml
-  minPlayers: 55
-  stations:
-    StarlightMing:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Ming "Complex" Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'MW'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_ming.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 3 ]
-            Botanist: [ 3, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 3 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 3, 4 ]
-            Zookeeper: [ 1, 1 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 6 ]
-            TechnicalAssistant: [ 4, 4 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 6, 7 ]
-            Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 4, 4 ]
-            Surgeon: [ 2, 2 ]
-            Psychologist: [ 1, 1 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 3, 4 ]
-            Roboticist: [ 2, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 10, 10 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 5, 6 ]
-            Brigmedic: [ 1, 1 ]
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
-            MiningSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 6, 7 ]
-            SalvageLead: [ 1, 1 ]
-            MailTech: [ 2, 2 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 2, 2 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 3, 5 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightMing
+#   mapName: 'Ming "Complex" Station'
+#   mapPath: /Maps/_Starlight/Stations/Ming.yml
+#   minPlayers: 55
+#   stations:
+#     StarlightMing:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Ming "Complex" Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'MW'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_ming.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 3 ]
+#             Botanist: [ 3, 3 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 2, 3 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 3, 4 ]
+#             Zookeeper: [ 1, 1 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 5, 6 ]
+#             TechnicalAssistant: [ 4, 4 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 6, 7 ]
+#             Paramedic: [ 2, 2 ]
+#             MedicalIntern: [ 4, 4 ]
+#             Surgeon: [ 2, 2 ]
+#             Psychologist: [ 1, 1 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 5, 5 ]
+#             ResearchAssistant: [ 3, 4 ]
+#             Roboticist: [ 2, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 10, 10 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 5, 6 ]
+#             Brigmedic: [ 1, 1 ]
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 3 ]
+#             MiningSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 6, 7 ]
+#             SalvageLead: [ 1, 1 ]
+#             MailTech: [ 2, 2 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 2, 2 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 3, 5 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/oasis.yml
+++ b/Resources/Prototypes/_StarLight/Maps/oasis.yml
@@ -1,78 +1,79 @@
-- type: gameMap
-  id: StarlightOasis
-  mapName: 'Oasis'
-  mapPath: /Maps/_Starlight/Stations/Oasis.yml
-  minPlayers: 65
-  stations:
-    StarlightOasis:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Oasis {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'B'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_accordia.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 2, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 3, 3 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 3, 3 ]
-            Zookeeper: [ 1, 1 ]
-            Reporter: [ 1, 2 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 6, 6 ]
-            TechnicalAssistant: [ 4, 4 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 6, 6 ]
-            Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 4, 4 ]
-            Psychologist: [ 1, 1 ]
-            Surgeon: [ 2, 2 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 6, 6 ]
-            ResearchAssistant: [ 5, 5 ]
-            Roboticist: [ 2, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 9, 10 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 5, 5 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 4 ]
-            MiningSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 4, 4 ]
-            MailTech: [ 1, 2 ]
-            SalvageLead: [ 1, 1 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 2 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 3, 4 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightOasis
+#   mapName: 'Oasis'
+#   mapPath: /Maps/_Starlight/Stations/Oasis.yml
+#   minPlayers: 65
+#   stations:
+#     StarlightOasis:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Oasis {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'B'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_accordia.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 2, 3 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 3, 3 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 3, 3 ]
+#             Zookeeper: [ 1, 1 ]
+#             Reporter: [ 1, 2 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 6, 6 ]
+#             TechnicalAssistant: [ 4, 4 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 6, 6 ]
+#             Paramedic: [ 2, 2 ]
+#             MedicalIntern: [ 4, 4 ]
+#             Psychologist: [ 1, 1 ]
+#             Surgeon: [ 2, 2 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 6, 6 ]
+#             ResearchAssistant: [ 5, 5 ]
+#             Roboticist: [ 2, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 9, 10 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 5, 5 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 4 ]
+#             MiningSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 4, 4 ]
+#             MailTech: [ 1, 2 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 2 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 3, 4 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/omega.yml
+++ b/Resources/Prototypes/_StarLight/Maps/omega.yml
@@ -1,75 +1,76 @@
-- type: gameMap
-  id: StarlightOmega
-  mapName: 'Omega'
-  mapPath: /Maps/_Starlight/Stations/Omega.yml
-  minPlayers: 0
-  maxPlayers: 35
-  stations:
-    StarlightOmega:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Omega Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'TG'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_omega.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 1, 1 ]
-            Botanist: [ 2, 2 ]
-            Chef: [ 1, 1 ]
-            Janitor: [ 1, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 3, 3 ]
-            TechnicalAssistant: [ 2, 2 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 3 ]
-            Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 2, 2 ]
-            Surgeon: [ 1, 1 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 2, 2 ]
-            Roboticist: [ 1, 1 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 2, 2 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 5, 5 ]
-            CargoTechnician: [ 2, 2 ]
-            MailTech: [ 1, 2 ]
-            MiningSpecialist: [ 2, 3 ]
-            SalvageLead: [ 1, 1 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
-            #law
-            IAA: [ 2, 2 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightOmega
+#   mapName: 'Omega'
+#   mapPath: /Maps/_Starlight/Stations/Omega.yml
+#   minPlayers: 0
+#   maxPlayers: 35
+#   stations:
+#     StarlightOmega:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Omega Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'TG'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_omega.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 1, 1 ]
+#             Botanist: [ 2, 2 ]
+#             Chef: [ 1, 1 ]
+#             Janitor: [ 1, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 2, 2 ]
+#             StationEngineer: [ 3, 3 ]
+#             TechnicalAssistant: [ 2, 2 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 3, 3 ]
+#             Paramedic: [ 1, 1 ]
+#             MedicalIntern: [ 2, 2 ]
+#             Surgeon: [ 1, 1 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 4, 4 ]
+#             ResearchAssistant: [ 2, 2 ]
+#             Roboticist: [ 1, 1 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 4, 4 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 2, 2 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 5, 5 ]
+#             CargoTechnician: [ 2, 2 ]
+#             MailTech: [ 1, 2 ]
+#             MiningSpecialist: [ 2, 3 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 2 ]
+#             #law
+#             IAA: [ 2, 2 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/origin.yml
+++ b/Resources/Prototypes/_StarLight/Maps/origin.yml
@@ -1,79 +1,80 @@
-- type: gameMap
-  id: StarlightOrigin
-  mapName: 'Origin'
-  mapPath: /Maps/_Starlight/Stations/Origin.yml
-  minPlayers: 50
-  stations:
-    StarlightOrigin:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Origin {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_courser.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 3, 3 ]
-            Chef: [ 3, 3 ]
-            Janitor: [ 3, 3 ]
-            Chaplain: [ 2, 2 ]
-            Librarian: [ 2, 2 ]
-            ServiceWorker: [ 3, 4 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 6, 6 ]
-            TechnicalAssistant: [ 2, 3 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 3 ]
-            Paramedic: [ 1, 1 ]
-            MedicalDoctor: [ 6, 7 ]
-            Psychologist: [ 1, 1 ]
-            MedicalIntern: [ 1, 2 ]
-            Surgeon: [ 1, 2 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 6, 6 ]
-            ResearchAssistant: [ 4, 4 ]
-            Roboticist: [ 2, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            Detective: [ 1, 1 ]
-            SecurityOfficer: [ 10, 14 ]
-            SecurityCadet: [ 2, 4 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 5, 5 ]
-            MiningSpecialist: [ 2, 2]
-            MailTech: [ 2, 3 ]
-            SalvageLead: [ 1, 1 ]
-            #civillian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 2, 2 ]
-            Boxer: [ 2, 2 ]
-            Reporter: [ 1, 1 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 4 ]  
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]      
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightOrigin
+#   mapName: 'Origin'
+#   mapPath: /Maps/_Starlight/Stations/Origin.yml
+#   minPlayers: 50
+#   stations:
+#     StarlightOrigin:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Origin {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_courser.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 3, 3 ]
+#             Chef: [ 3, 3 ]
+#             Janitor: [ 3, 3 ]
+#             Chaplain: [ 2, 2 ]
+#             Librarian: [ 2, 2 ]
+#             ServiceWorker: [ 3, 4 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 6, 6 ]
+#             TechnicalAssistant: [ 2, 3 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 3 ]
+#             Paramedic: [ 1, 1 ]
+#             MedicalDoctor: [ 6, 7 ]
+#             Psychologist: [ 1, 1 ]
+#             MedicalIntern: [ 1, 2 ]
+#             Surgeon: [ 1, 2 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 6, 6 ]
+#             ResearchAssistant: [ 4, 4 ]
+#             Roboticist: [ 2, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             Detective: [ 1, 1 ]
+#             SecurityOfficer: [ 10, 14 ]
+#             SecurityCadet: [ 2, 4 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 5, 5 ]
+#             MiningSpecialist: [ 2, 2]
+#             MailTech: [ 2, 3 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civillian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 2, 2 ]
+#             Boxer: [ 2, 2 ]
+#             Reporter: [ 1, 1 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 4 ]  
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]      
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]
 

--- a/Resources/Prototypes/_StarLight/Maps/orwell.yml
+++ b/Resources/Prototypes/_StarLight/Maps/orwell.yml
@@ -1,75 +1,76 @@
-- type: gameMap
-  id: StarlightOrwell
-  mapName: 'Orwell "Citadel" Station'
-  mapPath: /Maps/_Starlight/Stations/Orwell.yml
-  minPlayers: 50
-  stations:
-    StarlightOrwell:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Orwell "Citadel" Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'GO'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_delta.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 3 ]
-            Botanist: [ 3, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 3 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 3, 4 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 4, 4 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 5, 6 ]
-            Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 4, 4 ]
-            Surgeon: [ 2, 2 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 3, 4 ]
-            Roboticist: [ 2, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 10, 10 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 6, 6 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 4, 5 ]
-            MiningSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 6, 7 ]
-            SalvageLead: [ 1, 1 ]
-            MailTech: [ 1, 2 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 2, 2 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 3, 5 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 1, 1 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightOrwell
+#   mapName: 'Orwell "Citadel" Station'
+#   mapPath: /Maps/_Starlight/Stations/Orwell.yml
+#   minPlayers: 50
+#   stations:
+#     StarlightOrwell:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Orwell "Citadel" Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'GO'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_delta.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 3 ]
+#             Botanist: [ 3, 3 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 2, 3 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 3, 4 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 5, 5 ]
+#             TechnicalAssistant: [ 4, 4 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 5, 6 ]
+#             Paramedic: [ 2, 2 ]
+#             MedicalIntern: [ 4, 4 ]
+#             Surgeon: [ 2, 2 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 5, 5 ]
+#             ResearchAssistant: [ 3, 4 ]
+#             Roboticist: [ 2, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 10, 10 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 6, 6 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 4, 5 ]
+#             MiningSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 6, 7 ]
+#             SalvageLead: [ 1, 1 ]
+#             MailTech: [ 1, 2 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 2, 2 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 3, 5 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 1, 1 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/packed.yml
+++ b/Resources/Prototypes/_StarLight/Maps/packed.yml
@@ -1,76 +1,77 @@
-- type: gameMap
-  id: StarlightPacked
-  mapName: 'Packed'
-  mapPath: /Maps/_Starlight/Stations/Packed.yml
-  minPlayers: 0
-  maxPlayers: 35
-  stations:
-    StarlightPacked:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Packed {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'VG'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_crimson.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 1, 1 ]
-            Botanist: [ 1, 2 ]
-            Chef: [ 1, 1 ]
-            Janitor: [ 1, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 3, 3 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 3 ]
-            MedicalIntern: [ 2, 2 ]
-            Paramedic: [ 1, 1 ]
-            Surgeon: [ 1, 2 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 2, 2 ]
-            Roboticist: [ 1, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 2, 2 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageLead: [ 1, 1 ]
-            SalvageSpecialist: [ 4, 4 ]
-            CargoTechnician: [ 2, 2 ]
-            MailTech: [ 1, 2 ]
-            MiningSpecialist: [ 2, 3 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightPacked
+#   mapName: 'Packed'
+#   mapPath: /Maps/_Starlight/Stations/Packed.yml
+#   minPlayers: 0
+#   maxPlayers: 35
+#   stations:
+#     StarlightPacked:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Packed {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'VG'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_crimson.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 1, 1 ]
+#             Botanist: [ 1, 2 ]
+#             Chef: [ 1, 1 ]
+#             Janitor: [ 1, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 2, 2 ]
+#             StationEngineer: [ 4, 4 ]
+#             TechnicalAssistant: [ 3, 3 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 3, 3 ]
+#             MedicalIntern: [ 2, 2 ]
+#             Paramedic: [ 1, 1 ]
+#             Surgeon: [ 1, 2 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 4, 4 ]
+#             ResearchAssistant: [ 2, 2 ]
+#             Roboticist: [ 1, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 4, 4 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 2, 2 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageLead: [ 1, 1 ]
+#             SalvageSpecialist: [ 4, 4 ]
+#             CargoTechnician: [ 2, 2 ]
+#             MailTech: [ 1, 2 ]
+#             MiningSpecialist: [ 2, 3 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 2 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/reach.yml
+++ b/Resources/Prototypes/_StarLight/Maps/reach.yml
@@ -1,67 +1,68 @@
-- type: gameMap
-  id: StarlightReach
-  mapName: 'Reach'
-  mapPath: /Maps/_Starlight/Stations/Reach.yml
-  minPlayers: 0
-  maxPlayers: 15
-  stations:
-    StarlightReach:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Reach Transport {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'RT'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 1, 1 ]
-            Botanist: [ 1, 1 ]
-            Chef: [ 1, 1 ]
-            Janitor: [ 1, 1 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 1, 1 ]
-            StationEngineer: [ 1, 2 ]
-            TechnicalAssistant: [ 1, 1 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 1, 1 ]
-            MedicalDoctor: [ 1, 2 ]
-            MedicalIntern: [ 1, 1 ]
-            Paramedic: [ 1, 1 ]
-            Surgeon: [ 1, 1 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 1, 1 ]
-            ResearchAssistant: [ 1, 1 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 2, 3 ]
-            SecurityCadet: [ 1, 1 ]
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 1, 2 ]
-            CargoTechnician: [ 1, 2 ]
-            MailTech: [ 1, 1 ]
-            MiningSpecialist: [ 1, 2 ]
-            SalvageLead: [ 1, 1 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 1, 2 ]
-            #law
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightReach
+#   mapName: 'Reach'
+#   mapPath: /Maps/_Starlight/Stations/Reach.yml
+#   minPlayers: 0
+#   maxPlayers: 15
+#   stations:
+#     StarlightReach:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Reach Transport {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'RT'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 1, 1 ]
+#             Botanist: [ 1, 1 ]
+#             Chef: [ 1, 1 ]
+#             Janitor: [ 1, 1 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 1, 1 ]
+#             StationEngineer: [ 1, 2 ]
+#             TechnicalAssistant: [ 1, 1 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 1, 1 ]
+#             MedicalDoctor: [ 1, 2 ]
+#             MedicalIntern: [ 1, 1 ]
+#             Paramedic: [ 1, 1 ]
+#             Surgeon: [ 1, 1 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 1, 1 ]
+#             ResearchAssistant: [ 1, 1 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 2, 3 ]
+#             SecurityCadet: [ 1, 1 ]
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 1, 2 ]
+#             CargoTechnician: [ 1, 2 ]
+#             MailTech: [ 1, 1 ]
+#             MiningSpecialist: [ 1, 2 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 1, 2 ]
+#             #law
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/remix.yml
+++ b/Resources/Prototypes/_StarLight/Maps/remix.yml
@@ -1,75 +1,76 @@
-- type: gameMap
-  id: StarlightRemix
-  mapName: 'Remix'
-  mapPath: /Maps/_Starlight/Stations/Remix.yml
-  minPlayers: 0
-  maxPlayers: 100
-  stations:
-    StarlightRemix:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Remix {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'VG'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/_Starlight/Shuttles/Reach.yml #a variant of reach with all the job spawns removed, and BecomesStation removes
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 3, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 4, 4 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 4, 4 ] 
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 3, 3 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 5, 5 ]
-            MedicalDoctor: [ 4, 4 ]
-            MedicalIntern: [ 2, 2 ]
-            Paramedic: [ 2, 2 ]
-            Surgeon: [ 2, 2 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 2, 2 ]
-            Roboticist: [ 2, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 2, 2 ]
-            SecurityOfficer: [ 6, 6 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 5, 5 ]
-            MailTech: [ 2, 2 ]
-            MiningSpecialist: [ 3, 3 ]
-            #civilian
-            Assistant: [ 1, 1 ]
-            Clown: [ -1, -1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 6, 6 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]
-            #Representives
-            #BlueShield: [ 1, 1 ]
-            #NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightRemix
+#   mapName: 'Remix'
+#   mapPath: /Maps/_Starlight/Stations/Remix.yml
+#   minPlayers: 0
+#   maxPlayers: 100
+#   stations:
+#     StarlightRemix:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Remix {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'VG'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/_Starlight/Shuttles/Reach.yml #a variant of reach with all the job spawns removed, and BecomesStation removes
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 3, 3 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 4, 4 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 4, 4 ] 
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 5, 5 ]
+#             TechnicalAssistant: [ 3, 3 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 5, 5 ]
+#             MedicalDoctor: [ 4, 4 ]
+#             MedicalIntern: [ 2, 2 ]
+#             Paramedic: [ 2, 2 ]
+#             Surgeon: [ 2, 2 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 4, 4 ]
+#             ResearchAssistant: [ 2, 2 ]
+#             Roboticist: [ 2, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 2, 2 ]
+#             SecurityOfficer: [ 6, 6 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 4, 4 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 5, 5 ]
+#             MailTech: [ 2, 2 ]
+#             MiningSpecialist: [ 3, 3 ]
+#             #civilian
+#             Assistant: [ 1, 1 ]
+#             Clown: [ -1, -1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 6, 6 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]
+#             #Representives
+#             #BlueShield: [ 1, 1 ]
+#             #NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/saltern.yml
+++ b/Resources/Prototypes/_StarLight/Maps/saltern.yml
@@ -1,76 +1,77 @@
-- type: gameMap
-  id: StarlightSaltern
-  mapName: 'Saltern'
-  mapPath: /Maps/_Starlight/Stations/Saltern.yml
-  minPlayers: 0
-  maxPlayers: 50
-  stations:
-    StarlightSaltern:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Saltern {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 1, 1 ]
-            Botanist: [ 1, 2 ]
-            Chef: [ 1, 1 ]
-            Janitor: [ 1, 1 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            Reporter: [ 1, 2 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 4, 4 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 3 ]
-            MedicalIntern: [ 4, 4 ]
-            Paramedic: [ 1, 1 ]
-            Surgeon: [ 1, 2 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 2, 2 ]
-            Roboticist: [ 1, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            Detective: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
-            SecurityCadet: [ 4, 4 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 4 ]
-            MiningSpecialist: [ 2, 3 ]
-            CargoTechnician: [ 2, 3 ]
-            MailTech: [ 1, 2 ]
-            SalvageLead: [ 1, 1 ]
-            #civillian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]    
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 3, 3 ]  
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]      
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightSaltern
+#   mapName: 'Saltern'
+#   mapPath: /Maps/_Starlight/Stations/Saltern.yml
+#   minPlayers: 0
+#   maxPlayers: 50
+#   stations:
+#     StarlightSaltern:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Saltern {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: '14'
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 1, 1 ]
+#             Botanist: [ 1, 2 ]
+#             Chef: [ 1, 1 ]
+#             Janitor: [ 1, 1 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             Reporter: [ 1, 2 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 2, 2 ]
+#             StationEngineer: [ 4, 4 ]
+#             TechnicalAssistant: [ 4, 4 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 3, 3 ]
+#             MedicalIntern: [ 4, 4 ]
+#             Paramedic: [ 1, 1 ]
+#             Surgeon: [ 1, 2 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 4, 4 ]
+#             ResearchAssistant: [ 2, 2 ]
+#             Roboticist: [ 1, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             Detective: [ 1, 1 ]
+#             SecurityOfficer: [ 4, 4 ]
+#             SecurityCadet: [ 4, 4 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 4 ]
+#             MiningSpecialist: [ 2, 3 ]
+#             CargoTechnician: [ 2, 3 ]
+#             MailTech: [ 1, 2 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civillian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]    
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 3, 3 ]  
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]      
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]
 

--- a/Resources/Prototypes/_StarLight/Maps/silica.yml
+++ b/Resources/Prototypes/_StarLight/Maps/silica.yml
@@ -1,81 +1,82 @@
-- type: gameMap
-  id: StarlightSilica
-  mapName: 'Silica Station'
-  mapPath: /Maps/_Starlight/Stations/Silica.yml
-  minPlayers: 20
-  maxPlayers: 80
-  stations:
-    StarlightSilica:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Silica Station {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'CW'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_silica.yml
-        - type: StationCargoShuttle
-          path: /Maps/_Starlight/Shuttles/cargo_silica.yml
-        - type: StationJobs
-          availableJobs:
-            # 92 jobs, 82 not counting training jobs
-            #service (17)
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            Reporter: [ 1, 2 ]
-            ServiceWorker: [ 2, 3 ]
-            #engineering (9)
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 3, 4 ]
-            TechnicalAssistant: [ 2, 2 ]
-            #medical (13)
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
-            MedicalIntern: [ 2, 2 ]
-            Paramedic: [ 2, 2 ]
-            Surgeon: [ 1, 1 ]
-            Psychologist: [ 1, 1 ]
-            #science (9)
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 3, 4 ]
-            ResearchAssistant: [ 2, 2 ]
-            Roboticist: [ 2, 2 ]
-            #security (16)
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 8 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 2, 4 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply (15)
-            Quartermaster: [ 1, 1 ]
-            SalvageLead: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
-            MiningSpecialist: [ 2, 2 ]
-            CargoTechnician: [ 2, 4 ]
-            MailTech: [ 1, 2 ]
-            #civilian (3+)
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon (5)
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 4 ]
-            #law (3)
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]
-            #Representives (2)
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightSilica
+#   mapName: 'Silica Station'
+#   mapPath: /Maps/_Starlight/Stations/Silica.yml
+#   minPlayers: 20
+#   maxPlayers: 80
+#   stations:
+#     StarlightSilica:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Silica Station {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'CW'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_silica.yml
+#         - type: StationCargoShuttle
+#           path: /Maps/_Starlight/Shuttles/cargo_silica.yml
+#         - type: StationJobs
+#           availableJobs:
+#             # 92 jobs, 82 not counting training jobs
+#             #service (17)
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 2, 2 ]
+#             Chef: [ 2, 2 ]
+#             Janitor: [ 2, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             Reporter: [ 1, 2 ]
+#             ServiceWorker: [ 2, 3 ]
+#             #engineering (9)
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 2, 2 ]
+#             StationEngineer: [ 3, 4 ]
+#             TechnicalAssistant: [ 2, 2 ]
+#             #medical (13)
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 4, 4 ]
+#             MedicalIntern: [ 2, 2 ]
+#             Paramedic: [ 2, 2 ]
+#             Surgeon: [ 1, 1 ]
+#             Psychologist: [ 1, 1 ]
+#             #science (9)
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 3, 4 ]
+#             ResearchAssistant: [ 2, 2 ]
+#             Roboticist: [ 2, 2 ]
+#             #security (16)
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 4, 8 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 2, 4 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply (15)
+#             Quartermaster: [ 1, 1 ]
+#             SalvageLead: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 3 ]
+#             MiningSpecialist: [ 2, 2 ]
+#             CargoTechnician: [ 2, 4 ]
+#             MailTech: [ 1, 2 ]
+#             #civilian (3+)
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             #silicon (5)
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 2, 4 ]
+#             #law (3)
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]
+#             #Representives (2)
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/starboard.yml
+++ b/Resources/Prototypes/_StarLight/Maps/starboard.yml
@@ -1,78 +1,79 @@
-- type: gameMap
-  id: StarlightStarboard
-  mapName: 'Starboard'
-  mapPath: /Maps/_Starlight/Stations/Starboard.yml
-  minPlayers: 90
-  stations:
-    StarlightStarboard:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Starboard Depot {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'DS'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_starboard.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 3 ]
-            Botanist: [ 3, 3 ]
-            Chef: [ 3, 3 ]
-            Janitor: [ 2, 3 ]
-            Chaplain: [ 2, 3 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 3, 5 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 2, 3 ]
-            StationEngineer: [ 4, 6 ]
-            TechnicalAssistant: [ 2, 4 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 6 ]
-            MedicalIntern: [ 2, 4 ]
-            Paramedic: [ 2, 2 ]
-            Surgeon: [ 2, 3 ]
-            Psychologist: [ 1, 1 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 7 ]
-            ResearchAssistant: [ 2, 4 ]
-            Roboticist: [ 2, 3 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 2, 2 ]
-            Detective: [ 1, 1 ]
-            SecurityOfficer: [ 6, 10 ]
-            SecurityCadet: [ 4, 6 ]
-            Brigmedic: [ 1, 1 ]
-            #Corpsman: [1,1] #Far Horizons
-            #SecBorg: [1,1] #Far Horizons
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 4 ]
-            CargoTechnician: [ 6, 7 ]
-            MiningSpecialist: [ 1, 2]
-            MailTech: [ 2, 3 ]
-            SalvageLead: [ 1, 1 ]
-            #civillian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 2, 3 ]   
-            Boxer: [ 2, 2 ]
-            Reporter: [ 2, 2 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 4, 4 ]  
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 2, 2 ]      
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightStarboard
+#   mapName: 'Starboard'
+#   mapPath: /Maps/_Starlight/Stations/Starboard.yml
+#   minPlayers: 90
+#   stations:
+#     StarlightStarboard:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Starboard Depot {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'DS'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_starboard.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 3 ]
+#             Botanist: [ 3, 3 ]
+#             Chef: [ 3, 3 ]
+#             Janitor: [ 2, 3 ]
+#             Chaplain: [ 2, 3 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 3, 5 ]
+#             #engineering
+#             ChiefEngineer: [ 1, 1 ]
+#             AtmosphericTechnician: [ 2, 3 ]
+#             StationEngineer: [ 4, 6 ]
+#             TechnicalAssistant: [ 2, 4 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 4, 6 ]
+#             MedicalIntern: [ 2, 4 ]
+#             Paramedic: [ 2, 2 ]
+#             Surgeon: [ 2, 3 ]
+#             Psychologist: [ 1, 1 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 5, 7 ]
+#             ResearchAssistant: [ 2, 4 ]
+#             Roboticist: [ 2, 3 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 2, 2 ]
+#             Detective: [ 1, 1 ]
+#             SecurityOfficer: [ 6, 10 ]
+#             SecurityCadet: [ 4, 6 ]
+#             Brigmedic: [ 1, 1 ]
+#             #Corpsman: [1,1] #Far Horizons
+#             #SecBorg: [1,1] #Far Horizons
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 4 ]
+#             CargoTechnician: [ 6, 7 ]
+#             MiningSpecialist: [ 1, 2]
+#             MailTech: [ 2, 3 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civillian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 2, 3 ]   
+#             Boxer: [ 2, 2 ]
+#             Reporter: [ 2, 2 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 4, 4 ]  
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 2, 2 ]      
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]

--- a/Resources/Prototypes/_StarLight/Maps/stationbuilding.yml
+++ b/Resources/Prototypes/_StarLight/Maps/stationbuilding.yml
@@ -1,77 +1,78 @@
-- type: gameMap
-  id: StarlightStationBuilding
-  mapName: 'Under Construction'
-  mapPath: /Maps/_Starlight/Stations/StationBuilding.yml
-  minPlayers: 20
-  maxPlayers: 100
-  stations:
-    StarlightStationBuilding:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Under Construction {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'WIP'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_plasma.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2 ]
-            Chef: [ 1, 2 ]
-            Janitor: [ 2, 3 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 3 ]
-            Reporter: [ 1, 1 ]
-            #engineering
-            ChiefEngineer: [ 2, 2 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 6, 8 ]
-            TechnicalAssistant: [ 4, 6 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 4 ]
-            Paramedic: [ 1, 2 ]
-            MedicalIntern: [ 2, 3 ]
-            Psychologist: [ 1, 1 ]
-            Surgeon: [ 1, 1 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 3, 4 ]
-            ResearchAssistant: [ 2, 3 ]
-            Roboticist: [ 1, 2 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 6 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 3, 4 ]
-            Brigmedic: [ 1, 1 ]
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 4 ]
-            MiningSpecialist: [ 3, 4 ]
-            CargoTechnician: [ 5, 6 ]
-            MailTech: [ 1, 2 ]
-            SalvageLead: [ 1, 1 ]
-            #civilian
-            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 2 ]
-            Boxer: [ 1, 1 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 6, 8 ]
-            #law
-            Magistrate: [ 1, 1 ]
-            IAA: [ 1, 1 ]
-            #Representives
-            BlueShield: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+# Far Horizons - disable all non FH maps to not mess with admin commands and votes
+# - type: gameMap
+#   id: StarlightStationBuilding
+#   mapName: 'Under Construction'
+#   mapPath: /Maps/_Starlight/Stations/StationBuilding.yml
+#   minPlayers: 20
+#   maxPlayers: 100
+#   stations:
+#     StarlightStationBuilding:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Under Construction {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'WIP'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/Shuttles/emergency_plasma.yml
+#         - type: StationJobs
+#           availableJobs:
+#             #service
+#             Captain: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 2, 2 ]
+#             Chef: [ 1, 2 ]
+#             Janitor: [ 2, 3 ]
+#             Chaplain: [ 1, 1 ]
+#             Librarian: [ 1, 1 ]
+#             ServiceWorker: [ 2, 3 ]
+#             Reporter: [ 1, 1 ]
+#             #engineering
+#             ChiefEngineer: [ 2, 2 ]
+#             AtmosphericTechnician: [ 3, 3 ]
+#             StationEngineer: [ 6, 8 ]
+#             TechnicalAssistant: [ 4, 6 ]
+#             #medical
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#             MedicalDoctor: [ 3, 4 ]
+#             Paramedic: [ 1, 2 ]
+#             MedicalIntern: [ 2, 3 ]
+#             Psychologist: [ 1, 1 ]
+#             Surgeon: [ 1, 1 ]
+#             #science
+#             ResearchDirector: [ 1, 1 ]
+#             Scientist: [ 3, 4 ]
+#             ResearchAssistant: [ 2, 3 ]
+#             Roboticist: [ 1, 2 ]
+#             #security
+#             HeadOfSecurity: [ 1, 1 ]
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 4, 6 ]
+#             Detective: [ 1, 1 ]
+#             SecurityCadet: [ 3, 4 ]
+#             Brigmedic: [ 1, 1 ]
+#             #supply
+#             Quartermaster: [ 1, 1 ]
+#             SalvageSpecialist: [ 3, 4 ]
+#             MiningSpecialist: [ 3, 4 ]
+#             CargoTechnician: [ 5, 6 ]
+#             MailTech: [ 1, 2 ]
+#             SalvageLead: [ 1, 1 ]
+#             #civilian
+#             Assistant: [ -1, -1 ]
+#             Clown: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 2 ]
+#             Boxer: [ 1, 1 ]
+#             #silicon
+#             StationAi: [ 1, 1 ]
+#             Borg: [ 6, 8 ]
+#             #law
+#             Magistrate: [ 1, 1 ]
+#             IAA: [ 1, 1 ]
+#             #Representives
+#             BlueShield: [ 1, 1 ]
+#             NanoTrasenRepresentative: [ 1, 1 ]


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes and tweak

## Why we need to add this
closes #1186 
and other fixes

## Media (Video/Screenshots)
<img width="590" height="279" alt="image" src="https://github.com/user-attachments/assets/aa83a7c4-17af-43db-acda-22c6e2eda16e" />
<img width="609" height="411" alt="image" src="https://github.com/user-attachments/assets/8154e191-920d-4929-b0c6-79d6fe77961d" />
<img width="294" height="117" alt="image" src="https://github.com/user-attachments/assets/ad38b55c-7656-41bd-a447-71253c940513" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- fix: Fixed being able to get nexus on protogens and trinary on birds with export yaml edits
- fix: Fixed being able to queue the same research more than once
- tweak: Dragons have evolved faraday cage in their stomach to stop eaten hardsuits from showing up on mass scanner
- fix: Added missing displacements for rigs on resomi and cyclorite (as well as their proto- variants)
- tweak: Wizard is once again a roundstart antag you can spawn as
- tweak: Removed all non-FH maps so map voting doesn't require admin intervention