### PR TITLE
Ports SL #3951 -- Disables Cyclorite Color Filter

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Body/Species/cyclorite.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/cyclorite.yml
@@ -249,7 +249,7 @@
       - state: eyeball
   - type: FunctionalOrgan
     comps: 
-    - type: CycloriteVision
+   # - type: CycloriteVision #FH Edit Accessibility for people with certain color blindness
     - type: NightVision
 
 - type: entity

--- a/Resources/Prototypes/_FarHorizons/Body/Species/cyclorite.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/cyclorite.yml
@@ -249,7 +249,7 @@
       - state: eyeball
   - type: FunctionalOrgan
     comps: 
-   # - type: CycloriteVision #FH Edit Accessibility for people with certain color blindness
+   # - type: CycloriteVision --FH Edit Accessibility for people with certain color blindness--
     - type: NightVision
 
 - type: entity

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
@@ -1756,7 +1756,7 @@
   - type: Icon
     sprite: _FarHorizons/Mobs/Species/Proto-Cyclops/parts.rsi
     state: full
-  - type: CycloriteVision
+# - type: CycloriteVision --FH Edit Comments out teal-cyan color filter--
   - type: NightVision
   - type: Butcherable
     butcheringType: Spike

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/cyclorites.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/cyclorites.yml
@@ -15,7 +15,7 @@
   - type: Icon
     sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
     state: cyclorite
-  - type: CycloriteVision
+# - type: CycloriteVision #FH Edit Disables cyan-teal filter for accessibility
   - type: NightVision
   - type: Thirst
   - type: Butcherable

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/cyclorites.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/cyclorites.yml
@@ -15,7 +15,7 @@
   - type: Icon
     sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
     state: cyclorite
-# - type: CycloriteVision #FH Edit Disables cyan-teal filter for accessibility
+# - type: CycloriteVision --FH Edit Disables cyan-teal filter for accessibility--
   - type: NightVision
   - type: Thirst
   - type: Butcherable


### PR DESCRIPTION
## Short description
Disables the Cyclorites teal/cyan color filter as it is straining on the eye and might impair people with color blindness from playing Cyclorites. Its essentially a port of Coolsurf6 on SL in PR #3951. I aint leave a rocker bro hanging.

Please do ping me on discord in case I forget this PR, busy week this week.
## Why we need to add this
Accessibility.

## Media (Video/Screenshots)
No longer a 1 to 1 port since protogens are a thing, hold on I grab my OC for testing.

<img width="511" height="411" alt="image" src="https://github.com/user-attachments/assets/b8aca195-e47b-4094-8ffb-bd9e73eae81f" />

<img width="718" height="615" alt="image" src="https://github.com/user-attachments/assets/4804d228-e156-43ba-a8ff-12b69c727234" />

<img width="461" height="693" alt="image" src="https://github.com/user-attachments/assets/023c65d8-e6a6-4c44-aa5a-b78fc8c304b8" />



Here is media to show that the color filter is no longer applying. 

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Coolsurf6, IrkallaEpsilon
- tweak: Cyclorite color filter is disabled, same for protogen cyclorites. 

