### PR TITLE
Fixes the L6C having 2 magazines.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -209,11 +209,4 @@
         ballistic-ammo: !type:Container
         gun_magazine: !type:ContainerSlot
         gun_chamber: !type:ContainerSlot
-    - type: BatteryAmmoProvider
-      proto: CartridgeLightRifleFMJ
-      fireCost: 100
-    - type: Battery
-      maxCharge: 10000
-      startingCharge: 10000
-    - type: BatterySelfRecharger
-      autoRechargeRate: 25
+    # end region starlight

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -206,7 +206,6 @@
               - CartridgeLightRifle
     - type: ContainerContainer
       containers:
-        ballistic-ammo: !type:Container
         gun_magazine: !type:ContainerSlot
         gun_chamber: !type:ContainerSlot
     # end region starlight


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Removes the L6C's self charging.

## Why we need to add this
When we ported some changes from SL, we got the tweaks to the L6C module. Which included the change for it to use ammo. However, instead of replacing the self charge... we added to it. Which meant it had 2 magazines. We had both the actual magazine that consumed ammo, and the self-charging magazine. Which meant you were shooting 100% more bullet per bullet. I fixed that by deleting the battery-associated components from the L6C.

## Media (Video/Screenshots)
No.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: R3v3l4t1on
- tweak: The L6C no longer has a secondary phantom magazine that self-charges.