### PR TITLE
Fix missing labels on audio options for TTS

### DIFF
--- a/Resources/Locale/en-US/_Starlight/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/_Starlight/escape-menu/ui/options-menu.ftl
@@ -2,3 +2,16 @@ ui-options-function-open-m-help = Open mentor help
 ui-escape-connect-discord = Link Discord
 server-info-connect-discord-button = Link Discord
 
+## TTS
+
+ui-options-tts-label = Text-To-Speech
+ui-options-tts-volume = TTS Volume:
+ui-options-tts-chime-volume = Chime Volume:
+credits-window-tts-title = TTS (Text-To-Speech) Feature
+
+ui-options-tts-radio-volume = Radio Volume:
+ui-options-tts-announce-volume = Announcement Volume:
+
+ui-options-tts-enabled = Text-To-Speech Enabled
+ui-options-tts-radio-queue-enabled = Queue Radio TTS
+ui-options-radio-chime-mute = Mute Radio Chimes


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR fixes missing labels in options menu that target TTS.

## Why we need to add this
It looks bad without labels.

## Media (Video/Screenshots)
<img width="786" height="633" alt="image" src="https://github.com/user-attachments/assets/4be314a5-18ad-43c9-a8a1-65408cdf01c7" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- fix: Fixed missing labels in audio options for TTS.
