### PR TITLE
Quick Vehicle Fix

### DIFF
--- a/Content.Server/_FarHorizons/Tools/Towing/TowingSystems.cs
+++ b/Content.Server/_FarHorizons/Tools/Towing/TowingSystems.cs
@@ -114,11 +114,16 @@ public sealed partial class TowingSystem : EntitySystem
             _movementSpeed.RefreshMovementSpeedModifiers(attachedTo);
             RemComp<TiedComponent>(attachedTo);
             RemComp<JointVisualsComponent>(attachedTo);
+            
+            if(HasComp<HitchComponent>(attachedTo) && HasComp<TowingRopeComponent>(attachedTo))
+                QueueDel(attachedTo);
         }
 
         _movementSpeed.RefreshMovementSpeedModifiers(ent.Owner);    
         RemComp<TiedComponent>(ent.Owner);
         RemComp<JointVisualsComponent>(ent.Owner);
+        if(HasComp<HitchComponent>(ent.Owner) && HasComp<TowingRopeComponent>(ent.Owner))
+            QueueDel(ent.Owner);
         _joint.RecursiveClearJoints(ent.Owner);
     }
 

--- a/Content.Shared/_FarHorizons/Vehicles/SharedVehicleSystem.cs
+++ b/Content.Shared/_FarHorizons/Vehicles/SharedVehicleSystem.cs
@@ -140,6 +140,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
         SubscribeLocalEvent<RiderComponent, RefreshMovementSpeedModifiersEvent>(OnMovementSpeedRefreshRiderEvent);
         SubscribeLocalEvent<RiderComponent, DidEquipHandEvent>(OnHandEquippedRider);
         SubscribeLocalEvent<RiderComponent, PullAttemptEvent>(OnPullAttempt);
+        SubscribeLocalEvent<RiderComponent, EntityTerminatingEvent>(OnRiderTerminating);
 
         SubscribeLocalEvent<GunComponent, ItemWieldedEvent>(OnGunWielded);
         SubscribeLocalEvent<GunComponent, ItemUnwieldedEvent>(OnGunUnwielded);
@@ -769,6 +770,12 @@ public abstract partial class SharedVehicleSystem : EntitySystem
         args.Cancelled = true;
     }
 
+    private void OnRiderTerminating(Entity<RiderComponent> ent, ref EntityTerminatingEvent args)
+    {
+        if (ent.Comp.Riding is { } vehicle && TryComp<VehicleComponent>(vehicle, out var vehicleComp))
+            RemoveRider(ent.Owner, vehicle, vehicleComp);
+    }
+
     #endregion
     #region Gun Events
     private void OnGunUnwielded(EntityUid uid, GunComponent component, ItemUnwieldedEvent args)
@@ -839,6 +846,9 @@ public abstract partial class SharedVehicleSystem : EntitySystem
 
         if( vehicleComp.Rider == null) return;
         var rider = vehicleComp.Rider.Value;
+
+        if (!rider.IsValid() || !Exists(rider)) return;
+
         var riderTransform = Transform(rider);
         if(riderTransform.ParentUid !=  vehicle) return;
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds a guard to the move event in case the rider isn't valid or doesn't exist.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
A fix to a bug reported on 4/24/26 by Merria.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Very Minor not required

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: AthenaAI
- fix: Small guard against invalid riders.
- fix: Fixes the issue with the hitch being left behind after untying the rope from the ATV.
