### PR TITLE
Limb targetting for everyone + throwable limb targetting

### DIFF
--- a/Content.Client/UserInterface/Screens/DefaultGameScreen.xaml
+++ b/Content.Client/UserInterface/Screens/DefaultGameScreen.xaml
@@ -9,6 +9,7 @@
     xmlns:hotbar="clr-namespace:Content.Client.UserInterface.Systems.Hotbar.Widgets"
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:inventory="clr-namespace:Content.Client.UserInterface.Systems.Inventory.Widgets"
+    xmlns:limbDamage="clr-namespace:Content.Client._FarHorizons.LimbDamage.UI"
     Name="DefaultHud"
     VerticalExpand="False"
     VerticalAlignment="Bottom"
@@ -28,6 +29,7 @@
     <widgets:GhostGui Name="Ghost" Access="Protected" />
     <inventory:InventoryGui Name="Inventory" Access="Protected" />
     <hotbar:HotbarGui Name="Hotbar" Access="Protected" />
+    <limbDamage:LimbTargettingUI Name="LimbTargetting" Margin="0 0 50 0" Access="Protected"/>
     <chat:ResizableChatBox Name="Chat" Access="Protected" />
     <alerts:AlertsUI Name="Alerts" Access="Protected" />
 </screens:DefaultGameScreen>

--- a/Content.Client/UserInterface/Screens/DefaultGameScreen.xaml.cs
+++ b/Content.Client/UserInterface/Screens/DefaultGameScreen.xaml.cs
@@ -20,6 +20,7 @@ public sealed partial class DefaultGameScreen : InGameScreen
         SetAnchorAndMarginPreset(Ghost, LayoutPreset.BottomWide, margin: 80);
         SetAnchorAndMarginPreset(Inventory, LayoutPreset.BottomLeft, margin: 5);
         SetAnchorAndMarginPreset(Hotbar, LayoutPreset.BottomWide, margin: 5);
+        SetAnchorAndMarginPreset(LimbTargetting, LayoutPreset.BottomRight, margin: 5); // Far Horizons
         SetAnchorAndMarginPreset(Chat, LayoutPreset.TopRight, margin: 10);
         SetAnchorAndMarginPreset(Alerts, LayoutPreset.TopRight, margin: 10);
 

--- a/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml
+++ b/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml
@@ -10,6 +10,7 @@
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
     xmlns:inventory="clr-namespace:Content.Client.UserInterface.Systems.Inventory.Widgets"
+    xmlns:limbDamage="clr-namespace:Content.Client._FarHorizons.LimbDamage.UI"
     Name="SeparatedChatHud"
     VerticalExpand="False"
     VerticalAlignment="Bottom"
@@ -20,6 +21,7 @@
             <widgets:GhostGui Name="Ghost" Access="Protected" />
             <inventory:InventoryGui Name="Inventory" Access="Protected"/>
             <hotbar:HotbarGui Name="Hotbar" Access="Protected"/>
+            <limbDamage:LimbTargettingUI Name="LimbTargetting" Access="Protected"/>
             <BoxContainer Name="TopLeftContainer" Orientation="Vertical">
                 <actions:ActionsBar Name="Actions" Access="Protected" />
                 <BoxContainer Name="VoteMenu" Access="Public" Orientation="Vertical"/>

--- a/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml.cs
+++ b/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class SeparatedChatGameScreen : InGameScreen
         SetAnchorAndMarginPreset(TopLeftContainer, LayoutPreset.TopLeft, margin: 10);
         SetAnchorAndMarginPreset(Ghost, LayoutPreset.BottomWide, margin: 80);
         SetAnchorAndMarginPreset(Hotbar, LayoutPreset.BottomWide, margin: 5);
+        SetAnchorAndMarginPreset(LimbTargetting, LayoutPreset.BottomRight, margin: 5); // Far Horizons
         SetAnchorAndMarginPreset(Alerts, LayoutPreset.CenterRight, margin: 10);
 
         ScreenContainer.OnSplitResizeFinished += () =>

--- a/Content.Client/UserInterface/Systems/Hotbar/Widgets/HotbarGui.xaml
+++ b/Content.Client/UserInterface/Systems/Hotbar/Widgets/HotbarGui.xaml
@@ -3,7 +3,6 @@
     xmlns:inventory="clr-namespace:Content.Client.UserInterface.Systems.Inventory.Controls"
     xmlns:hands="clr-namespace:Content.Client.UserInterface.Systems.Hands.Controls"
     xmlns:widgets="clr-namespace:Content.Client.UserInterface.Systems.Hotbar.Widgets"
-    xmlns:limbDamage="clr-namespace:Content.Client._FarHorizons.LimbDamage.UI"
     Name="HotbarInterface"
     VerticalExpand="True"
     VerticalAlignment="Bottom"
@@ -81,8 +80,6 @@
                 ExpandBackwards="True"
                 Columns="6"
                 />
-            <limbDamage:LimbTargettingUI
-                Margin="4 0 0 0"/>
         </BoxContainer>
     </BoxContainer>
 </widgets:HotbarGui>

--- a/Content.Client/_FarHorizons/LimbDamage/UI/LimbTargettingUIController.cs
+++ b/Content.Client/_FarHorizons/LimbDamage/UI/LimbTargettingUIController.cs
@@ -109,6 +109,7 @@ public sealed class LimbTargettingUIController : UIController, IOnSystemLoaded<L
         {
             widget.InitTarget(_protoMan, _resourceCache, _sprite!, limbTarget.Proto);
             widget.Visible = true;
+            widget.UpdateLimb(limbTarget.Target);
         }
 
         if (widget.OnSelectedLimb == null)

--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -1,5 +1,7 @@
 using Content.Server.Administration.Logs;
 using Content.Server.Weapons.Ranged.Systems;
+using Content.Shared._FarHorizons.LimbDamage;
+using Content.Shared._FarHorizons.LimbDamage.Components;
 using Content.Shared.Camera;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
@@ -20,6 +22,7 @@ public sealed class DamageOtherOnHitSystem : SharedDamageOtherOnHitSystem
     [Dependency] private readonly Shared.Damage.Systems.DamageableSystem _damageable = default!;
     [Dependency] private readonly SharedCameraRecoilSystem _sharedCameraRecoil = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
+    [Dependency] private readonly LimbDamageSystem _limbDamage = default!; // Far Horizons
 
     public override void Initialize()
     {
@@ -33,7 +36,18 @@ public sealed class DamageOtherOnHitSystem : SharedDamageOtherOnHitSystem
         if (TerminatingOrDeleted(args.Target))
             return;
 
-        var dmg = _damageable.ChangeDamage(args.Target, component.Damage * _damageable.UniversalThrownDamageModifier, component.IgnoreResistances, origin: args.Component.Thrower);
+        // Far Horizons start
+        if (!TryComp<LimbAimedThrowComponent>(uid, out var limbAim) ||
+            !TryComp<LimbDamageableComponent>(args.Target, out var limbDamageable) ||
+            !_limbDamage.CheckAttackHit((args.Target, limbDamageable), limbAim.Target, out var hitTarget) ||
+            hitTarget == null ||
+            hitTarget == limbDamageable.DefaultLimb ||
+            !_limbDamage.TryChangeLimbDamage((args.Target, limbDamageable), hitTarget.Value, component.Damage * _damageable.UniversalThrownDamageModifier, out var dmg, component.IgnoreResistances, origin: args.Component.Thrower))
+            dmg = _damageable.ChangeDamage(args.Target, component.Damage * _damageable.UniversalThrownDamageModifier, component.IgnoreResistances, origin: args.Component.Thrower);
+
+        if (limbAim != null)
+            RemCompDeferred<LimbAimedThrowComponent>(uid);
+        // Far Horizons end
 
         // Log damage only for mobs. Useful for when people throw spears at each other, but also avoids log-spam when explosions send glass shards flying.
         if (HasComp<MobStateComponent>(args.Target))

--- a/Content.Shared/_FarHorizons/LimbDamage/Components/LimbAimedThrowComponent.cs
+++ b/Content.Shared/_FarHorizons/LimbDamage/Components/LimbAimedThrowComponent.cs
@@ -1,0 +1,11 @@
+using Content.Shared.Body;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._FarHorizons.LimbDamage.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class LimbAimedThrowComponent : Component
+{
+    [DataField] public ProtoId<OrganCategoryPrototype> Target = "Torso";
+}

--- a/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.Throwable.cs
+++ b/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.Throwable.cs
@@ -1,0 +1,23 @@
+using Content.Shared._FarHorizons.LimbDamage.Components;
+using Content.Shared.Throwing;
+
+namespace Content.Shared._FarHorizons.LimbDamage;
+
+public partial class LimbDamageSystem
+{
+
+    private void InitThrowable()
+    {
+        SubscribeLocalEvent<LimbTargettingComponent, ThrowEvent>(OnAimedThrow);
+        SubscribeLocalEvent<LimbAimedThrowComponent, LandEvent>(OnAimedLand);
+    }
+
+    private void OnAimedThrow(Entity<LimbTargettingComponent> ent, ref ThrowEvent args)
+    {
+        var aimedThrow = EnsureComp<LimbAimedThrowComponent>(args.Thrown);
+        aimedThrow.Target = ent.Comp.Target;
+    }
+
+    private void OnAimedLand(Entity<LimbAimedThrowComponent> ent, ref LandEvent args) => 
+        RemCompDeferred<LimbAimedThrowComponent>(ent);
+}

--- a/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.cs
+++ b/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.cs
@@ -26,6 +26,7 @@ public sealed partial class LimbDamageSystem : EntitySystem
         InitArmor();
         InitEffect();
         InitInspect();
+        InitThrowable();
 
         SubscribeLocalEvent<LimbDamageableComponent, ComponentInit>(OnBodyInit);
         SubscribeLocalEvent<DamageableLimbComponent, ComponentInit>(OnLimbInit);


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Originally I made limb targeting available to everyone with combat mode. However, I put the UI as part of hotbar, making it unavailable to anyone who doesn't have hotbar. Now I moved it to be a UI element of its own so it's always avaiable for everyone

Also throwable weapons target limbs too.

## Why we need to add this
QoL

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/f13fa45c-6cc1-4a08-8d46-201427a6ea37

https://github.com/user-attachments/assets/d35dcf9b-cd96-48de-8c04-ab618753b02a


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- tweak: Limb targeting UI has been moved outside of hotbar, making it available for everyone with combat mode, like originally intended (rat king, dragon, AI turrets, and everyone else with combat mode but no hotbar)
- add: You can now target limbs with thrown weapons
