### PR TITLE
Bird slow fix + zombie fixes

### DIFF
--- a/Content.Server/_FarHorizons/Zombies/LimbDamageableZombieSystem.cs
+++ b/Content.Server/_FarHorizons/Zombies/LimbDamageableZombieSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Server.Mobs;
 using Content.Shared._FarHorizons.Body;
 using Content.Shared._FarHorizons.LimbDamage;
 using Content.Shared._FarHorizons.LimbDamage.Components;
@@ -6,7 +7,6 @@ using Content.Shared._FarHorizons.Zombies;
 using Content.Shared.Body;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Mobs;
-using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Zombies;
 using Robust.Shared.Prototypes;
@@ -21,6 +21,8 @@ public sealed class LimbDamageableZombieSystem : EntitySystem
     [Dependency] private readonly LimbDamageSystem _limbDamage = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly DeathgaspSystem _deathgasp = default!;
+    [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
 
     private static readonly ProtoId<OrganCategoryPrototype> _headCategory = "Head";
 
@@ -41,7 +43,7 @@ public sealed class LimbDamageableZombieSystem : EntitySystem
             return;
 
         EnsureComp<ZombieHeadComponent>(head);
-        RemCompDeferred<MobThresholdsComponent>(ent);
+        _mobThreshold.MakeZombieThresholds(ent.Owner);
     }
 
     private void OnZombieHeadDamaged(Entity<ZombieHeadComponent> ent, ref DamageChangedEvent args)
@@ -50,22 +52,27 @@ public sealed class LimbDamageableZombieSystem : EntitySystem
             return;
 
         if (!TryComp<OrganComponent>(ent, out var organ) ||
-            organ.Body == null)
+            organ.Body == null ||
+            !_mobState.IsAlive(organ.Body.Value))
             return;
 
         var damage = _damageable.GetPositiveDamage((ent.Owner, args.Damageable));
         var totalDamage = damage.DamageDict.Values.Sum(p => (float)p);
 
-        if (totalDamage >= ent.Comp.DeathAt)
-            _mobState.ChangeMobState(organ.Body.Value, MobState.Dead);
+        if (!(totalDamage >= ent.Comp.DeathAt)) return;
+
+        _deathgasp.Deathgasp(organ.Body.Value);
+        _mobState.ChangeMobState(organ.Body.Value, MobState.Dead);
     }
 
     private void OnZombieHeadRemoved(Entity<ZombieHeadComponent> ent, ref OrganGotRemovedEvent args)
     {
         if (!TryComp<OrganComponent>(ent, out var organ) ||
-            organ.Body == null)
+            organ.Body == null ||
+            !_mobState.IsAlive(organ.Body.Value))
             return;
 
+        _deathgasp.Deathgasp(organ.Body.Value);
         _mobState.ChangeMobState(organ.Body.Value, MobState.Dead);
     }
 }

--- a/Content.Shared/Mobs/Systems/MobThresholdSystem.FatHorizons.cs
+++ b/Content.Shared/Mobs/Systems/MobThresholdSystem.FatHorizons.cs
@@ -1,0 +1,16 @@
+using Content.Shared.Mobs.Components;
+
+namespace Content.Shared.Mobs.Systems;
+
+public sealed partial class MobThresholdSystem
+{
+    public void MakeZombieThresholds(Entity<MobThresholdsComponent?> mob)
+    {
+        if (!Resolve(mob, ref mob.Comp))
+            return;
+
+        mob.Comp.Thresholds = [];
+        mob.Comp.Thresholds.Add(0, MobState.Alive);
+        Dirty(mob);
+    }
+}

--- a/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
@@ -11,7 +11,8 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared.Mobs.Systems;
 
-public sealed class MobThresholdSystem : EntitySystem
+// Far Horizons - made partial
+public sealed partial class MobThresholdSystem : EntitySystem
 {
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
     [Dependency] private readonly AlertsSystem _alerts = default!;

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoResomi.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoResomi.yml
@@ -61,6 +61,11 @@
     shiveringHeatRegulation: 2000
     normalBodyTemperature: 261
     thermalRegulationTemperatureThreshold: 1
+  - type: TemperatureSpeed
+    thresholds:
+      250: 0.9
+      230: 0.8
+      223: 0.6
     
 # Organs
 

--- a/Resources/Prototypes/_FarHorizons/Body/Species/resomi.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/resomi.yml
@@ -213,6 +213,11 @@
     shiveringHeatRegulation: 2000
     normalBodyTemperature: 261
     thermalRegulationTemperatureThreshold: 1
+  - type: TemperatureSpeed
+    thresholds:
+      250: 0.9
+      230: 0.8
+      223: 0.6
 
 # Organs
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Some small fixes

## Why we need to add this
bugs

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/699b9c5a-2d17-44f0-bfbc-d7210910ca8d



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- fix: Resomi and proto-resomi no longer get slowed down by their normal body temperature
- fix: Getting transformed into a zombie from crit condition properly removes screen overlay
- tweak: Zombies play deathgasp emote before dying 

