### PR TITLE
mghost Permission Tweak

### DIFF
--- a/Content.Server/_Starlight/Ghost/MGhostCommand.cs
+++ b/Content.Server/_Starlight/Ghost/MGhostCommand.cs
@@ -39,7 +39,7 @@ public sealed class MGhostCommand : LocalizedCommands
 
         if (!_discordLinkManager.HasPermission(player.UserId.UserId, AdditionalPermissionsTypes.Mentor)) // if you are a admin you should be using aghost
         {
-            shell.WriteError(LocalizationManager.GetString("mghost-mentors-only"));
+            shell.WriteError(LocalizationManager.GetString("fh-mghost-mentors-only")); //FH, this didnt have a .ftl for some reason
             return;
         }
 

--- a/Resources/Locale/en-US/_FarHorizons/commands/mghost-commands.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/commands/mghost-commands.ftl
@@ -1,0 +1,1 @@
+fh-mghost-mentors-only = You are not a Mentor!

--- a/Resources/Prototypes/_FarHorizons/DiscordLink/discord_roles.yml
+++ b/Resources/Prototypes/_FarHorizons/DiscordLink/discord_roles.yml
@@ -3,49 +3,49 @@
   discordRoleId: 1407109433670111315
   playerTitle: "Senior"
   order: 1
-  additionalPermissions: [PeacefulBypass, RoleRequirementBypass, CCSHC, AdminSkins]
+  additionalPermissions: [PeacefulBypass, RoleRequirementBypass, CCSHC, AdminSkins, Mentor]
 
 - type: discordRole
   id: SeniorAdmin
   discordRoleId: 1411084097404801104
   playerTitle: "Senior"
   order: 2
-  additionalPermissions: [PeacefulBypass, RoleRequirementBypass, CCSHC, AdminSkins]
+  additionalPermissions: [PeacefulBypass, RoleRequirementBypass, CCSHC, AdminSkins, Mentor]
 
 - type: discordRole
   id: EventAdmin
   discordRoleId: 1407084985680269382
   playerTitle: "Eventmin"
   order: 3
-  additionalPermissions: [PeacefulBypass, RoleRequirementBypass, CCSHC, AdminSkins]
+  additionalPermissions: [PeacefulBypass, RoleRequirementBypass, CCSHC, AdminSkins, Mentor]
 
 - type: discordRole
   id: GameAdmin
   discordRoleId: 1407078784611385534
   playerTitle: "Admin"
   order: 4
-  additionalPermissions: [PeacefulBypass, RoleRequirementBypass, AdminSkins]
+  additionalPermissions: [PeacefulBypass, RoleRequirementBypass, AdminSkins, Mentor]
 
 - type: discordRole
   id: DevAdmin
   discordRoleId: 1415515150123012219
   playerTitle: "Dev Admin"
   order: 5
-  additionalPermissions: [RoleRequirementBypass, AdminSkins]
+  additionalPermissions: [RoleRequirementBypass, AdminSkins, Mentor]
 
 - type: discordRole
   id: TrialAdmin
   discordRoleId: 1407078837325402152
   playerTitle: "Trialmin"
   order: 6
-  additionalPermissions: [AdminSkins]
+  additionalPermissions: [AdminSkins, Mentor]
 
 - type: discordRole
   id: CCSHC
   discordRoleId: 1456857344393613354
   playerTitle: "CC-op"
   order: 7
-  additionalPermissions: [CCSHC]
+  additionalPermissions: [CCSHC, Mentor]
 
 - type: discordRole
   id: Mentor


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Gives every discord role above mentor `AdditionalPermissionsTypes.Mentor` so all staff mentor and above can mghost.
Also fixes the locale for the mghost command, cus for some reason it just didn't have one before.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
mghost is an excellent tool for all members of staff when aghost isn't acceptable for use in the situation/don't have permission. This also gives admins access to the mhelp menu.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="212" height="43" alt="Content Client_ogxyWdEaDI" src="https://github.com/user-attachments/assets/1c84596d-6dc1-46f5-9bcb-e24fefb9ccde" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: KarusKardin
- tweak: gave mentor perms to every role above mentor. (they can now use the mhelp menu and mghost)
