### PR TITLE
Admin OOC Colors Tweak

### DIFF
--- a/Content.Server/Chat/Managers/ChatManager.cs
+++ b/Content.Server/Chat/Managers/ChatManager.cs
@@ -300,7 +300,7 @@ internal sealed partial class ChatManager : IChatManager
         var playerName = player.Name;
         var playerTitle = "";
 
-        if (_adminManager.HasAdminFlag(player, AdminFlags.NameColor))
+        if (_adminManager.HasAdminFlag(player, AdminFlags.NameColor, true)) //FH
         {
             var prefs = _preferencesManager.GetPreferences(player.UserId);
             colorOverride = prefs.AdminOOCColor;


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Gives admins their OOC colors when deadmined
Changes a boolean in SendOOC when its checking flags to tell it to also check deadmined players, not just active admins.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
9/10 admins stay admined for their colors, also players are more likely to listen to deadmined admins when they have their color still.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="465" height="93" alt="Content Client_7xmzBYx0XY" src="https://github.com/user-attachments/assets/bed93f01-100f-44fb-b5b6-93e99943b8df" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: KarusKardin
- tweak: Changed the admin ooc colors so they also apply to deadmined staff
