### PR TITLE
Fix scope offsetting to the side

### DIFF
--- a/Content.Shared/_RMC14/Scoping/SharedScopeSystem.cs
+++ b/Content.Shared/_RMC14/Scoping/SharedScopeSystem.cs
@@ -150,7 +150,7 @@ public abstract partial class SharedScopeSystem : EntitySystem
         //     return;
         // Far Horizons End
 
-        var dir = _transform.GetWorldRotation(args.User).GetCardinalDir(); // Far Horizons - World rotation instead of local rotation
+        var dir = GetEyeDirection(args.User); // Far Horizons - Calculate direction
         if (ent.Comp.ScopingDirection != dir)
             Unscope(ent);
     }
@@ -195,7 +195,7 @@ public abstract partial class SharedScopeSystem : EntitySystem
 
     private void OnGunGunShot(Entity<GunScopingComponent> ent, ref GunShotEvent args)
     {
-        var dir = _transform.GetWorldRotation(args.User).GetCardinalDir(); // Far Horizons - World rotation instead of local rotation
+        var dir = GetEyeDirection(args.User); // Far Horizons - Calculate direction
         if (TryComp(ent.Comp.Scope, out ScopeComponent? scope) && scope.ScopingDirection != dir)
             UnscopeGun(ent);
     }
@@ -257,7 +257,7 @@ public abstract partial class SharedScopeSystem : EntitySystem
         if (!CanScopePopup(scope, user))
             return null;
 
-        var cardinalDir = _transform.GetWorldRotation(user).GetCardinalDir();
+        var cardinalDir = GetEyeDirection(user); // Far Horizons - Calculate direction
         var ev = new ScopeDoAfterEvent(cardinalDir);
         var zoomLevel = GetCurrentZoomLevel(scope);
         var doAfter = new DoAfterArgs(EntityManager, user, zoomLevel.DoAfter, ev, scope, null, scope)
@@ -427,4 +427,8 @@ public abstract partial class SharedScopeSystem : EntitySystem
         RaiseLocalEvent(user, ref ev);
         _eye.SetOffset(user, ev.Offset);
     }
+
+    // FarHorizons edit start - get local rotation
+    private Direction GetEyeDirection(EntityUid user) => _transform.GetWorldRotation(user).GetDir();
+    // FarHorizons edit end
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
The current scope implementation is offsetting to the side a bit, due to me not knowing what a cardinal direction is in a context of the world map.

## Why we need to add this
It makes the scope snap to the correct direction

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/93b54771-119b-4e5e-9589-e9f2552e8276

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- fix: Fixed scopes snapping diagonally instead of straight.
