### PR TITLE
active crit adjustments

### DIFF
--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -716,7 +716,7 @@ namespace Content.Shared.Interaction
             if (!Resolve(other, ref other.Comp))
                 return false;
 
-            var ev = new InRangeOverrideEvent(origin, other);
+            var ev = new InRangeOverrideEvent(origin, other, true); // Far Horizons
             RaiseLocalEvent(origin, ref ev);
 
             if (ev.Handled)
@@ -1588,10 +1588,11 @@ namespace Content.Shared.Interaction
     /// Override event raised directed on a user to check InRangeUnoccluded AND InRangeUnobstructed to the target if you require custom logic.
     /// </summary>
     [ByRefEvent]
-    public record struct InRangeOverrideEvent(EntityUid User, EntityUid Target)
+    public record struct InRangeOverrideEvent(EntityUid User, EntityUid Target, bool Action = false) // Far Horizons
     {
         public readonly EntityUid User = User;
         public readonly EntityUid Target = Target;
+        public readonly bool Action = Action; // Far Horizons
 
         public bool Handled;
         public bool InRange = false;

--- a/Content.Shared/_FarHorizons/Mobs/ActiveCritComponent.cs
+++ b/Content.Shared/_FarHorizons/Mobs/ActiveCritComponent.cs
@@ -28,6 +28,8 @@ public sealed partial class ActiveCritComponent : Component
 
     [DataField] public float SpeechDistortionStrength = 0.5f;
 
+    [DataField] public int AdjustTemporaryEyeDamage;
+
     [DataField] public LocId CantUseHandsMessage = "active-crit-cant-use-hands";
     [DataField] public LocId FailedStandUpMessage = "active-crit-standup-fail";
 

--- a/Content.Shared/_FarHorizons/Mobs/BlockActionInCritComponent.cs
+++ b/Content.Shared/_FarHorizons/Mobs/BlockActionInCritComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._FarHorizons.Mobs;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BlockActionInCritComponent : Component;

--- a/Content.Shared/_FarHorizons/Mobs/SharedActiveCritSystem.Actions.cs
+++ b/Content.Shared/_FarHorizons/Mobs/SharedActiveCritSystem.Actions.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Actions.Events;
+
+namespace Content.Shared._FarHorizons.Mobs;
+
+public abstract partial class SharedActiveCritSystem
+{
+    private void InitializeActions()
+    {
+        SubscribeLocalEvent<BlockActionInCritComponent, ActionValidateEvent>(OnActionCheck);
+    }
+
+    private void OnActionCheck(Entity<BlockActionInCritComponent> ent, ref ActionValidateEvent args)
+    {
+        if (_mobState.IsCritical(args.User))
+            args.Invalid = true;
+    }
+}

--- a/Content.Shared/_FarHorizons/Mobs/SharedActiveCritSystem.cs
+++ b/Content.Shared/_FarHorizons/Mobs/SharedActiveCritSystem.cs
@@ -1,7 +1,9 @@
 using Content.Shared.ActionBlocker;
 using Content.Shared.CombatMode;
 using Content.Shared.Damage.Systems;
+using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.IdentityManagement;
+using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
 using Content.Shared.Mobs;
@@ -18,7 +20,7 @@ using Robust.Shared.Timing;
 
 namespace Content.Shared._FarHorizons.Mobs;
 
-public abstract class SharedActiveCritSystem : EntitySystem
+public abstract partial class SharedActiveCritSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] protected readonly MobStateSystem _mobState = default!;
@@ -28,10 +30,13 @@ public abstract class SharedActiveCritSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedCombatModeSystem _combat = default!;
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+    [Dependency] private readonly BlindableSystem _blindable = default!;
 
     public override void Initialize()
     {
         base.Initialize();
+
+        InitializeActions();
 
         SubscribeLocalEvent<ActiveCritComponent, MobStateChangedEvent>(OnStateChanged);
         SubscribeLocalEvent<ActiveCritComponent, RefreshMovementSpeedModifiersEvent>(OnMovementModifierRefresh);
@@ -46,6 +51,15 @@ public abstract class SharedActiveCritSystem : EntitySystem
         SubscribeLocalEvent<ActiveCritComponent, ConsciousAttemptEvent>(OnConsciousCheck);
         SubscribeLocalEvent<ActiveCritComponent, UpdateCanMoveEvent>(OnCanMoveCheck);
         SubscribeLocalEvent<ActiveCritComponent, SpeakAttemptEvent>(OnSpeakAttempt);
+        SubscribeLocalEvent<ActiveCritComponent, InRangeOverrideEvent>(OnInRangeCheck);
+    }
+
+    private void OnInRangeCheck(Entity<ActiveCritComponent> ent, ref InRangeOverrideEvent args)
+    {
+        if (!_mobState.IsCritical(ent.Owner) || args.Handled || args.Action) return;
+
+        args.InRange = false;
+        args.Handled = true;
     }
 
     private void OnSpeakAttempt(Entity<ActiveCritComponent> ent, ref SpeakAttemptEvent args)
@@ -73,7 +87,7 @@ public abstract class SharedActiveCritSystem : EntitySystem
 
     private void OnUseAttempt(Entity<ActiveCritComponent> ent, ref UseAttemptEvent args)
     {
-        if (!_mobState.IsCritical(ent.Owner) || args.Cancelled) return;
+        if (!_mobState.IsCritical(ent.Owner) || args.Cancelled || !_timing.IsFirstTimePredicted) return;
 
         if (HasComp<KnockedDownComponent>(ent.Owner))
         {
@@ -93,16 +107,7 @@ public abstract class SharedActiveCritSystem : EntitySystem
         if (!_mobState.IsCritical(ent.Owner) || args.Cancelled) return;
 
         if (HasComp<KnockedDownComponent>(ent.Owner))
-        {
             args.Cancelled = true;
-            return;
-        }
-
-        var random = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(ent));
-        if (!random.Prob(ent.Comp.FallOnUseChance)) return;
-        _stun.TryKnockdown(ent.Owner, ent.Comp.CrawlDuration, true, false, true, true);
-        _damage.TryChangeDamage(ent.Owner, ent.Comp.DamageOnFall, true, false);
-        args.Cancelled = true;
     }
 
     private void OnPickupAttempt(Entity<ActiveCritComponent> ent, ref PickupAttemptEvent args)
@@ -154,6 +159,8 @@ public abstract class SharedActiveCritSystem : EntitySystem
 
     private void OnStateChanged(Entity<ActiveCritComponent> ent, ref MobStateChangedEvent args)
     {
+        if (!_timing.IsFirstTimePredicted) return;
+
         if (args.OldMobState == MobState.ActiveCritical && args.NewMobState != MobState.ActiveCritical)
             CleanupActiveCrit(ent.AsNullable());
         else if (args.OldMobState != MobState.ActiveCritical && args.NewMobState == MobState.ActiveCritical)
@@ -187,16 +194,27 @@ public abstract class SharedActiveCritSystem : EntitySystem
         _movementSpeed.RefreshMovementSpeedModifiers(ent.Owner);
         EnterBlackout(ent);
         _combat.SetInCombatMode(ent.Owner, false);
+
+        if (ent.Comp.AdjustTemporaryEyeDamage <= 0) 
+            return;
+        
+        _blindable.AdjustEyeDamage(ent.Owner, ent.Comp.AdjustTemporaryEyeDamage);
+
     }
 
     public void CleanupActiveCrit(Entity<ActiveCritComponent?> ent)
     {
-        if (!Resolve(ent, ref ent.Comp) || !_mobState.IsCritical(ent))
+        if (!Resolve(ent, ref ent.Comp))
             return;
 
         ExitBlackout(ent);
         ent.Comp.BlackoutToggleAt = null;
         _movementSpeed.RefreshMovementSpeedModifiers(ent.Owner);
+
+        if (ent.Comp.AdjustTemporaryEyeDamage <= 0) 
+            return;
+        
+        _blindable.AdjustEyeDamage(ent.Owner, -ent.Comp.AdjustTemporaryEyeDamage);
     }
 
     public void EnterBlackout(Entity<ActiveCritComponent?> ent)

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/base.yml
@@ -21,6 +21,7 @@
     restrictCombat: true # No combat actions allowed
     requireStandingForHands: true # Needs to stand up to grab items
     speechDistortionStrength: 1 # 100% distorted speech, kinda arbitrary
+    adjustTemporaryEyeDamage: 5 # gives target this much eye damage for the duration of crit
     cantUseHandsMessage: active-crit-cant-use-hands
     failedStandUpMessage: active-crit-standup-fail
   - type: MobState

--- a/Resources/Prototypes/_Starlight/Actions/avali.yml
+++ b/Resources/Prototypes/_Starlight/Actions/avali.yml
@@ -13,6 +13,7 @@
         state: heal
     - type: InstantAction
       event: !type:PrepareStasisActionEvent
+    - type: BlockActionInCrit # FH
 
 - type: entity
   id: ActionStasisExit

--- a/Resources/Prototypes/_Starlight/Actions/jump.yml
+++ b/Resources/Prototypes/_Starlight/Actions/jump.yml
@@ -17,6 +17,7 @@
     event: !type:JumpActionEvent
       sound:
         path: /Audio/_Starlight/Effects/Jump/resomi.ogg
+  - type: BlockActionInCrit # FH
 
 - type: entity
   parent: Jump

--- a/Resources/Prototypes/_Starlight/Actions/lagomorph.yml
+++ b/Resources/Prototypes/_Starlight/Actions/lagomorph.yml
@@ -16,6 +16,7 @@
     #  rechargeDuration: 50
     - type: InstantAction
       event: !type:StaminaSurgeActionEvent
+    - type: BlockActionInCrit # FH
 
 - type: entity
   id: Zoomies
@@ -35,3 +36,4 @@
     #  rechargeDuration: 50
     - type: InstantAction
       event: !type:ZoomiesActionEvent
+    - type: BlockActionInCrit # FH


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Some adjustments based on dev feedback

## Why we need to add this
balance

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/6be299d0-3655-40b4-b0b7-ce7963057bbe



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- tweak: You can no longer examine anything or use right-click menu in active crit
- tweak: When entering active crit - you will take temporary eye damage that will be removed when you're no longer crit
- tweak: Avali regeneration, jumps of any kind and lagomorph abilities are no longer usable in active crit
- fix: Fixed a funny little issue making you roll fail chances twice in active crit
