### PR TITLE
Maroon target for Non-Command Crew can no longer roll

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -31,7 +31,7 @@
 - type: weightedRandom
   id: TraitorObjectiveGroupKill
   weights:
-    KillRandomPersonObjective: 1
+#   KillRandomPersonObjective: 1 #FH Edit: Flick on if KillRandomPerson in the ‎Objectives/traitors.yml is enabled
     KillRandomHeadObjective: 0.25
     TeachRandomPersonObjective: 1 #Starlight Teach them a lesson
     TeachRandomHeadObjective: 0.25 # Starlight Teach them a lesson

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -84,29 +84,25 @@
 # kill
 # FH Edit Begin -- Increasing overall round entropy by removing RR of a random person i.e. the janitor is going to increase likelyhood of rolling more high-profile objectives
 
-- type: entity
-  parent: [BaseTraitorObjective, BaseKillObjective]
-  id: KillRandomPersonObjective
-  description: Do it however you like, just make sure they don't get off the station.
-  components:
-  - type: Objective
-    difficulty: 2.5 #FH Edit
-    unique: false
-  - type: TargetObjective
-    title: objective-condition-maroon-person-title
-  - type: PickRandomPerson
-    filters:
+#- type: entity
+#  parent: [BaseTraitorObjective, BaseKillObjective]
+#  id: KillRandomPersonObjective
+#  description: Do it however you like, just make sure they don't get off the station.
+#  components:
+#  - type: Objective
+#    difficulty: 1.5 #Starlight Edit
+#    unique: false
+#  - type: TargetObjective
+#    title: objective-condition-maroon-person-title
+#  - type: PickRandomPerson
+#    filters:
     # Can't have multiple objectives to kill the same person.
-    - !type:BodyMindFilter #FH Edit
-      whitelist: #FH Edit
-        components: #FH Edit
-        - CommandStaff #FH Edit
-    - !type:TargetObjectiveMindFilter
-      blacklist:
-        components:
-        - KillPersonCondition
-  - type: KillPersonCondition
-    requireMaroon: true
+#    - !type:TargetObjectiveMindFilter
+#      blacklist:
+#        components:
+#        - KillPersonCondition
+#  - type: KillPersonCondition
+#    requireMaroon: true
 #FH Edit End
 
 - type: entity

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -82,10 +82,6 @@
 #    - type: HijackShuttleCondition
 
 # kill
-# FH Edit Begin -- Increasing overall round entropy by removing RR of a random person is going to increase likelyhood of rolling more high-profile objectives as well as overall in-character behavior of non-command crew
-
-
-# kill
 #FH Edit Begin -- Increasing overall round entropy by removing RR of a random person is going to increase likelyhood of rolling more high-profile objectives as well as overall in-character behavior of non-command crew
 
 # - type: entity

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -97,7 +97,7 @@
   - type: PickRandomPerson
     filters:
     # Can't have multiple objectives to kill the same person.
-    - !type:BodyMindFilter
+    - !type:BodyMindFilter #FH Edit
       whitelist: #FH Edit
         components: #FH Edit
         - CommandStaff #FH Edit

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -82,27 +82,31 @@
 #    - type: HijackShuttleCondition
 
 # kill
-#FH Edit Begin -- Increasing overall round entropy by removing RR of a random person is going to increase likelyhood of rolling more high-profile objectives as well as overall in-character behavior of non-command crew
+# FH Edit Begin -- Increasing overall round entropy by removing RR of a random person i.e. the janitor is going to increase likelyhood of rolling more high-profile objectives
 
-# - type: entity
-#  parent: [BaseTraitorObjective, BaseKillObjective]
-#  id: KillRandomPersonObjective
-#  description: Do it however you like, just make sure they don't get off the station.
-#  components:
-#  - type: Objective
-#    difficulty: 1.5 #Starlight edit
-#    unique: false
-#  - type: TargetObjective
-#    title: objective-condition-maroon-person-title
-#  - type: PickRandomPerson
-#    filters:
+- type: entity
+  parent: [BaseTraitorObjective, BaseKillObjective]
+  id: KillRandomPersonObjective
+  description: Do it however you like, just make sure they don't get off the station.
+  components:
+  - type: Objective
+    difficulty: 2.5 #FH Edit
+    unique: false
+  - type: TargetObjective
+    title: objective-condition-maroon-person-title
+  - type: PickRandomPerson
+    filters:
     # Can't have multiple objectives to kill the same person.
-#    - !type:TargetObjectiveMindFilter
-#      blacklist:
-#        components:
-#        - KillPersonCondition
-#  - type: KillPersonCondition
-#    requireMaroon: true
+    - !type:BodyMindFilter
+      whitelist: #FH Edit
+        components: #FH Edit
+        - CommandStaff #FH Edit
+    - !type:TargetObjectiveMindFilter
+      blacklist:
+        components:
+        - KillPersonCondition
+  - type: KillPersonCondition
+    requireMaroon: true
 #FH Edit End
 
 - type: entity

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -82,26 +82,28 @@
 #    - type: HijackShuttleCondition
 
 # kill
+# FH Edit Begin -- Increasing overall round entropy by removing RR of a random person is going to increase likelyhood of rolling more high-profile objectives as well as overall in-character behavior of non-command crew
 
-- type: entity
-  parent: [BaseTraitorObjective, BaseKillObjective]
-  id: KillRandomPersonObjective
-  description: Do it however you like, just make sure they don't get off the station.
-  components:
-  - type: Objective
-    difficulty: 1.5 #Starlight edit
-    unique: false
-  - type: TargetObjective
-    title: objective-condition-maroon-person-title
-  - type: PickRandomPerson
-    filters:
-    # Can't have multiple objectives to kill the same person.
-    - !type:TargetObjectiveMindFilter
-      blacklist:
-        components:
-        - KillPersonCondition
-  - type: KillPersonCondition
-    requireMaroon: true
+#- type: entity
+#  parent: [BaseTraitorObjective, BaseKillObjective]
+#  id: KillRandomPersonObjective
+#  description: Do it however you like, just make sure they don't get off the station.
+#  components:
+#  - type: Objective
+#    difficulty: 1.5 #Starlight edit
+#    unique: false
+#  - type: TargetObjective
+#    title: objective-condition-maroon-person-title
+#  - type: PickRandomPerson
+#    filters:
+#    # Can't have multiple objectives to kill the same person.
+#    - !type:TargetObjectiveMindFilter
+#      blacklist:
+#        components:
+#        - KillPersonCondition
+#  - type: KillPersonCondition
+#    requireMaroon: true
+# FH Edit End
 
 - type: entity
   parent: [BaseTraitorObjective, BaseKillObjective]

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -84,7 +84,11 @@
 # kill
 # FH Edit Begin -- Increasing overall round entropy by removing RR of a random person is going to increase likelyhood of rolling more high-profile objectives as well as overall in-character behavior of non-command crew
 
-#- type: entity
+
+# kill
+#FH Edit Begin -- Increasing overall round entropy by removing RR of a random person is going to increase likelyhood of rolling more high-profile objectives as well as overall in-character behavior of non-command crew
+
+# - type: entity
 #  parent: [BaseTraitorObjective, BaseKillObjective]
 #  id: KillRandomPersonObjective
 #  description: Do it however you like, just make sure they don't get off the station.
@@ -96,14 +100,14 @@
 #    title: objective-condition-maroon-person-title
 #  - type: PickRandomPerson
 #    filters:
-#    # Can't have multiple objectives to kill the same person.
+    # Can't have multiple objectives to kill the same person.
 #    - !type:TargetObjectiveMindFilter
 #      blacklist:
 #        components:
 #        - KillPersonCondition
 #  - type: KillPersonCondition
 #    requireMaroon: true
-# FH Edit End
+#FH Edit End
 
 - type: entity
   parent: [BaseTraitorObjective, BaseKillObjective]


### PR DESCRIPTION
Okay bear with me on this for a moment:

https://discord.com/channels/1407077238876147783/1500440297870590113

In our discord the discussion came up to make an opt-in objective for maroon. The discussion seems very reasonable as Maroon a crew makes no sense since they won't learn a thing on what they presumably did wrong, is very often done without any memorable impact and leaves the target often with nothing of value.

Now TAL on the other hand is usually either done loud, messy and puts on a display (i.e. some crazed gunman walking into medbay and shooting up a doctor in public) or with very interesting theatrics (grabbing the target and doing some stuff in maints, kinda using the exploitables some people set). Both memorable, increase round entropy further than just RR a non-command and gives something for the target to do (e.g. traumabonding).

I am aware that this is not the exact thing with the opt-in trait, that unfortunately requires C# and is a bit beyond of what I am currently capable of doing. This simple solution (for now) is proposed considering dev focus is currently full steam ahead for NeoSol station. Its, in my eyes, an okay albeit temporary compromise for now.

## Short description

This PR comments out the "maroon a non-command" objective. It leaves TAL and all the other objectives operational. 
The aim for this is threefold:

- Increase overall RP quality for non-command members by not having to watch a, to them, random person suddenly spike in interest in them only to be met with sudden RR 
- Give incentive for people to put stuff in their exploitables so TAL
- Most importantly: Increase overall round entropy. How? Well Maroon is, from frequent observation, usually done by proxies. Syndicat into quick body grab, using emagged borgs into bodycrusher or the good old sleepypen + micro or gun down + micro. Not very engaging. Minimal impact on the round except it makes one person completely unable to play or do anything with the round itself for character development. 

With Maroon for non-command crew gone the objective selector has a higher probability to roll higher impact objectives. This includes TAL and DAGD as well as the new RP objectives implemented earlier that straight up tell you you can shoot up sci if you want to sabotage them.


## Why we need to add this

Basically an attempt to increase round entropy during traitor and most importantly don't have implausible targets like the Janitor be slated for RR as well as increase overall RP quality and experience of non-command crew without compromising lethality of a round (remember, TAL is still in and can now roll with higher probability than Maroon Crewmember since freed up roll chance so to say).

Other considerations so far, probably unrelated:

Theres a shuttle hijack objective, it is commented out. On SS13 this was a rare version of DAGD, more extreme and directed. I could see that being of interest later on, especially considering hostages can be taken onto the shuttle too.

## Media (Video/Screenshots)
Now with demonstration from Local

<img width="883" height="603" alt="Sample 1" src="https://github.com/user-attachments/assets/5a86e385-f3e1-4db1-b0f9-959e2a992b7e" />

<img width="396" height="527" alt="Sample 2" src="https://github.com/user-attachments/assets/c3a0f048-ca16-40b5-b3b8-77fb8e4b58d6" />

<img width="1579" height="854" alt="Kill and Maroon on somebody with command component" src="https://github.com/user-attachments/assets/f3d8772c-6b29-4dc2-949a-b4a32b83b9ef" />



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Irkalla
- tweak: Maroon on non-command crew cannot roll anymore until C# implementation for a trait can be done. This will increase probability of other objectives to roll, including DAGD, TAL and the new "Disrupt Department X" from a previous PR.
