### PR TITLE
Vulp eyes fix

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Body/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/vulpkanin.yml
@@ -86,7 +86,7 @@
 # Internal
 
 - type: entity
-  parent: [ OrganVulpkaninExternal, OrganHumanEyes ]
+  parent: [ OrganBaseEyes, OrganVulpkaninInternal, OrganVulpkaninExternal ]
   id: OrganVulpkaninEyes
 
 - type: entity

--- a/Resources/Prototypes/_FarHorizons/Body/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/vulpkanin.yml
@@ -86,7 +86,7 @@
 # Internal
 
 - type: entity
-  parent: [ OrganHumanEyes, OrganVulpkaninExternal ]
+  parent: [ OrganVulpkaninExternal, OrganHumanEyes ]
   id: OrganVulpkaninEyes
 
 - type: entity


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Make vulpkanin eyes ACCTUALLY vulp eyes.
(In other words, two pixels)

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Vulps kept have 1x1 pixel eyes (and other wrong cosmetics) in the eye customisation tab, which turned out to be because they straight up had the wrong components tagged on their eyes.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="255" height="295" alt="image" src="https://github.com/user-attachments/assets/df5afa46-5b4d-45d1-9d0a-27ab80af5c21" />
<img width="243" height="297" alt="image" src="https://github.com/user-attachments/assets/00a036a0-dc77-48d3-b2f6-8382384ec98a" />
<img width="233" height="274" alt="image" src="https://github.com/user-attachments/assets/f4b1c27b-b17b-486a-a2c6-255eddb3b352" />
<img width="264" height="302" alt="image" src="https://github.com/user-attachments/assets/10957901-de11-47b0-a48c-6c3ade897cfb" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: LeFop
- fix: Vulps now have the correct eye markings (We have two more pixels now) (Big thanks to Omega)
