### PR TITLE
Its fixin time

### DIFF
--- a/Content.Client/UserInterface/Systems/DamageOverlays/DamageOverlayUiController.cs
+++ b/Content.Client/UserInterface/Systems/DamageOverlays/DamageOverlayUiController.cs
@@ -84,7 +84,10 @@ public sealed class DamageOverlayUiController : UIController
             return;
 
         if (!_mobThresholdSystem.TryGetIncapThreshold(entity, out var foundThreshold, thresholds))
+        {
+            ClearOverlay(); // Far Horizons
             return; //this entity cannot die or crit!!
+        }
 
         if (!thresholds.ShowOverlays)
         {

--- a/Content.Server/_FarHorizons/Zombies/LimbDamageableZombieSystem.cs
+++ b/Content.Server/_FarHorizons/Zombies/LimbDamageableZombieSystem.cs
@@ -1,6 +1,6 @@
 using System.Linq;
+using Content.Server._FarHorizons.Body;
 using Content.Server.Mobs;
-using Content.Shared._FarHorizons.Body;
 using Content.Shared._FarHorizons.LimbDamage;
 using Content.Shared._FarHorizons.LimbDamage.Components;
 using Content.Shared._FarHorizons.Zombies;
@@ -32,7 +32,7 @@ public sealed class LimbDamageableZombieSystem : EntitySystem
 
         SubscribeLocalEvent<LimbDamageableComponent, EntityZombifiedEvent>(OnZombified);
         SubscribeLocalEvent<ZombieHeadComponent, DamageChangedEvent>(OnZombieHeadDamaged);
-        SubscribeLocalEvent<ZombieHeadComponent, OrganGotRemovedEvent>(OnZombieHeadRemoved, before: [ typeof(VitalOrganComponent) ]);
+        SubscribeLocalEvent<ZombieHeadComponent, OrganGotRemovedEvent>(OnZombieHeadRemoved, before: [ typeof(VitalOrganSystem) ]);
     }
 
     private void OnZombified(Entity<LimbDamageableComponent> ent, ref EntityZombifiedEvent args)
@@ -63,6 +63,7 @@ public sealed class LimbDamageableZombieSystem : EntitySystem
 
         _deathgasp.Deathgasp(organ.Body.Value);
         _mobState.ChangeMobState(organ.Body.Value, MobState.Dead);
+        _mobThreshold.MakeZombieDead(organ.Body.Value);
     }
 
     private void OnZombieHeadRemoved(Entity<ZombieHeadComponent> ent, ref OrganGotRemovedEvent args)
@@ -74,5 +75,6 @@ public sealed class LimbDamageableZombieSystem : EntitySystem
 
         _deathgasp.Deathgasp(organ.Body.Value);
         _mobState.ChangeMobState(organ.Body.Value, MobState.Dead);
+        _mobThreshold.MakeZombieDead(organ.Body.Value);
     }
 }

--- a/Content.Shared/EntityConditions/Conditions/Body/MobStateEntityConditionSystem.cs
+++ b/Content.Shared/EntityConditions/Conditions/Body/MobStateEntityConditionSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Mobs;
+﻿using System.Linq;
+using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Robust.Shared.Prototypes;
 
@@ -12,7 +13,7 @@ public sealed partial class MobStateEntityConditionSystem : EntityConditionSyste
 {
     protected override void Condition(Entity<MobStateComponent> entity, ref EntityConditionEvent<MobStateCondition> args)
     {
-        if (entity.Comp.CurrentState == args.Condition.Mobstate)
+        if (args.Condition.Mobstates.Contains(entity.Comp.CurrentState)) // Far Horizons
             args.Result = true;
     }
 }
@@ -21,8 +22,8 @@ public sealed partial class MobStateEntityConditionSystem : EntityConditionSyste
 public sealed partial class MobStateCondition : EntityConditionBase<MobStateCondition>
 {
     [DataField]
-    public MobState Mobstate = MobState.Alive;
+    public List<MobState> Mobstates = new(){ MobState.Alive }; // Far Horizons
 
     public override string EntityConditionGuidebookText(IPrototypeManager prototype) =>
-        Loc.GetString("entity-condition-guidebook-mob-state-condition", ("state", Mobstate));
+        Loc.GetString("entity-condition-guidebook-mob-state-condition", ("state", Mobstates.First()));
 }

--- a/Content.Shared/Mobs/Systems/MobThresholdSystem.FatHorizons.cs
+++ b/Content.Shared/Mobs/Systems/MobThresholdSystem.FatHorizons.cs
@@ -13,4 +13,14 @@ public sealed partial class MobThresholdSystem
         mob.Comp.Thresholds.Add(0, MobState.Alive);
         Dirty(mob);
     }
+
+    public void MakeZombieDead(Entity<MobThresholdsComponent?> mob)
+    {
+        if (!Resolve(mob, ref mob.Comp))
+            return;
+
+        mob.Comp.Thresholds = [];
+        mob.Comp.Thresholds.Add(0, MobState.Dead);
+        Dirty(mob);
+    }
 }

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -781,6 +781,7 @@ namespace Content.Shared.Preferences
             // Track points count for each group.
             var groups = new Dictionary<string, int>();
             var result = new List<ProtoId<TraitPrototype>>();
+            var totalInGroup = new Dictionary<string, int>(); // Far Horizons
 
             foreach (var trait in traits)
             {
@@ -804,6 +805,16 @@ namespace Content.Shared.Preferences
                 // Too expensive.
                 if (existing > category.MaxPoints) // Starlight
                     continue;
+                
+                // Far Horizons start
+                var total = totalInGroup.GetOrNew(category.ID);
+                total += 1;
+
+                if (total > category.MaxTraits)
+                    continue;
+                
+                totalInGroup[category.ID] = total;
+                // Far Horizons end
 
                 groups[category.ID] = existing;
                 result.Add(trait);

--- a/Content.Shared/_FarHorizons/Mobs/SharedActiveCritSystem.cs
+++ b/Content.Shared/_FarHorizons/Mobs/SharedActiveCritSystem.cs
@@ -244,7 +244,7 @@ public abstract partial class SharedActiveCritSystem : EntitySystem
 
     public bool IsBlackout(Entity<ActiveCritComponent?> ent)
     {
-        if (!Resolve(ent, ref ent.Comp) || !_mobState.IsCritical(ent))
+        if (!Resolve(ent, ref ent.Comp, false) || !_mobState.IsCritical(ent))
             return false;
 
         return ent.Comp.Blackout;

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -363,7 +363,9 @@
         conditions:
           # they gotta be in crit first
         - !type:MobStateCondition
-          mobstate: Critical
+          mobstates: # Far Horizons
+            - Critical
+            - ActiveCritical # Far Horizons
         - !type:ReagentCondition
           reagent: Epinephrine
           max: 20
@@ -375,7 +377,9 @@
         conditions:
           # they gotta be in crit first
         - !type:MobStateCondition
-          mobstate: Critical
+          mobstates: # Far Horizons
+            - Critical
+            - ActiveCritical # Far Horizons
         - !type:ReagentCondition
           reagent: Epinephrine
           max: 20
@@ -489,7 +493,9 @@
         conditions:
           # they gotta be in crit first
         - !type:MobStateCondition
-          mobstate: Critical
+          mobstates: # Far Horizons
+            - Critical
+            - ActiveCritical # Far Horizons
         damage:
           types:
             Asphyxiation: -2
@@ -1404,7 +1410,8 @@
           - !type:TemperatureCondition
             max: 150.0
           - !type:MobStateCondition
-            mobstate: Dead
+            mobstates: # Far Horizons
+              - Dead # Far Horizons
 
 - type: reagent
   id: Arcryox

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -190,7 +190,9 @@
       - !type:EvenHealthChange
         conditions:
         - !type:MobStateCondition
-          mobstate: Critical
+          mobstates: # Far Horizons
+            - Critical
+            - ActiveCritical # Far Horizons
         damage: # Doesn't heal poison because if you OD'd I'm not giving you a safety net
           Burn: -0.5
           Brute: -0.5
@@ -198,7 +200,9 @@
       - !type:HealthChange
         conditions:
         - !type:MobStateCondition
-          mobstate: Critical
+          mobstates: # Far Horizons
+            - Critical
+            - ActiveCritical # Far Horizons
         damage:
           types:
             Asphyxiation: -2

--- a/Resources/Prototypes/_Starlight/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Starlight/Reagents/medicine.yml
@@ -122,7 +122,8 @@
           - !type:TemperatureCondition
             max: 213.0
           - !type:MobStateCondition
-            mobstate: Dead
+            mobstates: # Far Horizons
+              - Dead
           damage:
             types:
               Radiation: -5


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
* Chems that work in crit also work in active crit
* Zombies don't revive when they take damage
* Mobs with old crit no longer get console spawned with errors
* Zombies can see after converting from active crit
* Added missing validation for traits

## Why we need to add this
fixes

## Media (Video/Screenshots)
<img width="1083" height="453" alt="image" src="https://github.com/user-attachments/assets/2db74602-d0cb-4a98-8dea-2dcc8655bf13" />


https://github.com/user-attachments/assets/43720c6d-08f5-498d-9e71-3baf46f6f715


https://github.com/user-attachments/assets/c4aa5d00-c468-46b9-93f3-2068773a5975



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- fix: Chems that require critical state will also work in active critical
- fix: Mobs without active critical no longer spam your console with errors
- fix: Zombies stay dead when killed (you don't have to destroy their heads, I swear!)
- fix: Zombies no longer have vision obscuring effects after getting converted from active critical
- fix: Added missing validation for number of selected traits in a category
