### PR TITLE
Making the Concord Liaison's Jumpsuit not Contraband to the Concord Liaison

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -27,7 +27,7 @@
   - type: VentCrawClothing
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseRepresentativesContraband ] # FH
+  parent: [ ClothingUniformBase, BaseCommandContraband ] # FH
   id: MagistrateUniformSuit
   name: Concord Liaison's Jumpsuit #Far Horizons
   components:


### PR DESCRIPTION
## Short description
About a month ago, a bunch of entities had their parents changed from BaseCommandContraband to BaseRepresentativesContraband, so that instead of being contraband to everyone but command, it would be contraband to everyone but the NT Rep and the BSO.

However, there was a little slip, and the CL's Jumpsuit also had its parent changed from BaseCommandContraband to BaseRepresentativesContraband, making it contraband to the CL themselves.

This PR seeks to bring back the CL's Jumpsuit to BaseCommandContraband, like the other pieces of clothing of the CL.

(Also, this is my first PR ever, so feel free to yell at me for messing up)

## Why we need to add this
Mainly consistency, every other piece of clothing of the CL is under BaseCommandContraband, except for the CL's Jumpsuit. 
Also, right now the jumpsuit is considered contraband to the CL, which doesn't really make sense.

## Media (Video/Screenshots)
<img width="402" height="72" alt="Captura de pantalla 2026-05-25 193016" src="https://github.com/user-attachments/assets/b3a9de8a-6916-46d9-9282-008e8137293e" />

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**

:cl: RubiconLocked
- fix: It is no longer illegal for the Concord Liaison to wear their work-issued Jumpsuit.
