### PR TITLE
Small Cleanup of the Crime List

### DIFF
--- a/Resources/ServerInfo/_FarHorizons/Guidebook/ServerRules/SpaceLaw/FHCrimeList.xml
+++ b/Resources/ServerInfo/_FarHorizons/Guidebook/ServerRules/SpaceLaw/FHCrimeList.xml
@@ -852,10 +852,9 @@
         Breach of Custody
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#593a4e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         To break out of a cell or custody with the intention of escaping. This applies to people breaking others out. Repeat offenses may have this charge increased to permanent confinement and later elevated to an execution with the Captain's authority only if the suspect has repeatedly committed breach of custody.
-        
         Breach of custody for the preservation of life, not including to escape execution, such as to vacate a location made dangerous due to gunfire, fire, spacing, or lack of oxygen- may be reduced or ignored at the Warden or Head of Security's discretion.
       </Box>
     </ColorBox>
@@ -973,15 +972,6 @@
     <ColorBox Color="#2e422e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
       	To engage in malicious destructive actions which threaten to destroy or successfully destroy a vessel, habitat, or station. This includes extreme sabotage of station systems or setting off the self-destruction systems.
-      </Box>
-    </ColorBox>
-    <ColorBox>
-      <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-      </Box>
-    </ColorBox>
-    <ColorBox Color="#4d2e2e">
-      <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        
       </Box>
     </ColorBox>
     <ColorBox Color="#4d2e2e">


### PR DESCRIPTION
## Short description
The current crime list has a few minor bugs:
1. There is an empty line in the Extreme Crimes table
2. The description for Breach of Custody in the Table is not colored like it should be.
3. The description for Breach of Custody is broken, and half of it does not appear in the Table.

This PR fixes those issues.

## Why we need to add this
Because it breaks the format of the Crime List.

## Media (Video/Screenshots)
### Current
<img width="578" height="220" alt="Captura de pantalla 2026-05-26 192623" src="https://github.com/user-attachments/assets/e3028d65-ffcf-48c4-b49e-2554ae2076f4" />

<img width="541" height="539" alt="Captura de pantalla 2026-05-26 192608" src="https://github.com/user-attachments/assets/d992dc50-caf6-49a3-9bd8-e8049f4bc7c7" />

### New
<img width="761" height="235" alt="Captura de pantalla 2026-05-26 192238" src="https://github.com/user-attachments/assets/29875200-cbb0-4702-93ef-c4d8fc246e86" />

<img width="761" height="427" alt="Captura de pantalla 2026-05-26 192250" src="https://github.com/user-attachments/assets/74ffcc91-ff02-46d5-a378-0da606b55a81" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

:cl: RubiconLocked
- fix: The CFA has granted us enough budget to buy a sharpie and an eraser, which has allowed us to format the crime list correctly (Duplicated line in Capital Crime List erased, Breach of Custody correctly formatted and colored).

