### PR TITLE
Xenoborgs Minimum Requirement of 80 players, Adjusting Current GamePresets

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -54,6 +54,8 @@
     rules:
     - id: Thief
       prob: 0.5
+    - id: SLChangeling #Far Horizons - Because Xenoborg rounds are now major antag, this is being introduced.
+      prob: 0.4
     - id: SubWizard
       prob: 0.05
 
@@ -64,7 +66,13 @@
   - type: SubGamemodes
     rules:
     - id: Thief
-      prob: 0.5
+    #Far Horizons-Start - This subgamerule is only used in the Wizard gamePreset. Why not add in some other antags so it's not completely quiet?
+      prob: 0.9 
+    - id: SLChangeling 
+      prob: 0.6
+    - id: Traitor
+      prob: 0.6
+    #Far Horizons-End
 
 - type: entity
   parent: BaseGameRule
@@ -467,7 +475,7 @@
   id: Xenoborgs
   components:
   - type: GameRule
-    minPlayers: 30
+    minPlayers: 80 #Far Horizons - This requires a much larger player base and it's not welcome with other major antags going on. -- Original is 30 minimum players.
   - type: AntagMultipleRoleSpawner
     antagRoleToPrototypes:
       MothershipCore: [ MothershipCore ]

--- a/Resources/Prototypes/_FarHorizons/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_FarHorizons/GameRules/roundstart.yml
@@ -1,0 +1,12 @@
+- type: entity
+  parent: BaseGameRule
+  id: SubGamemodesRuleNoChangelingsNoXenoborgs
+  components:
+  - type: SubGamemodes
+    rules:
+    - id: Thief
+      prob: 0.5
+#    - id: Vampire # disabled until reworked
+#      prob: 0.25
+    - id: SubWizard
+      prob: 0.05

--- a/Resources/Prototypes/_FarHorizons/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_FarHorizons/GameRules/roundstart.yml
@@ -1,6 +1,6 @@
 - type: entity
   parent: BaseGameRule
-  id: SubGamemodesRuleNoChangelingsNoXenoborgs
+  id: SubGamemodesRuleNoXenoborgsMaybeTraitorLingx2 #This is being used in TraitorLings gamePreset.
   components:
   - type: SubGamemodes
     rules:
@@ -10,3 +10,7 @@
 #      prob: 0.25
     - id: SubWizard
       prob: 0.05
+    - id: Traitor #TraitorLing gamePreset requires minimum of 50 people. Let's add a small chance to get double amounts.
+      prob: 0.2
+    - id: SLChangeling
+      prob: 0.2

--- a/Resources/Prototypes/_FarHorizons/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_FarHorizons/GameRules/roundstart.yml
@@ -14,3 +14,16 @@
       prob: 0.2
     - id: SLChangeling
       prob: 0.2
+
+- type: entity
+  parent: BaseGameRule
+  id: SubGamemodesRuleNoChangelingsNoXenoborgs #This is being used in Traitor gamePreset.
+  components:
+  - type: SubGamemodes
+    rules:
+    - id: Thief
+      prob: 0.5
+#    - id: Vampire # disabled until reworked
+#      prob: 0.25
+    - id: SubWizard
+      prob: 0.05

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -327,7 +327,7 @@
   rules:
     - SLChangeling #Starlight
     - Traitor
-    - SubGamemodesRuleNoChangelingsNoXenoborgs #Far Horizons - Xenoborgs are now a major antag. No more including in this.
+    - SubGamemodesRuleNoXenoborgsMaybeTraitorLingx2 #Far Horizons - Xenoborgs are now a major antag. No more including in this.
     - BasicStationEventScheduler
     - BasicRoundstartVariation
 

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -157,7 +157,7 @@
   rules:
   # - DummyNonAntagChance 🌟Starlight🌟
   - Traitor
-  - SubGamemodesRuleNoChangelings #Starlight
+  - SubGamemodesRuleNoChangelingsNoXenoborgs #Far Horizons - Fuck off Xenoborgs.
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
@@ -189,7 +189,7 @@
   rules:
   - Nukeops
   # - DummyNonAntagChance 🌟Starlight🌟
-  - SubGamemodesRule
+  - SubGamemodesRuleNoXenoborg #Far Horizons - Xenoborgs are now turning into a major antag, no more nukeops/xenoborg combo.
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
@@ -208,7 +208,7 @@
   rules:
   # - DummyNonAntagChance 🌟Starlight🌟
   - Revolutionary
-  - SubGamemodesRule
+  - SubGamemodesRuleNoXenoborg #Far Horizons - Xenoborgs are now turning into a major antag, no more rev/xenoborg combo.
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
@@ -224,7 +224,7 @@
   rules:
   - Wizard
   # - DummyNonAntagChance 🌟Starlight🌟
-  - SubGamemodesRuleNoWizard #No Dual Wizards at the start, midround is fine
+  - SubGamemodesRuleNoWizardNoXenoborg #No Dual Wizards at the start, midround is fine -- #Far Horizons - Also fuck off Xenoborgs.
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
@@ -240,7 +240,7 @@
   rules:
   - Xenoborgs
   # - DummyNonAntagChance 🌟Starlight🌟
-  - SubGamemodesRuleNoWizardNoXenoborg # no two motherships
+  - SubGamemodesRuleNoXenoborg # no two motherships - #Far Horizons - I enabled Wizards to spawn on Xenoborgs, because why the fuck not?
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
@@ -311,7 +311,7 @@
   showInVote: false
   rules:
     - SLChangeling #Starlight
-    - SubGamemodesRule
+    - SubGamemodesRuleNoXenoborg #Far Horizons - Xenoborgs are now a major antag. No more including in this.
     - BasicStationEventScheduler
     - BasicRoundstartVariation
 
@@ -327,7 +327,7 @@
   rules:
     - SLChangeling #Starlight
     - Traitor
-    - SubGamemodesRuleNoChangelings #Starlight
+    - SubGamemodesRuleNoChangelingsNoXenoborgs #Far Horizons - Xenoborgs are now a major antag. No more including in this.
     - BasicStationEventScheduler
     - BasicRoundstartVariation
 
@@ -359,7 +359,7 @@
     - DerelictGenericCyborgSpawn
     - BasicStationEventScheduler
     - MeteorSwarmMildScheduler
-    - SubGamemodesRuleNoChangelings #Far Horizons
+    - SubGamemodesRuleNoXenoborg #Far Horizons - Changed from no extra changelings to no Xenoborgs. Would rather more changelings than xenoborgs.
     - IonStorm
     - CockroachMigration
     - MouseMigration

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -11,9 +11,9 @@
     Revolutionary: 0.10
     #Vampire: 0.15 #SL
     Wizard: 0.10
-    Traitorling: 0.10 #SL
+    Traitorling: 0.15 #Far Horizons - Increased this for decreased Xenoborgs
     ShitStation: 0.10 #SL
-    Xenoborgs: 0.15 #SL
+    Xenoborgs: 0.10 #Far Horizons - Decreased chance of this happening, increased traitorling
 
 - type: weightedRandom #FH - Adds to 100. God. Why was it in decimals..
   id: SecretLP


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
The original purpose was to adjust Xenoborgs to be a major antag instead of a minor antag that is used in subgamerules.
Now they are considered a major antag. They have a minimum of 80 players and don't get included in anything else except for their own gamemode.

Along the way I modified a lot of the "Sub Game Modes" because things were too quiet, or were missing stuff, etc.

List of changes:

Traitor: No more xenoborgs
Nukeops: No more xenoborgs, added changeling chance for chaos
Revolutionary: No more xenoborgs, added changeling chance for chaos
Wizard (Did you realize this was a gamemode? I didn't): No xenoborgs, increased chance for thieves, added high chance for Changelings and Traitors.
**Xenoborgs**: Only available with 80+ players, wizards now have a chance to spawn because why not.
Changeling: No xenoborgs.
TraitorLing: No xenoborgs, to be less quiet I gave small chance to double traitors and lings.
ShitStation: No xenoborgs, chance for extra lings.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The amount of suggestions and player feedback about how much they hate the Xenoborg gamemode has led Leadership in wanting to do something with it. Without completely removing it, we made it for only a server population of 80+.

And on top of that when the few traitors/changelings did end up doing their tasks the server ended up being way too quiet, almost like it was a greenshift. WELL NO MORE.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
# For the first time ever, I don't have much in terms of media. I can't show number changes for stuff....

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: CorruptOmega
- tweak: Xenoborgs will no longer notice small stations in the sector. At least 80 crew members are required to get on their scanners.
- tweak: The Far Horizons have gotten a little more dangerous without the military in the sector. Increased amounts of antagonistic forces in the area.
