### PR TITLE
Minor Spelling Mistakes in the Crime List

### DIFF
--- a/Resources/ServerInfo/_FarHorizons/Guidebook/ServerRules/SpaceLaw/FHCrimeList.xml
+++ b/Resources/ServerInfo/_FarHorizons/Guidebook/ServerRules/SpaceLaw/FHCrimeList.xml
@@ -866,7 +866,7 @@
     <ColorBox Color="#2f3832">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         To make, hold, or use Significant Syndicate contraband. Significant Syndicate contraband may only be used in emergencies, and only to prevent death or gross bodily harm.
-        *Significant Syndicate contraband is any Syndicate contraband that can be used to hinder the station or aid it's enemies in an obvious way. Any syndicate contraband that does not meet this definition is to be considered minor contraband.*
+        *Significant Syndicate contraband is any Syndicate contraband that can be used to hinder the station or aid its enemies in an obvious way. Any syndicate contraband that does not meet this definition is to be considered minor contraband.*
       </Box>
     </ColorBox>
     <ColorBox>
@@ -991,7 +991,7 @@
     </ColorBox>
     <ColorBox Color="#4d2e2e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        To kill three or more sentient humanoid with malicious intent. Only applies when there have been multiple killings with intention.
+        To kill three or more sentient humanoids with malicious intent. Only applies when there have been multiple killings with intention.
       </Box>
     </ColorBox>
     <ColorBox Color="#475c7d">


### PR DESCRIPTION
## Short description
After my last PR, I have been rereading the Crime list in search of an excuse to make another PR, and I found two extremely minor spelling mistakes. So here we are.

## Why we need to add this
For proper spelling.

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**

:cl: RubiconLocked
- fix: Corrected two minor spelling mistakes in the Crime List.
