### PR TITLE
Protogen Marking Loc Fix

### DIFF
--- a/Resources/Locale/en-US/_FarHorizons/markings/protogen_markings.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/markings/protogen_markings.ftl
@@ -1,108 +1,187 @@
-marking-ProtogenTailShark = shark tail
-marking-ProtogenTailBushy = bushy tail
-marking-ProtogenTail = tail
+marking-ProtogenTailShark = Shark Tail
+marking-ProtogenTailShark-shark_tail_protogen = Shark Tail
+marking-ProtogenTailBushy = Bushy Tail
+marking-ProtogenTailBushy-bushy_tail_protogen = Bushy Tail
+marking-ProtogenTail = Tail
+marking-ProtogenTail-tail_protogen = Tail
 
-marking-ProtogenEars = four protogen ears
-marking-ProtogenEarsTips = four protogen ears (tips)
-marking-TwoProtogenEars = two protogen ears
+marking-ProtogenEars = Four Protogen Ears
+marking-ProtogenEars-ears_protogen = Four Protogen Ears
+marking-ProtogenEarsTips = Four Protogen Ears (Tips)
+marking-ProtogenEarsTips-ears_protogen_tips = Four Protogen Ears (Tips)
+marking-TwoProtogenEars = Two Protogen Ears
+marking-TwoProtogenEars-two_ears_protogen = Two Protogen Ears
 
 marking-ProtogenLights = Circular LEDs
+marking-ProtogenLights-body = Circular LEDs
 marking-ProtogenVisor = Protogen Visor
+marking-ProtogenVisor-visor = Protogen Visor
 marking-ProtogenLEDFace = Default Protogen LEDs
+marking-ProtogenLEDFace-face = Default Protogen LEDs
 marking-ProtogenLEDFaceNoseless = Noseless LEDs
+marking-ProtogenLEDFaceNoseless-noseless = Noseless LEDs
 marking-ProtogenVisorRound = Round Visor
+marking-ProtogenVisorRound-rounded = Round Visor
 marking-ProtogenLEDFaceRound = Round LEDs
+marking-ProtogenLEDFaceRound-rounded = Round LEDs
 
 marking-ProtogenMediumArmor = Standard Protogen Cybernetics
+marking-ProtogenMediumArmor-medium = Standard Protogen Cybernetics
 
 marking-ProtoVulpPawSocksFeet = Paw Socks (Feet)
+marking-ProtoVulpPawSocksFeet-pawsocks_feet = Paw Socks (Feet)
 marking-ProtoVulpPawSocksLegs = Paw Socks (Legs)
+marking-ProtoVulpPawSocksLegs-pawsocks_legs = Paw Socks (Legs)
 
 marking-ProtoVulpLights = Circular LEDs
+marking-ProtoVulpLights-body = Circular LEDs
 marking-ProtoVulpLightsAngled = Angled LEDs
+marking-ProtoVulpLightsAngled-bodyangled = Angled LEDs
+marking-ProtoVulpLightsAngled-bodyangled_inner = Angled LEDs
 marking-ProtoVulpVisor = Vulpine/Reptile Visor
+marking-ProtoVulpVisor-vulpvisor = Vulpine/Reptile Visor
 marking-ProtoVulpLEDFace = Default Vulpine LEDs
+marking-ProtoVulpLEDFace-face = Default Vulpine LEDs
 marking-ProtoVulpVisorFourEyes = Large Vulpine Visor
+marking-ProtoVulpVisorFourEyes-vulpvisor-four-eyes = Large Vulpine Visor
 marking-ProtoVulpLEDFaceFourEyes = Four-eyes Vulpine LEDs
+marking-ProtoVulpLEDFaceFourEyes-four-eyes = Four-eyes Vulpine LEDs
 marking-ProtoVulpSnoutLong = Long Vulpine Visor
+marking-ProtoVulpSnoutLong-snout = Long Vulpine Visor
 marking-ProtoVulpLEDFaceLong = Long Vulpine LEDs
+marking-ProtoVulpLEDFaceLong-long = Long Vulpine LEDs
 
 marking-ProtoVulpClaws = Vulpine Claws
+marking-ProtoVulpClaws-claws = Vulpine Claws
 marking-ProtoVulpClawsLong = Long Vulpine Claws
+marking-ProtoVulpClawsLong-clawslong = Long Vulpine Claws
 marking-ProtoVulpVisorSideWings = Side Visor Wings
+marking-ProtoVulpVisorSideWings-side-visor-wings = Side Visor Wings
 
 marking-ProtoVulpMediumArmor = Standard Protogen-Vulpine Cybernetics
+marking-ProtoVulpMediumArmor-medium = Standard Protogen-Vulpine Cybernetics
 marking-ProtoVulpMediumArmorAngled = Angled Standard Protogen-Vulpine Cybernetics
+marking-ProtoVulpMediumArmorAngled-mediumangled = Angled Standard Protogen-Vulpine Cybernetics
 
 marking-ProtoVoxVisor = Vox Visor
+marking-ProtoVoxVisor-visor = Vox Visor
 marking-ProtoVoxLEDFace = Default Vox LEDs
+marking-ProtoVoxLEDFace-face = Default Vox LEDs
 marking-ProtoVoxLights = Circular LEDs
+marking-ProtoVoxLights-body = Circular LEDs
 marking-ProtoVoxClaws = Long Vox Claws
+marking-ProtoVoxClaws-claws = Long Vox Claws
 
 marking-ProtoVoxMediumArmor = Standard Protogen-Vox Cybernetics
+marking-ProtoVoxMediumArmor-medium = Standard Protogen-Vox Cybernetics
 
 marking-ProtoThavenVisor = Thaven Visor
+marking-ProtoThavenVisor-visor = Thaven Visor
 marking-ProtoThavenLEDFace = Default Thaven LEDs
+marking-ProtoThavenLEDFace-face = Default Thaven LEDs
 marking-ProtoThavenLights = Circular LEDs
+marking-ProtoThavenLights-body = Circular LEDs
 
 marking-ProtoThavenMediumArmor = Standard Protogen-Thaven Cybernetics
+marking-ProtoThavenMediumArmor-medium = Standard Protogen-Thaven Cybernetics
 
 marking-ProtoSlimePersonVisor = Laspii Visor
+marking-ProtoSlimePersonVisor-visor = Laspii Visor
 marking-ProtoSlimePersonLEDFace = Default Laspii LEDs
+marking-ProtoSlimePersonLEDFace-face = Default Laspii LEDs
 marking-ProtoSlimePersonLights = Circular LEDs
+marking-ProtoSlimePersonLights-body = Circular LEDs
 
 marking-ProtoSlimePersonMediumArmor = Standard Protogen-Laspii Cybernetics
+marking-ProtoSlimePersonMediumArmor-medium = Standard Protogen-Laspii Cybernetics
 
 marking-ProtoKinVisor = Kin Visor
+marking-ProtoKinVisor-visor = Kin Visor
 marking-ProtoKinLEDFace = Default Kin LEDs
+marking-ProtoKinLEDFace-face = Default Kin LEDs
 marking-ProtoKinLights = Circular LEDs
+marking-ProtoKinLights-body = Circular LEDs
 
 marking-ProtoKinMediumArmor = Standard Protogen-Kin Cybernetics
+marking-ProtoKinMediumArmor-medium = Standard Protogen-Kin Cybernetics
 
 marking-ProtoResomiVisor = Resomi Visor
+marking-ProtoResomiVisor-visor = Resomi Visor
 marking-ProtoResomiLEDFace = Default Resomi LEDs
+marking-ProtoResomiLEDFace-face = Default Resomi LEDs
 marking-ProtoResomiLights = Circular LEDs
+marking-ProtoResomiLights-body = Circular LEDs
 
 marking-ProtoResomiMediumArmor = Standard Protogen-Resomi Cybernetics
+marking-ProtoResomiMediumArmor-medium = Standard Protogen-Resomi Cybernetics
 
 marking-ProtoReptileLEDFaceBoxy = Default Reptile LEDs
+marking-ProtoReptileLEDFaceBoxy-boxy = Default Reptile LEDs
 marking-ProtoReptileClaws = Long Reptile Claws
+marking-ProtoReptileClaws-claws = Long Reptile Claws
 
 marking-ProtoReptileMediumArmor = Standard Protogen-Reptile Cybernetics
+marking-ProtoReptileMediumArmor-medium = Standard Protogen-Reptile Cybernetics
 
 marking-ProtoMothVisor = Moth Visor
+marking-ProtoMothVisor-visor = Moth Visor
 marking-ProtoMothLEDFace = Default Moth LEDs
+marking-ProtoMothLEDFace-face = Default Moth LEDs
 marking-ProtoMothLights = Circular LEDs
+marking-ProtoMothLights-body = Circular LEDs
 marking-ProtoMothClaws = Long Moth Claws
+marking-ProtoMothClaws-claws = Long Moth Claws
 
 marking-ProtoMothMediumArmor = Standard Protogen-Moth Cybernetics
+marking-ProtoMothMediumArmor-medium = Standard Protogen-Moth Cybernetics
 
 marking-ProtoFelineVisor = Feline Visor
+marking-ProtoFelineVisor-visor = Feline Visor
 marking-ProtoFelineLEDFace = Default Feline LEDs
+marking-ProtoFelineLEDFace-face = Default Feline LEDs
 marking-ProtoFelineLights = Circular LEDs
+marking-ProtoFelineLights-body = Circular LEDs
 marking-ProtoFelineClaws = Long Feline Claws
+marking-ProtoFelineClaws-claws = Long Feline Claws
 
 marking-ProtoFelineMediumArmor = Standard Protogen-Feline Cybernetics
+marking-ProtoFelineMediumArmor-medium = Standard Protogen-Feline Cybernetics
 
 marking-ProtoDionaeVisor = Dionae Visor
+marking-ProtoDionaeVisor-visor = Dionae Visor
 marking-ProtoDionaeLEDFace = Default Dionae LEDs
+marking-ProtoDionaeLEDFace-face = Default Dionae LEDs
 marking-ProtoDionaeLights = Circular LEDs
+marking-ProtoDionaeLights-body = Circular LEDs
 marking-ProtoDionaeVines = Long Dionae Vines
+marking-ProtoDionaeVines-vines = Long Dionae Vines
 
 marking-ProtoDionaeMediumArmor = Standard Protogen-Dionae Cybernetics
+marking-ProtoDionaeMediumArmor-medium = Standard Protogen-Dionae Cybernetics
 
 marking-ProtoCyclopsVisor = Cyclops Visor
+marking-ProtoCyclopsVisor-visor = Cyclops Visor
 marking-ProtoCyclopsLEDFace = Default Cyclops LEDs
+marking-ProtoCyclopsLEDFace-face = Default Cyclops LEDs
 marking-ProtoCyclopsLights = Circular LEDs
+marking-ProtoCyclopsLights-body = Circular LEDs
 
 marking-ProtoCyclopsMediumArmor = Standard Protogen-Cyclops Cybernetics
+marking-ProtoCyclopsMediumArmor-medium = Standard Protogen-Cyclops Cybernetics
 
 marking-ProtoAvaliVisor = Avali Visor
+marking-ProtoAvaliVisor-visor = Avali Visor
 marking-ProtoAvaliLEDFace = Default Avali LEDs
+marking-ProtoAvaliLEDFace-face = Default Avali LEDs
 marking-ProtoAvaliLights = Circular LEDs
+marking-ProtoAvaliLights-body = Circular LEDs
 marking-ProtoAvaliWings = Hardlight Avali Wings
+marking-ProtoAvaliWings-wings = Hardlight Avali Wings
 
 marking-ProtoAvaliMediumArmor = Standard Protogen-Avali Cybernetics
+marking-ProtoAvaliMediumArmor-medium = Standard Protogen-Avali Cybernetics
 
 marking-ProtoArachnidVisor = Arachnid Visor
+marking-ProtoArachnidVisor-visor = Arachnid Visor
 marking-ProtoArachnidLEDFace = Default Arachnid LEDs
+marking-ProtoArachnidLEDFace-face = Default Arachnid LEDs

--- a/Resources/Locale/en-US/_FarHorizons/markings/protogen_markings.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/markings/protogen_markings.ftl
@@ -7,8 +7,7 @@ marking-ProtogenTail-tail_protogen = Tail
 
 marking-ProtogenEars = Four Protogen Ears
 marking-ProtogenEars-ears_protogen = Four Protogen Ears
-marking-ProtogenEarsTips = Four Protogen Ears (Tips)
-marking-ProtogenEarsTips-ears_protogen_tips = Four Protogen Ears (Tips)
+marking-ProtogenEars-ears_protogen_tips = Four Protogen Ears (Tips)
 marking-TwoProtogenEars = Two Protogen Ears
 marking-TwoProtogenEars-two_ears_protogen = Two Protogen Ears
 


### PR DESCRIPTION
## Short description
Fixes missing protogen marking loc.

## Why we need to add this
I had to fix it over on Starlight, and saw it was broken here too, so I'm sharing my fixes.

## Media (Video/Screenshots)
<img width="591" height="414" alt="image" src="https://github.com/user-attachments/assets/4a528841-a7df-4b00-ac3d-7c3ea248ffb9" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).


**Changelog**
:cl: wonderfulnewworld
- fix: Protogen markings now have proper localization.
