### PR TITLE
Add a high value target trait

### DIFF
--- a/Content.Shared/_FarHorizons/Traits/Components/HighValueTargetComponent.cs
+++ b/Content.Shared/_FarHorizons/Traits/Components/HighValueTargetComponent.cs
@@ -1,0 +1,6 @@
+namespace Content.Shared._FarHorizons.Traits.Components;
+
+[RegisterComponent]
+public sealed partial class HighValueTargetComponent : Component
+{
+}

--- a/Resources/Locale/en-US/_FarHorizons/traits/quirks.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/traits/quirks.ftl
@@ -1,0 +1,2 @@
+trait-high-value-target-name = High-value target
+trait-high-value-target-desc = For one reason or another you are considered a high-value target by various organizations. It could be that you wronged the wrong person or were at the wrong place at the right time, perhaps the right place at the wrong time too.. Occassionally traitorous elements will seek to maroon and obliterate you.

--- a/Resources/Locale/en-US/_FarHorizons/traits/quirks.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/traits/quirks.ftl
@@ -1,2 +1,2 @@
-trait-high-value-target-name = High-value target
+trait-high-value-target-name = High-Value Target
 trait-high-value-target-desc = For one reason or another you are considered a high-value target by various organizations. It could be that you wronged the wrong person or were at the wrong place at the right time, perhaps the right place at the wrong time too.. Occassionally traitorous elements will seek to maroon and obliterate you.

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -123,6 +123,7 @@
       whitelist:
         components:
         - CommandStaff
+        - HighValueTarget
     # Can't have multiple objectives to kill the same person.
     - !type:TargetObjectiveMindFilter
       blacklist:

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -123,7 +123,7 @@
       whitelist:
         components:
         - CommandStaff
-        - HighValueTarget
+        - HighValueTarget #FH
     # Can't have multiple objectives to kill the same person.
     - !type:TargetObjectiveMindFilter
       blacklist:

--- a/Resources/Prototypes/_FarHorizons/Traits/quirks.yml
+++ b/Resources/Prototypes/_FarHorizons/Traits/quirks.yml
@@ -1,0 +1,10 @@
+- type: trait
+  id: HighValueTarget
+  name: trait-high-value-target-name
+  description: trait-high-value-target-desc
+  category: Quirks
+  cost: 0
+  effects:
+    - !type:AddCompsEffect
+      components:
+        - type: HighValueTarget


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This is a follow up PR for the removal of RR objectives from traitor's against targets that are command. This PR adds a new trait that allows players to opt-in to be a high value target. As of now this trait provides no benefits, only a negative, this is mostly because as of now i cant really think of a good enough benefit for this. The current trait system needs a bit of a rework to allow giving trait points to categories other than the trait is in.

## Why we need to add this
I think it is a good flavor for people to decide to pick for themselves, even without any benefits i see this as something people could take just for the increased RP value.

Similarly other Quirks also don't provide any real benefits.

## Media (Video/Screenshots)
<img width="814" height="431" alt="image" src="https://github.com/user-attachments/assets/2f83de3b-d5bb-42e7-9305-903d3e7ba106" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- add: Added High-value target trait.
