### PR TITLE
Turnstile Construction Recipe Category Fix

### DIFF
--- a/Resources/Locale/en-US/_FarHorizons/construction/recipes/structures.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/construction/recipes/structures.ftl
@@ -35,3 +35,4 @@ construction-recipe-airlock-glass-shuttle-fh = Glass Shuttle Airlock
 construction-recipe-plastic-flaps-clear-fh = Plastic Flaps (Clear)
 construction-recipe-plastic-flaps-opaque-fh = Plastic Flaps (Opaque)
 recipes-secret-door-name-fh = Secret Door
+construction-recipe-turnstile-fh = Turnstile

--- a/Resources/Prototypes/Entities/Structures/Doors/turnstile.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/turnstile.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: Turnstile
   parent: BaseStructure
-  name: turnstile
+  name: Turnstile #FH - The Capitalization Fight Continues
   description: A mechanical door that permits one-way access and prevents tailgating.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -630,7 +630,7 @@
   graph: Turnstile
   startNode: start
   targetNode: turnstile
-  category: construction-category-structures-fh #Far Horizons - The Great Capitalization Crusade
+  category: construction-category-structures
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: false

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -627,6 +627,7 @@
 
 - type: construction
   id: Turnstile
+  name: construction-recipe-turnstile-fh
   graph: Turnstile
   startNode: start
   targetNode: turnstile

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -627,7 +627,7 @@
 
 - type: construction
   id: Turnstile
-  name: construction-recipe-turnstile-fh
+  name: construction-recipe-turnstile-fh # Far Horizons - The Capitalization Fight Continues
   graph: Turnstile
   startNode: start
   targetNode: turnstile


### PR DESCRIPTION
## Short description
The full thing is [here](https://discord.com/channels/1407077238876147783/1511042120776028332), but TLDR, the turnstile's construction recipe is in its own category, category which doesn't have a locale, and as far as I can tell, was an oversight.

This PR moves the turnstile back to its original category.

Edit: This PR also now capitalises Turnstile.

## Why we need to add this
So the turnstile doesn't stand on its own locale-less category by itself.

## Media (Video/Screenshots)

<img width="562" height="452" alt="Captura de pantalla 2026-06-03 232134" src="https://github.com/user-attachments/assets/b5dab56d-aa7b-431f-8392-0d96d9d4e52d" />
<img width="348" height="401" alt="Captura de pantalla 2026-06-03 232207" src="https://github.com/user-attachments/assets/ab0b89a1-fefe-49b4-8a96-3dd5ac8e499c" />

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

:cl: RubiconLocked
- fix: The turnstile construction recipe has been added back to the "Structures" category, instead of standing on its own category. Also, it is now correctly capitalized.
