### PR TITLE
A few fixes

### DIFF
--- a/Content.Server/Mobs/DeathgaspSystem.cs
+++ b/Content.Server/Mobs/DeathgaspSystem.cs
@@ -21,7 +21,8 @@ public sealed class DeathgaspSystem: EntitySystem
     private void OnMobStateChanged(EntityUid uid, DeathgaspComponent component, MobStateChangedEvent args)
     {
         // don't deathgasp if they arent going straight from crit to dead
-        if (args.NewMobState != MobState.Dead || args.OldMobState != MobState.Critical)
+        List<MobState> critStates = [MobState.Critical, MobState.ActiveCritical]; // Far Horizons
+        if (args.NewMobState != MobState.Dead || !critStates.Contains(args.OldMobState))
             return;
 
         Deathgasp(uid, component);

--- a/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
+++ b/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
@@ -23,6 +23,7 @@ using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Utility;
 using Content.Shared._FarHorizons.Factions;
 using Content.Server._FarHorizons.Factions;
+using Content.Shared._CD.Records;
 using Content.Shared._Starlight.Traits;
 using Content.Shared.Starlight.TextToSpeech; // Far Horizons edit
 
@@ -241,6 +242,36 @@ namespace Content.Server.Preferences.Managers
             }
             else
                 siliconSymspeech = null;
+
+            PlayerProvidedCharacterRecords? cdProfile = null;
+            if (profile.CDProfile is { CharacterRecords: not null })
+            {
+                cdProfile = profile.CDProfile!.CharacterRecords.Deserialize<PlayerProvidedCharacterRecords>();
+
+                var medicalEntries = profile.CDProfile!.CharacterRecordEntries
+                    .Where(p => p.Type == CDModel.DbRecordEntryType.Medical).Select(p =>
+                        new PlayerProvidedCharacterRecords.RecordEntry(p.Title, p.Involved, p.Description)).ToList();
+                if (medicalEntries.Count > 0)
+                    cdProfile = cdProfile?.WithMedicalEntries(medicalEntries);
+
+                var secEntries = profile.CDProfile!.CharacterRecordEntries
+                    .Where(p => p.Type == CDModel.DbRecordEntryType.Security).Select(p =>
+                        new PlayerProvidedCharacterRecords.RecordEntry(p.Title, p.Involved, p.Description)).ToList();
+                if (secEntries.Count > 0)
+                    cdProfile = cdProfile?.WithSecurityEntries(secEntries);
+
+                var employmentEntries = profile.CDProfile!.CharacterRecordEntries
+                    .Where(p => p.Type == CDModel.DbRecordEntryType.Employment).Select(p =>
+                        new PlayerProvidedCharacterRecords.RecordEntry(p.Title, p.Involved, p.Description)).ToList();
+                if (employmentEntries.Count > 0)
+                    cdProfile = cdProfile?.WithEmploymentEntries(employmentEntries);
+
+                var adminEntries = profile.CDProfile!.CharacterRecordEntries
+                    .Where(p => p.Type == CDModel.DbRecordEntryType.Admin).Select(p =>
+                        new PlayerProvidedCharacterRecords.RecordEntry(p.Title, p.Involved, p.Description)).ToList();
+                if (adminEntries.Count > 0)
+                    cdProfile = cdProfile?.WithAdminEntries(adminEntries);
+            }
             // Far Horizons end
             
             return new HumanoidCharacterProfile(
@@ -274,7 +305,8 @@ namespace Content.Server.Preferences.Managers
                 loadouts,
                 profile.StarLightProfile?.CyberneticIds ?? [], // Starlight
                 profile.Enabled,
-                speciesLoadout // Far Horizons
+                speciesLoadout, // Far Horizons
+                cdProfile // Far Horizons
             );
         }
 

--- a/Content.Server/_FarHorizons/Tools/HandheldRadio/HandheldRadioSystem.cs
+++ b/Content.Server/_FarHorizons/Tools/HandheldRadio/HandheldRadioSystem.cs
@@ -157,7 +157,8 @@ public sealed class HandheldRadioSystem : EntitySystem
             HasComp<HandheldRadioComponent>(args.Source) ||
             !TryComp(args.Source, out TransformComponent? source_tf) ||
             !TryComp(ent, out TransformComponent? target_tf) ||
-            !_interaction.InRangeUnobstructed((args.Source, source_tf), (ent, target_tf), ent.Comp.MicListeningRange))
+            !_interaction.InRangeUnobstructed((args.Source, source_tf), (ent, target_tf), ent.Comp.MicListeningRange) ||
+            !_language.GetLanguage(args.Source).SpeechOverride.AllowRadio)
                 args.Cancel();
     }
 
@@ -186,7 +187,10 @@ public sealed class HandheldRadioSystem : EntitySystem
             if (senderTf.MapID != targetTf.MapID && !targetRadio.Comp.RecievesFromAnyMap)
                 continue;
             
-            var name = Loc.GetString("speech-name-relay", ("speaker", Name(radio)), ("originalName", Name(source)));
+            var nameEv = new TransformSpeakerNameEvent(source, Name(source));
+            RaiseLocalEvent(source, nameEv);
+            
+            var name = Loc.GetString("speech-name-relay", ("speaker", Name(targetRadio)), ("originalName", nameEv.VoiceName));
             LanguagePrototype? language = null;
             if (TryComp(source, out LanguageSpeakerComponent? sourceLang))
                 language = _language.GetLanguage((source, sourceLang));

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -146,7 +146,9 @@ namespace Content.Shared.Preferences
             Dictionary<string, RoleLoadout> loadouts,
             List<string> cybernetics, // Starlight
             bool enabled,
-            RoleLoadout? speciesLoadout) // Far Horizons
+            RoleLoadout? speciesLoadout, // Far Horizons
+            PlayerProvidedCharacterRecords? cdCharacterRecords = null // Far Horizons
+            )
         {
             Name = name;
             Symspeech = symspeech;
@@ -171,6 +173,7 @@ namespace Content.Shared.Preferences
             Cybernetics = cybernetics; // Starlight
             Enabled = enabled;
             SpeciesLoadout = speciesLoadout;
+            CDCharacterRecords = cdCharacterRecords ?? PlayerProvidedCharacterRecords.DefaultRecords(); // Far Horizons
         }
 
         /// <summary>Copy constructor</summary>
@@ -197,15 +200,9 @@ namespace Content.Shared.Preferences
                 new Dictionary<string, RoleLoadout>(other.Loadouts),
                 other.Cybernetics, // Starlight
                 other.Enabled,
-                other.SpeciesLoadout) // Far Horizons
-        {
-            // Cosmatic Drift Record System-start
-            CDCharacterRecords = other.CDCharacterRecords != null
-                ? new PlayerProvidedCharacterRecords(other.CDCharacterRecords)
-                : PlayerProvidedCharacterRecords.DefaultRecords();
-            CDCharacterRecords.EnsureValid();
-            // Cosmatic Drift Record System-end
-        }
+                other.SpeciesLoadout, // Far Horizons
+                other.CDCharacterRecords // Far Horizons
+                ) { }
 
         /// <summary>
         ///     Get the default humanoid character profile, using internal constant values.

--- a/Content.Shared/_CD/Records/PlayerProvidedCharacterRecords.cs
+++ b/Content.Shared/_CD/Records/PlayerProvidedCharacterRecords.cs
@@ -1,10 +1,7 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Text.Json.Serialization;
 using Content.Shared.Humanoid.Prototypes;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
@@ -25,16 +22,14 @@ public sealed partial class PlayerProvidedCharacterRecords
 
     // Additional data is fetched from the profile itself (name, age, etc.)
 
-    [DataField]
-    public int Height { get; private set; }
-    public const int MaxHeight = 800;
-
-    [DataField]
-    public int Weight { get; private set; }
-    public const int MaxWeight = 300;
-
     // Far Horizons start
     // Changed accessibility of all these fields so they can actually be parsed
+    [DataField, JsonIgnore] public int Height { get; private set; } = 164;
+    public const int MaxHeight = 800;
+
+    [DataField, JsonIgnore] public int Weight { get; private set; } = 74;
+    public const int MaxWeight = 300;
+
     [DataField] public string EmergencyContactName { get; set; } = "";
 
     // Employment

--- a/Content.Shared/_CD/Records/PlayerProvidedCharacterRecords.cs
+++ b/Content.Shared/_CD/Records/PlayerProvidedCharacterRecords.cs
@@ -33,34 +33,27 @@ public sealed partial class PlayerProvidedCharacterRecords
     public int Weight { get; private set; }
     public const int MaxWeight = 300;
 
-    [DataField]
-    public string EmergencyContactName { get; private set; }
+    // Far Horizons start
+    // Changed accessibility of all these fields so they can actually be parsed
+    [DataField] public string EmergencyContactName { get; set; } = "";
 
     // Employment
-    [DataField]
-    public bool HasWorkAuthorization { get; private set; }
+    [DataField] public bool HasWorkAuthorization { get; set; } = true;
 
     // Security
-    [DataField]
-    public string IdentifyingFeatures { get; private set; }
+    [DataField] public string IdentifyingFeatures { get; set; } = "";
 
     // Medical
-    [DataField]
-    public string Allergies { get; private set; }
-    [DataField]
-    public string DrugAllergies { get; private set; }
-    [DataField]
-    public string PostmortemInstructions { get; private set; }
+    [DataField] public string Allergies { get; set; } = "None";
+    [DataField] public string DrugAllergies { get; set; } = "None";
+    [DataField] public string PostmortemInstructions { get; set; } = "Return home";
 
     // Incidents / free-form entries
-    [DataField, JsonIgnore]
-    public List<RecordEntry> MedicalEntries { get; private set; }
-    [DataField, JsonIgnore]
-    public List<RecordEntry> SecurityEntries { get; private set; }
-    [DataField, JsonIgnore]
-    public List<RecordEntry> EmploymentEntries { get; private set; }
-    [DataField, JsonIgnore]
-    public List<RecordEntry> AdminEntries { get; private set; }
+    [DataField, JsonIgnore] public List<RecordEntry> MedicalEntries { get; private set; } = [];
+    [DataField, JsonIgnore] public List<RecordEntry> SecurityEntries { get; private set; } = [];
+    [DataField, JsonIgnore] public List<RecordEntry> EmploymentEntries { get; private set; } = [];
+    [DataField, JsonIgnore] public List<RecordEntry> AdminEntries { get; private set; } = [];
+    // Far Horizons end
 
     [DataDefinition]
     [Serializable, NetSerializable]


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
a few fixes:
* handheld radio fixes - those are problems created by me and I was meant to fix those for a while. You can no longer use handhelds to read people's name behind voice changer. And it won't pick up sign language either
* character records - they just weren't ever loading from db for some reason. I have no clue when this functionality was lost
* active crit was preventing death gasp emote.

## Why we need to add this
fixes

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/bae376e3-9384-4554-baeb-d9c4e3901cd9

<img width="1205" height="675" alt="image" src="https://github.com/user-attachments/assets/47b9ab0a-1be3-4bd9-a90d-74b8459c08bc" />


https://github.com/user-attachments/assets/4a429211-a08f-436a-b9cc-a56781ea46bb



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- fix: Death gasp emote will automatically play again with active crit
- fix: Character records actually get loaded from database
- fix: Handheld radio will no longer reveal true name behind voice mask
- fix: Handheld radio lost its ability to relay sign language