### PR TITLE
Research Tree Map Construction Tweak

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -52,6 +52,7 @@
   - MassDriverCircuitboard
   - MassDriverComputerCircuitboard
   # Starlight-end
+  - ResearchTreeMapElectronics #FH
 
 - type: latheRecipePack
   id: EngineeringBoardsStatic

--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -83,7 +83,6 @@
   - APECircuitboard
   - ArtifactAnalyzerMachineCircuitboard
   - ArtifactCrusherMachineCircuitboard
-  - ResearchTreeMapElectronics #FH
 
 - type: latheRecipePack
   id: CameraBoards

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Wallmounts/WallmountMachines/research_map.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Wallmounts/WallmountMachines/research_map.yml
@@ -119,7 +119,6 @@
       enum.ConstructionVisuals.Key:
         enum.ConstructionVisuals.Layer:
           assembly: { state: research_tree_map_frame0 }
-          wired: { state: research_tree_map_frame1 }
           electronics: { state: research_tree_map_frame2 }
   - type: Construction
     graph: ResearchTreeMap

--- a/Resources/Prototypes/_FarHorizons/Recipes/Construction/Graphs/utilities/research_tree_maps.yml
+++ b/Resources/Prototypes/_FarHorizons/Recipes/Construction/Graphs/utilities/research_tree_maps.yml
@@ -15,10 +15,14 @@
     actions:
     - !type:AppearanceChange
     edges:
-    - to: wired
+    - to: electronics
       steps:
-      - material: Cable
-        amount: 2
+      - tag: ResearchTreeMapElectronics
+        store: board
+        name: research-tree-map-electronics
+        icon:
+          sprite: "Objects/Misc/module.rsi"
+          state: "science"
         doAfter: 1
     - to: start
       completed:
@@ -29,29 +33,6 @@
       steps:
       - tool: Welding
         doAfter: 2
-
-  - node: wired
-    entity: ResearchTreeMapAssembly
-    actions:
-    - !type:AppearanceChange
-    edges:
-    - to: electronics
-      steps:
-      - tag: ResearchTreeMapElectronics
-        store: board
-        name: research-tree-map-electronics
-        icon:
-          sprite: "Objects/Misc/module.rsi"
-          state: "science"
-        doAfter: 1
-    - to: assembly
-      completed:
-      - !type:GivePrototype
-        prototype: CableApcStack1
-        amount: 2
-      steps:
-      - tool: Cutting
-        doAfter: 1
 
   - node: electronics
     actions:
@@ -65,7 +46,7 @@
   - node: research_tree_map
     entity: ResearchTreeMap
     edges:
-    - to: wired
+    - to: assembly
       conditions:
       - !type:ContainerNotEmpty
         container: board

--- a/Resources/Prototypes/_FarHorizons/Recipes/Construction/Graphs/utilities/research_tree_maps.yml
+++ b/Resources/Prototypes/_FarHorizons/Recipes/Construction/Graphs/utilities/research_tree_maps.yml
@@ -15,7 +15,7 @@
     actions:
     - !type:AppearanceChange
     edges:
-    - to: electronics
+    - to: research_tree_map
       steps:
       - tag: ResearchTreeMapElectronics
         store: board
@@ -31,20 +31,13 @@
         amount: 2
       - !type:DeleteEntity {}
       steps:
-      - tool: Welding
-        doAfter: 2
-
-  - node: electronics
-    actions:
-    - !type:AppearanceChange
-    edges:
-    - to: research_tree_map
-      steps:
       - tool: Screwing
         doAfter: 2
 
-  - node: research_tree_map
-    entity: ResearchTreeMap
+  - node: electronics
+    entity: ResearchTreeMapAssembly
+    actions:
+    - !type:AppearanceChange
     edges:
     - to: assembly
       conditions:
@@ -56,4 +49,16 @@
         emptyAtUser: true
       steps:
       - tool: Prying
+        doAfter: 3
+    - to: research_tree_map
+      steps:
+      - tool: Screwing
+        doAfter: 1
+
+  - node: research_tree_map
+    entity: ResearchTreeMap
+    edges:
+    - to: electronics
+      steps:
+      - tool: Screwing
         doAfter: 1

--- a/Resources/Prototypes/_FarHorizons/Recipes/Lathes/Packs/NS/science.yml
+++ b/Resources/Prototypes/_FarHorizons/Recipes/Lathes/Packs/NS/science.yml
@@ -30,4 +30,3 @@
   - APECircuitboard
   - ArtifactAnalyzerMachineCircuitboard
   - ArtifactCrusherMachineCircuitboard
-  - ResearchTreeMapElectronics #FH

--- a/Resources/Prototypes/_FarHorizons/Research/research_nodes_nt.yml
+++ b/Resources/Prototypes/_FarHorizons/Research/research_nodes_nt.yml
@@ -391,7 +391,6 @@
     - AnomCoreHarvesting
   unlocks:
     - TechDiskComputerCircuitboard
-    - ResearchTreeMapElectronics
 
 # Civ
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Removes the wiring step from the research tree map construction graph.
Makes the Research Tree Map Electronics a roundstart recipe in the autolathe
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
research tree maps are mildly annoying to construct in large quantities, this PR makes the similar to APCs by making it only require the electronics and steel.
Research tree map electronics were originally made a tech because they were added alongside several other tech tree changes, I now see this was a mistake and have made it a roundstart recipe.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="243" height="330" alt="Content Client_KUjR5PJ08y" src="https://github.com/user-attachments/assets/d7027677-2d55-4c2d-a525-d6fd39c61e03" />
<img width="369" height="130" alt="Content Client_L1H07EOldx" src="https://github.com/user-attachments/assets/a070f1b7-aef1-472b-b042-893f494d7e4f" />

https://github.com/user-attachments/assets/ecb28d84-6f60-4087-a4ae-43e94d74e870



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: KarusKardin
- tweak: Made the Research Tree Map much faster to construct
- tweak: Removed Research Tree Map Electronics from tech tree, now a static available in the autolathe at roundstart
