### PR TITLE
Fix job picks refresh

### DIFF
--- a/Content.Client/_FarHorizons/Lobby/UI/JobPicksWindow.xaml.cs
+++ b/Content.Client/_FarHorizons/Lobby/UI/JobPicksWindow.xaml.cs
@@ -24,6 +24,8 @@ public sealed partial class JobPicksWindow : DefaultWindow
 
     private readonly SpriteSystem _sprite;
 
+    private Dictionary<ProtoId<FactionJobAssignmentPrototype>, (Label low, Label med, Label high)> _labelsCache; 
+
     public JobPicksWindow()
     {
         Title = Loc.GetString("job-picks-window-title");
@@ -32,12 +34,31 @@ public sealed partial class JobPicksWindow : DefaultWindow
 
         _sprite = _entMan.System<SpriteSystem>();
 
+        _labelsCache = new();
+        
         _lobby.OnJobPicksUpdated += UpdateJobList;
+        BuildJobList();
         UpdateJobList();
     }
 
     private void UpdateJobList()
     {
+        var picks = _lobby.GetJobPicks();
+
+        foreach (var (job, (lowLabel, medLabel, highLabel)) in _labelsCache)
+        {
+            if (!picks.TryGetValue(job, out var value))
+                value = (0, 0, 0);
+
+            lowLabel.Text = $" {value.low}";
+            medLabel.Text = $" {value.med}";
+            highLabel.Text = $" {value.high}";
+        }
+    }
+
+    private void BuildJobList()
+    {
+        _labelsCache.Clear();
         FactionTabs.RemoveAllChildren();
 
         foreach (var faction in _factions.ListPlayableFactions().ToList())
@@ -143,26 +164,25 @@ public sealed partial class JobPicksWindow : DefaultWindow
                     HorizontalExpand = true
                 };
 
-                if (!_lobby.GetJobPicks().TryGetValue(jobAssignment, out var value))
-                    value = (0, 0, 0);
-
                 var lowPrioLabel = new Label
                 {
                     Margin = new Thickness(5f, 0, 0, 0),
-                    Text = $" {value.Item1}"
+                    Text = " 0"
                 };
 
                 var mediumPrioLabel = new Label
                 {
                     Margin = new Thickness(5f, 0, 0, 0),
-                    Text = $" {value.Item2}"
+                    Text = " 0"
                 };
 
                 var highPrioLabel = new Label
                 {
                     Margin = new Thickness(5f, 0, 0, 0),
-                    Text = $" {value.Item3}"
+                    Text = " 0"
                 };
+
+                _labelsCache.Add(jobAssignment, (lowPrioLabel, mediumPrioLabel, highPrioLabel));
 
                 jobContainer.AddChild(icon);
                 jobContainer.AddChild(jobLabel);

--- a/Content.Shared/_FarHorizons/Lobby/ISharedLobbyManager.cs
+++ b/Content.Shared/_FarHorizons/Lobby/ISharedLobbyManager.cs
@@ -10,5 +10,5 @@ public interface ISharedLobbyManager
 
     event Action? OnJobPicksUpdated;
 
-    Dictionary<ProtoId<FactionJobAssignmentPrototype>, (int, int, int)> GetJobPicks();
+    Dictionary<ProtoId<FactionJobAssignmentPrototype>, (int low, int med, int high)> GetJobPicks();
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Job picks window no longer jumps around

## Why we need to add this
fix

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- fix: Job Picks window no longer resets scroll progress on update