### PR TITLE
Fixed HoP Stamp Duplication

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -198,9 +198,9 @@
     #- id: IDComputerCircuitboard # FarHorizons - Dupes in the BoxHoPCircuitboards
     #- id: FundingAllocationComputerCircuitboard # FarHorizons - Dupes in the BoxHoPCircuitboards
     #- id: CargoRequestServiceComputerCircuitboard # FarHorizons - Dupes in the BoxHoPCircuitboards
-    - id: RubberStampApproved
-    - id: RubberStampDenied
-    - id: RubberStampHop
+    #- id: RubberStampApproved # FarHorizons - Dupes in the BoxHoPStamps
+    #- id: RubberStampDenied # FarHorizons - Dupes in the BoxHoPStamps
+    #- id: RubberStampHop # FarHorizons - Dupes in the BoxHoPStamps
     - id: ClothingEyesHudCommand
     - id: ClothingEyesGlassesCommand #Far Horizons
     #- id: BoxFolderHoPClipboard #Starlight Change - #Far Horizons disabled - HoP already spawns with one.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Currently, the Head of Personnel's locker spawns two of each stamp, one in the stamp box, and one loose. This makes it the only head locker (as far as Im aware) that spawns multiple stamps, and I am willing to bet that it is not intended, This PR removes the loose stamps, leaving only the stamp box.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Fixes and such.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
(this is the best I can do, I have no clue how to compress videos)
https://medal.tv/games/requested/clips/mU5H7F8QDDoW1z-P_?invite=cr-MSxaRWcsNTI5MTI5NjEy
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: RubiconLocked
- fix: The Head of Personnel's locker no longer has duplicate stamps.
