### PR TITLE
soviet coat fix

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/coats.yml
@@ -237,6 +237,9 @@
     level: Metal
   - type: Armor
     modifiers:
+      flatReductions: #FH
+        Piercing: 5 #FH
+        Heat: 4 #FH
       coefficients:
         Blunt: 0.8
         Slash: 0.8


### PR DESCRIPTION


<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
The soviet great coat lacked flat resists

## Why we need to add this
it's THE main armor revs get in their uplink and rifts, every other rev armor has flat resist, including the one that's supposed to be worse than the great coat.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1029" height="606" alt="image" src="https://github.com/user-attachments/assets/8b2245c0-67bc-4651-8a72-05f634d6483f" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: rain_enjoyer
- fix: Fixed the soviet great coat not having flat resists.
