### PR TITLE
Vamp fixes

### DIFF
--- a/Content.Server/Bible/BibleSystem.cs
+++ b/Content.Server/Bible/BibleSystem.cs
@@ -4,12 +4,14 @@ using Content.Server.Chat; //Starlight
 using Content.Server.Ghost.Roles.Events;
 using Content.Server.Hands.Systems; //Starlight
 using Content.Server.Popups;
+using Content.Shared._FarHorizons.LimbDamage;
 using Content.Shared._FarHorizons.Vampire.Traits.Positive;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
 using Content.Shared.Bible;
 using Content.Shared.Clumsy; //Starlight
-using Content.Shared.Cluwne; //Starlight
+using Content.Shared.Cluwne;
+using Content.Shared.CombatMode.Pacification; //Starlight
 using Content.Shared.Damage;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Ghost.Roles.Components;
@@ -50,6 +52,7 @@ namespace Content.Server.Bible
         [Dependency] private readonly SharedStunSystem _stun = default!;
         [Dependency] private readonly HandsSystem _hands = default!; //Starlight
         [Dependency] private readonly TagSystem _tags = default!; //Starlight
+        [Dependency] private readonly LimbDamageSystem _limbDamage = default!; // Far Horizons
 
         public override void Initialize()
         {
@@ -73,6 +76,7 @@ namespace Content.Server.Bible
                 {
                     _stun.TryUpdateParalyzeDuration(args.Container.Owner, TimeSpan.FromSeconds(10));
                     _damageableSystem.TryChangeDamage(args.Container.Owner, component.DamageOnUnholyUse);
+                    _limbDamage.ChangeDamageAll(args.Container.Owner, component.DamageOnUnholyUse); // Far Horizons
                     _audio.PlayPvs(component.SizzleSoundPath, args.Container.Owner);
                 });
             }
@@ -142,6 +146,7 @@ namespace Content.Server.Bible
 
                 _audio.PlayPvs(component.SizzleSoundPath, args.User);
                 _damageableSystem.TryChangeDamage(args.User, component.DamageOnUntrainedUse, true, origin: uid);
+                _limbDamage.ChangeDamageAll(args.User, component.DamageOnUntrainedUse, true, origin: uid); // Far Horizons
                 _delay.TryResetDelay((uid, useDelay));
 
                 return;
@@ -151,15 +156,18 @@ namespace Content.Server.Bible
             string selfMessage;
 
             //Damage unholy creatures
-            if (HasComp<UnholyComponent>(args.Target))
+            if (HasComp<UnholyComponent>(args.Target) && !HasComp<PacifiedComponent>(args.User)) // Far Horizons
             {
                 _damageableSystem.TryChangeDamage(args.Target.Value, component.DamageUnholy, true, origin: uid);
+                _limbDamage.ChangeDamageAll(args.Target.Value, component.DamageUnholy, true, origin: uid); // Far Horizons
 
                  othersMessage = Loc.GetString(component.LocPrefix + "-damage-unholy-others", ("user", Identity.Entity(args.User, EntityManager)), ("target", Identity.Entity(args.Target.Value, EntityManager)), ("bible", uid));
                 _popupSystem.PopupEntity(othersMessage, args.User, Filter.PvsExcept(args.User), true, PopupType.MediumCaution);
 
                 selfMessage = Loc.GetString(component.LocPrefix + "-damage-unholy-self", ("target", Identity.Entity(args.Target.Value, EntityManager)), ("bible", uid));
                 _popupSystem.PopupEntity(selfMessage, args.User, args.User, PopupType.LargeCaution);
+
+                _audio.PlayPvs(component.SizzleSoundPath, args.Target.Value); // Far Horizons - idk why it wasn't here before
 
                 _delay.TryResetDelay((uid, useDelay));
 
@@ -171,7 +179,7 @@ namespace Content.Server.Bible
             
 
             // This only has a chance to fail if the target is not wearing anything on their head and is not a familiar.
-            if (!_invSystem.TryGetSlotEntity(args.Target.Value, "head", out _) && !HasComp<FamiliarComponent>(args.Target.Value))
+            if (!_invSystem.TryGetSlotEntity(args.Target.Value, "head", out _) && !HasComp<FamiliarComponent>(args.Target.Value) && !HasComp<PacifiedComponent>(args.User)) // Far Horizons added pacification check
             {
                 if (_random.Prob(component.FailChance))
                 {
@@ -183,6 +191,7 @@ namespace Content.Server.Bible
 
                     _audio.PlayPvs(component.BibleHitSound, args.User);
                     _damageableSystem.TryChangeDamage(args.Target.Value, component.DamageOnFail, true, origin: uid);
+                    _limbDamage.ChangeDamageAll(args.Target.Value, component.DamageOnFail, true, origin: uid); // Far Horizons
                     _delay.TryResetDelay((uid, useDelay));
                     return;
                 }
@@ -241,6 +250,8 @@ namespace Content.Server.Bible
 
             if (_damageableSystem.TryChangeDamage(args.Target.Value, component.Damage, true, origin: uid))
             {
+                _limbDamage.ChangeDamageAll(args.Target.Value, component.Damage, true, origin: uid); // Far Horizons
+
                 othersMessage = Loc.GetString(component.LocPrefix + "-heal-success-others", ("user", userEnt), ("target", targetEnt), ("bible", uid));
                 selfMessage = Loc.GetString(component.LocPrefix + "-heal-success-self", ("target", targetEnt), ("bible", uid));
 

--- a/Content.Server/_FarHorizons/Vampire/Traits/LesserVampireTratSystems.cs
+++ b/Content.Server/_FarHorizons/Vampire/Traits/LesserVampireTratSystems.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server.Atmos.Components;
+using Content.Server.Shuttles.Components;
 using Content.Server.Station.Components;
 using Content.Shared._FarHorizons.LimbDamage;
 using Content.Shared._FarHorizons.Vampire;
@@ -36,7 +37,8 @@ public sealed class
         var uvProtected = _transform.GetGrid(transform.Coordinates) is { } grid &&
                           (HasComp<BecomesStationComponent>(grid) ||
                            HasComp<StationMemberComponent>(grid) ||
-                           HasComp<MapAtmosphereComponent>(grid));
+                           HasComp<MapAtmosphereComponent>(grid) ||
+                           HasComp<EmergencyShuttleComponent>(grid));
 
         var valBefore = ent.Comp2.CurrentlyDrained;
         ent.Comp2.CurrentlyDrained = !uvProtected;

--- a/Resources/Locale/en-US/_FarHorizons/chapel/bible.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/chapel/bible.ftl
@@ -1,0 +1,2 @@
+bible-damage-unholy-others = {$user} {CONJUGATE-BASIC($vampire, "touch", "touches")} {$target} with {THE($bible)} and {POSS-ADJ($target)} skin begins to boil!
+bible-damage-unholy-self = You touch {$target} with {THE($bible)} and {POSS-ADJ($target)} skin begins to boil!

--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -39,6 +39,7 @@
     - ProtoThaven # Far Horizons
     - ProtoVox # Far Horizons
     - ProtoVulp # Far Horizons
+    - Lagomorph # Starlight
 
 - type: loadoutEffectGroup
   id: EffectSpeciesVox

--- a/Resources/Prototypes/_Starlight/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Starlight/Traits/disabilities.yml
@@ -121,6 +121,11 @@
   - !type:AddStatusEffect
     statusEffects:
     - StatusEffectHemophiliaTrait
+  requirements: # FH - no IPCs though
+    - !type:SpeciesRequirement
+      species:
+        - IPC
+      inverted: true
 
 - type: trait
   id: ImpairedMobility


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Random fixes mostly vamps

## Why we need to add this
fixes

## Media (Video/Screenshots)
<img width="796" height="554" alt="image" src="https://github.com/user-attachments/assets/83397d0b-addd-4883-8fc5-1cc29b8d8903" />
<img width="800" height="206" alt="image" src="https://github.com/user-attachments/assets/46f9b830-b542-4351-a49d-313988b26b8a" />
<img width="784" height="368" alt="image" src="https://github.com/user-attachments/assets/87cdb19a-1c0f-41ec-96c3-3b791963f075" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- fix: Seeing the growing vampire population, NT has invested into UV shielding for their evac shuttle
- fix: Chaplain can no longer deal any damage with their bible if they are pacified
- fix: Chaplain healing and damage applies to all limbs at once, not just torso
- fix: Hitting a vampire with the bible now has proper popup and sound
- fix: IPC can no longer select hemophilia trait
- fix: Lagomorphs get their survival box on spawn