### PR TITLE
Gives Loneops an Ammo Bundle & Fixes WT spread

### DIFF
--- a/Resources/Maps/_FarHorizons/Shuttles/ShuttleEvent/fhstriker.yml
+++ b/Resources/Maps/_FarHorizons/Shuttles/ShuttleEvent/fhstriker.yml
@@ -1,0 +1,2413 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 272.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 06/22/2026 18:09:44
+  entityCount: 297
+maps:
+- 169
+grids:
+- 325
+orphans: []
+nullspace: []
+tilemap:
+  0: Space
+  29: FloorDark
+  84: FloorShuttleRed
+  104: FloorTechMaint
+  105: FloorTechMaint2
+  118: FloorWood
+  120: Lattice
+  121: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 169
+    components:
+    - type: MetaData
+      name: Map Entity
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: GridTree
+    - type: Broadphase
+    - type: OccluderTree
+  - uid: 325
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.5638949,0.47865233
+      parent: 169
+    - type: MapGrid
+      chunks:
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAaAAAAAAAAGgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAaAAAAAAAAHkAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAaQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAAB5AAAAAAAAdgAAAAAAAHYAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAAHYAAAAAAwB2AAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAaQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAAdAAAAAAMAHQAAAAADAB0AAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGkAAAAAAABpAAAAAAAAHQAAAAABAB0AAAAAAQAdAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAeQAAAAAAAB0AAAAAAQAdAAAAAAIAHQAAAAABAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGgAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAaAAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHYAAAAAAgB5AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB2AAAAAAEAeQAAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB0AAAAAAAAdAAAAAAEAeQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdAAAAAAEAHQAAAAABAB0AAAAAAQB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHQAAAAADAB0AAAAAAgB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAAHkAAAAAAABUAAAAAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAAB5AAAAAAAAeQAAAAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHkAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        0,0:
+          ind: 0,0
+          tiles: VAAAAAAAAHkAAAAAAAB5AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerNe
+          decals:
+            11: 1,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerNw
+          decals:
+            5: -3,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerSe
+          decals:
+            4: 1,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerSw
+          decals:
+            3: -3,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineS
+          decals:
+            0: -1,-3
+            1: -2,-3
+            2: 0,-3
+        - node:
+            color: '#7F1C1FFF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            13: 1,-1
+        - node:
+            color: '#7F1C1FFF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            12: -3,-1
+        - node:
+            color: '#7F1C1FFF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            9: 1,-3
+        - node:
+            color: '#7F1C1FFF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            10: -3,-3
+        - node:
+            color: '#7F1C1FFF'
+            id: BrickTileWhiteLineS
+          decals:
+            6: -2,-3
+            7: -1,-3
+            8: 0,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            23: 2,-2
+            24: -4,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineE
+          decals:
+            14: 1,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            16: -3,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineW
+          decals:
+            15: -1,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineN
+          decals:
+            17: -1,-5
+            18: 0,-5
+            19: -2,-5
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineS
+          decals:
+            20: -2,-6
+            21: -1,-6
+            22: 0,-6
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          -1,-1:
+            0: 65535
+          0,-1:
+            0: 65535
+          -2,-1:
+            0: 52424
+          -1,-3:
+            0: 65280
+          -1,-2:
+            0: 65535
+          0,-3:
+            0: 30464
+          0,-2:
+            0: 30583
+          -2,0:
+            0: 8
+          -1,0:
+            0: 3839
+          0,0:
+            0: 895
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: GravityShake
+      shakeTimes: 10
+    - type: SpreaderGrid
+    - type: GridPathfinding
+    - type: ImplicitRoof
+    - type: ExplosionAirtightGrid
+    - type: TileHistory
+      chunkHistory: {}
+    - type: NavMap
+- proto: AirCanister
+  entities:
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 325
+- proto: AmmoSelectionAmmoBagS
+  entities:
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 1.561105,-0.41328236
+      parent: 325
+- proto: APCBasic
+  entities:
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 325
+    - type: PowerNetworkBattery
+      loadingNetworkDemand: 15107
+      currentReceiving: 15106.935
+      currentSupply: 15107
+      supplyRampPosition: 0.064453125
+    - type: Fixtures
+      fixtures: {}
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 325
+- proto: Bed
+  entities:
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 325
+- proto: BedsheetSyndie
+  entities:
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 325
+- proto: BlastDoorOpen
+  entities:
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 331
+  - uid: 191
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 332
+  - uid: 192
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 333
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 334
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 337
+  - uid: 198
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 339
+  - uid: 199
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 340
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 341
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 342
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 343
+- proto: BoxMRE
+  entities:
+  - uid: 320
+    components:
+    - type: Transform
+      pos: 0.70504504,-7.29326
+      parent: 325
+- proto: CableApcExtension
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 325
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 325
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 325
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 325
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 325
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 325
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 325
+  - uid: 127
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 325
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -3.5,-8.5
+      parent: 325
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 325
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 325
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 325
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 325
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 325
+  - uid: 134
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 325
+  - uid: 135
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 325
+  - uid: 136
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 325
+  - uid: 137
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 325
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 325
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 325
+  - uid: 140
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 325
+  - uid: 141
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 325
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 325
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 325
+  - uid: 146
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 325
+  - uid: 147
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 325
+  - uid: 148
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 325
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 325
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 325
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 325
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 325
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 325
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 325
+  - uid: 155
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 325
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 325
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 325
+  - uid: 158
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 325
+- proto: CableHV
+  entities:
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 325
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 325
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 325
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 325
+  - uid: 115
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 325
+  - uid: 116
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 325
+- proto: CableHVStack1
+  entities:
+  - uid: 235
+    components:
+    - type: Transform
+      parent: 41
+    - type: Stack
+      count: 10
+    - type: Physics
+      canCollide: False
+  - uid: 239
+    components:
+    - type: Transform
+      parent: 56
+    - type: Stack
+      count: 10
+    - type: Physics
+      canCollide: False
+- proto: CableMV
+  entities:
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 325
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 325
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 325
+- proto: Carpet
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 325
+  - uid: 89
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 325
+- proto: Catwalk
+  entities:
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 325
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 325
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 325
+- proto: ChairOfficeDark
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 325
+- proto: ChairPilotSeat
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 325
+- proto: ComputerIFFSyndicate
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 325
+- proto: ComputerShuttleSyndie
+  entities:
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 245
+        disk_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        pai_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: CyberPen
+  entities:
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -1.1813428,-5.15565
+      parent: 325
+- proto: DoorElectronics
+  entities:
+  - uid: 331
+    components:
+    - type: Transform
+      parent: 190
+    - type: Physics
+      canCollide: False
+  - uid: 332
+    components:
+    - type: Transform
+      parent: 191
+    - type: Physics
+      canCollide: False
+  - uid: 333
+    components:
+    - type: Transform
+      parent: 192
+    - type: Physics
+      canCollide: False
+  - uid: 334
+    components:
+    - type: Transform
+      parent: 193
+    - type: Physics
+      canCollide: False
+  - uid: 337
+    components:
+    - type: Transform
+      parent: 196
+    - type: Physics
+      canCollide: False
+  - uid: 339
+    components:
+    - type: Transform
+      parent: 198
+    - type: Physics
+      canCollide: False
+  - uid: 340
+    components:
+    - type: Transform
+      parent: 199
+    - type: Physics
+      canCollide: False
+  - uid: 341
+    components:
+    - type: Transform
+      parent: 200
+    - type: Physics
+      canCollide: False
+  - uid: 342
+    components:
+    - type: Transform
+      parent: 201
+    - type: Physics
+      canCollide: False
+  - uid: 343
+    components:
+    - type: Transform
+      parent: 202
+    - type: Physics
+      canCollide: False
+  - uid: 346
+    components:
+    - type: Transform
+      parent: 206
+    - type: Physics
+      canCollide: False
+- proto: DresserFilled
+  entities:
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 325
+- proto: DrinkNukieCan
+  entities:
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -2.6964839,-2.109029
+      parent: 325
+- proto: FaxMachineSyndie
+  entities:
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 325
+    - type: FaxMachine
+      name: Striker
+- proto: FHAirlockExternalShuttleSyndicateLocked
+  entities:
+  - uid: 142
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-1.5
+      parent: 325
+- proto: FHAirlockSyndicateLocked
+  entities:
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 325
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 325
+- proto: FHFoodBoxDonut
+  entities:
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -2.470145,-2.3953476
+      parent: 325
+- proto: filingCabinetRandom
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 325
+- proto: Firelock
+  entities:
+  - uid: 224
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 350
+    - type: DeviceNetwork
+      address: 44a24659
+      receiveFrequency: 1621
+  - uid: 225
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 351
+    - type: DeviceNetwork
+      address: 6fdb75cf
+      receiveFrequency: 1621
+- proto: FirelockElectronics
+  entities:
+  - uid: 350
+    components:
+    - type: Transform
+      parent: 224
+    - type: Physics
+      canCollide: False
+  - uid: 351
+    components:
+    - type: Transform
+      parent: 225
+    - type: Physics
+      canCollide: False
+- proto: GasPipeFourway
+  entities:
+  - uid: 216
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 325
+- proto: GasPipeStraight
+  entities:
+  - uid: 211
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-6.5
+      parent: 325
+  - uid: 213
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 325
+  - uid: 214
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 325
+  - uid: 215
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 325
+  - uid: 217
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
+      parent: 325
+- proto: GasPipeTJunction
+  entities:
+  - uid: 210
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-7.5
+      parent: 325
+  - uid: 212
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 325
+- proto: GasPort
+  entities:
+  - uid: 59
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-8.5
+      parent: 325
+- proto: GasVentPump
+  entities:
+  - uid: 218
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 325
+    - type: DeviceNetwork
+      address: Vnt-5f41a0ae
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+  - uid: 219
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 325
+    - type: DeviceNetwork
+      address: Vnt-129c27d2
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+  - uid: 220
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 325
+    - type: DeviceNetwork
+      address: Vnt-11c4609d
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+  - uid: 221
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-5.5
+      parent: 325
+    - type: DeviceNetwork
+      address: Vnt-6859729f
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+  - uid: 222
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 325
+    - type: DeviceNetwork
+      address: Vnt-19d24c7f
+      transmitFrequency: 1621
+      receiveFrequency: 1621
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 325
+    - type: PowerSupplier
+      supplyRampPosition: 7552.5303
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          ents:
+          - 232
+        machine_parts: !type:Container
+          ents:
+          - 233
+          - 234
+          - 235
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 325
+    - type: PowerSupplier
+      supplyRampPosition: 7552.5303
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          ents:
+          - 236
+        machine_parts: !type:Container
+          ents:
+          - 237
+          - 238
+          - 239
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 325
+- proto: Grille
+  entities:
+  - uid: 1
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 325
+  - uid: 2
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 325
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 325
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 325
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 325
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 325
+  - uid: 50
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-5.5
+      parent: 325
+  - uid: 51
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-4.5
+      parent: 325
+  - uid: 52
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-5.5
+      parent: 325
+  - uid: 53
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 325
+- proto: Gyroscope
+  entities:
+  - uid: 58
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-8.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 240
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 241
+          - 242
+          - 243
+          - 244
+- proto: GyroscopeMachineCircuitboard
+  entities:
+  - uid: 240
+    components:
+    - type: Transform
+      parent: 58
+    - type: Physics
+      canCollide: False
+- proto: HandheldStationMapNukeops
+  entities:
+  - uid: 168
+    components:
+    - type: Transform
+      pos: 1.493886,-2.2168128
+      parent: 325
+- proto: MedkitCombatFilled
+  entities:
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 1.48298,-0.3211529
+      parent: 325
+- proto: MicroManipulatorStockPart
+  entities:
+  - uid: 233
+    components:
+    - type: Transform
+      parent: 41
+    - type: Physics
+      canCollide: False
+  - uid: 234
+    components:
+    - type: Transform
+      parent: 41
+    - type: Physics
+      canCollide: False
+  - uid: 237
+    components:
+    - type: Transform
+      parent: 56
+    - type: Physics
+      canCollide: False
+  - uid: 238
+    components:
+    - type: Transform
+      parent: 56
+    - type: Physics
+      canCollide: False
+  - uid: 241
+    components:
+    - type: Transform
+      parent: 58
+    - type: Physics
+      canCollide: False
+  - uid: 242
+    components:
+    - type: Transform
+      parent: 58
+    - type: Physics
+      canCollide: False
+  - uid: 243
+    components:
+    - type: Transform
+      parent: 58
+    - type: Physics
+      canCollide: False
+  - uid: 250
+    components:
+    - type: Transform
+      parent: 95
+    - type: Physics
+      canCollide: False
+  - uid: 251
+    components:
+    - type: Transform
+      parent: 95
+    - type: Physics
+      canCollide: False
+  - uid: 252
+    components:
+    - type: Transform
+      parent: 95
+    - type: Physics
+      canCollide: False
+  - uid: 253
+    components:
+    - type: Transform
+      parent: 95
+    - type: Physics
+      canCollide: False
+  - uid: 254
+    components:
+    - type: Transform
+      parent: 95
+    - type: Physics
+      canCollide: False
+  - uid: 257
+    components:
+    - type: Transform
+      parent: 96
+    - type: Physics
+      canCollide: False
+  - uid: 258
+    components:
+    - type: Transform
+      parent: 96
+    - type: Physics
+      canCollide: False
+  - uid: 259
+    components:
+    - type: Transform
+      parent: 96
+    - type: Physics
+      canCollide: False
+  - uid: 260
+    components:
+    - type: Transform
+      parent: 96
+    - type: Physics
+      canCollide: False
+  - uid: 261
+    components:
+    - type: Transform
+      parent: 96
+    - type: Physics
+      canCollide: False
+  - uid: 264
+    components:
+    - type: Transform
+      parent: 97
+    - type: Physics
+      canCollide: False
+  - uid: 265
+    components:
+    - type: Transform
+      parent: 97
+    - type: Physics
+      canCollide: False
+  - uid: 266
+    components:
+    - type: Transform
+      parent: 97
+    - type: Physics
+      canCollide: False
+  - uid: 267
+    components:
+    - type: Transform
+      parent: 97
+    - type: Physics
+      canCollide: False
+  - uid: 268
+    components:
+    - type: Transform
+      parent: 97
+    - type: Physics
+      canCollide: False
+  - uid: 271
+    components:
+    - type: Transform
+      parent: 98
+    - type: Physics
+      canCollide: False
+  - uid: 272
+    components:
+    - type: Transform
+      parent: 98
+    - type: Physics
+      canCollide: False
+  - uid: 273
+    components:
+    - type: Transform
+      parent: 98
+    - type: Physics
+      canCollide: False
+  - uid: 274
+    components:
+    - type: Transform
+      parent: 98
+    - type: Physics
+      canCollide: False
+  - uid: 275
+    components:
+    - type: Transform
+      parent: 98
+    - type: Physics
+      canCollide: False
+  - uid: 278
+    components:
+    - type: Transform
+      parent: 99
+    - type: Physics
+      canCollide: False
+  - uid: 279
+    components:
+    - type: Transform
+      parent: 99
+    - type: Physics
+      canCollide: False
+  - uid: 280
+    components:
+    - type: Transform
+      parent: 99
+    - type: Physics
+      canCollide: False
+  - uid: 281
+    components:
+    - type: Transform
+      parent: 99
+    - type: Physics
+      canCollide: False
+  - uid: 282
+    components:
+    - type: Transform
+      parent: 99
+    - type: Physics
+      canCollide: False
+  - uid: 285
+    components:
+    - type: Transform
+      parent: 100
+    - type: Physics
+      canCollide: False
+  - uid: 286
+    components:
+    - type: Transform
+      parent: 100
+    - type: Physics
+      canCollide: False
+  - uid: 287
+    components:
+    - type: Transform
+      parent: 100
+    - type: Physics
+      canCollide: False
+  - uid: 288
+    components:
+    - type: Transform
+      parent: 100
+    - type: Physics
+      canCollide: False
+  - uid: 289
+    components:
+    - type: Transform
+      parent: 100
+    - type: Physics
+      canCollide: False
+  - uid: 292
+    components:
+    - type: Transform
+      parent: 101
+    - type: Physics
+      canCollide: False
+  - uid: 293
+    components:
+    - type: Transform
+      parent: 101
+    - type: Physics
+      canCollide: False
+  - uid: 294
+    components:
+    - type: Transform
+      parent: 101
+    - type: Physics
+      canCollide: False
+  - uid: 295
+    components:
+    - type: Transform
+      parent: 101
+    - type: Physics
+      canCollide: False
+  - uid: 296
+    components:
+    - type: Transform
+      parent: 101
+    - type: Physics
+      canCollide: False
+  - uid: 299
+    components:
+    - type: Transform
+      parent: 102
+    - type: Physics
+      canCollide: False
+  - uid: 300
+    components:
+    - type: Transform
+      parent: 102
+    - type: Physics
+      canCollide: False
+  - uid: 301
+    components:
+    - type: Transform
+      parent: 102
+    - type: Physics
+      canCollide: False
+  - uid: 302
+    components:
+    - type: Transform
+      parent: 102
+    - type: Physics
+      canCollide: False
+  - uid: 303
+    components:
+    - type: Transform
+      parent: 102
+    - type: Physics
+      canCollide: False
+- proto: Mirror
+  entities:
+  - uid: 321
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 325
+    - type: Fixtures
+      fixtures: {}
+- proto: NitrogenTankFilled
+  entities:
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 1.373605,-0.2749618
+      parent: 325
+- proto: NukeCodePaper
+  entities:
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 1.561105,-2.5567772
+      parent: 325
+- proto: OxygenTankFilled
+  entities:
+  - uid: 167
+    components:
+    - type: Transform
+      pos: 1.60798,-0.3062118
+      parent: 325
+- proto: PinpointerNuclear
+  entities:
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 1.3790641,-2.3161128
+      parent: 325
+    - type: Physics
+      canCollide: False
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 104
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-0.5
+      parent: 325
+  - uid: 109
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-0.5
+      parent: 325
+- proto: PlushieNuke
+  entities:
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 0.5061571,-5.233775
+      parent: 325
+- proto: PortableGeneratorSuperPacmanMachineCircuitboard
+  entities:
+  - uid: 232
+    components:
+    - type: Transform
+      parent: 41
+    - type: Physics
+      canCollide: False
+  - uid: 236
+    components:
+    - type: Transform
+      parent: 56
+    - type: Physics
+      canCollide: False
+- proto: PosterContrabandC20r
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 325
+    - type: Fixtures
+      fixtures: {}
+- proto: PosterContrabandEnergySwords
+  entities:
+  - uid: 227
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 325
+    - type: Fixtures
+      fixtures: {}
+- proto: PosterContrabandNuclearDeviceInformational
+  entities:
+  - uid: 228
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 325
+    - type: Fixtures
+      fixtures: {}
+- proto: PosterContrabandSyndicateRecruitment
+  entities:
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 325
+    - type: Fixtures
+      fixtures: {}
+- proto: Poweredlight
+  entities:
+  - uid: 94
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 325
+  - uid: 110
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-2.5
+      parent: 325
+- proto: PoweredlightLED
+  entities:
+  - uid: 182
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-5.5
+      parent: 325
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-5.5
+      parent: 325
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 325
+    - type: ApcPowerReceiver
+      powerLoad: 0
+- proto: PoweredSmallLight
+  entities:
+  - uid: 204
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-5.5
+      parent: 325
+    - type: ApcPowerReceiver
+      powerLoad: 0
+- proto: Rack
+  entities:
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 325
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 325
+- proto: ReinforcedPlasmaWindow
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 325
+  - uid: 15
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 325
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 325
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 325
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 325
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 325
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 325
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 325
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 325
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 325
+- proto: RemoteSignaller
+  entities:
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 1.3427892,-2.379079
+      parent: 325
+    - type: Physics
+      canCollide: False
+- proto: SheetGlass1
+  entities:
+  - uid: 244
+    components:
+    - type: Transform
+      parent: 58
+    - type: Stack
+      count: 2
+    - type: Physics
+      canCollide: False
+- proto: SheetSteel1
+  entities:
+  - uid: 255
+    components:
+    - type: Transform
+      parent: 95
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 262
+    components:
+    - type: Transform
+      parent: 96
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 269
+    components:
+    - type: Transform
+      parent: 97
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 276
+    components:
+    - type: Transform
+      parent: 98
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 283
+    components:
+    - type: Transform
+      parent: 99
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 290
+    components:
+    - type: Transform
+      parent: 100
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 297
+    components:
+    - type: Transform
+      parent: 101
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+  - uid: 304
+    components:
+    - type: Transform
+      parent: 102
+    - type: Stack
+      count: 5
+    - type: Physics
+      canCollide: False
+- proto: SignalButton
+  entities:
+  - uid: 205
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 325
+    - type: DeviceLinkSource
+      linkedPorts:
+        193:
+        - - Pressed
+          - Toggle
+        192:
+        - - Pressed
+          - Toggle
+        190:
+        - - Pressed
+          - Toggle
+        191:
+        - - Pressed
+          - Toggle
+        196:
+        - - Pressed
+          - Toggle
+        202:
+        - - Pressed
+          - Toggle
+        201:
+        - - Pressed
+          - Toggle
+        200:
+        - - Pressed
+          - Toggle
+        199:
+        - - Pressed
+          - Toggle
+        198:
+        - - Pressed
+          - Toggle
+    - type: Fixtures
+      fixtures: {}
+- proto: SignSpace
+  entities:
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 325
+    - type: Fixtures
+      fixtures: {}
+- proto: SoapSyndie
+  entities:
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 0.5436061,-7.5129323
+      parent: 325
+- proto: SpawnPointNukies
+  entities:
+  - uid: 322
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 325
+- proto: StealthBox
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 0.49860507,-2.4513345
+      parent: 325
+    - type: Stealth
+      enabled: False
+    - type: EntityStorage
+      open: True
+- proto: SubstationWallBasic
+  entities:
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 325
+    - type: PowerNetworkBattery
+      loadingNetworkDemand: 15106.935
+      currentReceiving: 15105.06
+      currentSupply: 15106.935
+      supplyRampPosition: 1.875
+- proto: SuitStorageSyndie
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 325
+- proto: SyndicateCommsComputerCircuitboard
+  entities:
+  - uid: 246
+    components:
+    - type: Transform
+      parent: 65
+    - type: Physics
+      canCollide: False
+- proto: SyndicateComputerComms
+  entities:
+  - uid: 65
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 246
+        pai_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: SyndicateIDCard
+  entities:
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 1.57673,-2.3849022
+      parent: 325
+- proto: SyndicateShuttleConsoleCircuitboard
+  entities:
+  - uid: 245
+    components:
+    - type: Transform
+      parent: 64
+    - type: Physics
+      canCollide: False
+- proto: Table
+  entities:
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 325
+- proto: TableWood
+  entities:
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 325
+- proto: Thruster
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-9.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 249
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 250
+          - 251
+          - 252
+          - 253
+          - 254
+          - 255
+  - uid: 96
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-9.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 256
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 257
+          - 258
+          - 259
+          - 260
+          - 261
+          - 262
+  - uid: 97
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 263
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 264
+          - 265
+          - 266
+          - 267
+          - 268
+          - 269
+  - uid: 98
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-5.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 270
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 271
+          - 272
+          - 273
+          - 274
+          - 275
+          - 276
+  - uid: 99
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-4.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 277
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 278
+          - 279
+          - 280
+          - 281
+          - 282
+          - 283
+  - uid: 100
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 284
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 285
+          - 286
+          - 287
+          - 288
+          - 289
+          - 290
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 291
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 292
+          - 293
+          - 294
+          - 295
+          - 296
+          - 297
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 298
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 299
+          - 300
+          - 301
+          - 302
+          - 303
+          - 304
+- proto: ThrusterMachineCircuitboard
+  entities:
+  - uid: 249
+    components:
+    - type: Transform
+      parent: 95
+    - type: Physics
+      canCollide: False
+  - uid: 256
+    components:
+    - type: Transform
+      parent: 96
+    - type: Physics
+      canCollide: False
+  - uid: 263
+    components:
+    - type: Transform
+      parent: 97
+    - type: Physics
+      canCollide: False
+  - uid: 270
+    components:
+    - type: Transform
+      parent: 98
+    - type: Physics
+      canCollide: False
+  - uid: 277
+    components:
+    - type: Transform
+      parent: 99
+    - type: Physics
+      canCollide: False
+  - uid: 284
+    components:
+    - type: Transform
+      parent: 100
+    - type: Physics
+      canCollide: False
+  - uid: 291
+    components:
+    - type: Transform
+      parent: 101
+    - type: Physics
+      canCollide: False
+  - uid: 298
+    components:
+    - type: Transform
+      parent: 102
+    - type: Physics
+      canCollide: False
+- proto: ToolboxSyndicateFilled
+  entities:
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 1.5699697,-0.44908836
+      parent: 325
+    - type: Physics
+      canCollide: False
+- proto: ToyFigurineNukie
+  entities:
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -2.3371089,-2.140279
+      parent: 325
+- proto: VendingMachineSyndieDrobe
+  entities:
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 325
+- proto: WallPlastitanium
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 325
+  - uid: 8
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 325
+  - uid: 9
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 325
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 325
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 325
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 325
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 325
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 325
+  - uid: 27
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 325
+  - uid: 28
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-6.5
+      parent: 325
+  - uid: 29
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-6.5
+      parent: 325
+  - uid: 30
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 325
+  - uid: 31
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-8.5
+      parent: 325
+  - uid: 32
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-8.5
+      parent: 325
+  - uid: 33
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-6.5
+      parent: 325
+  - uid: 34
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-3.5
+      parent: 325
+  - uid: 35
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-9.5
+      parent: 325
+  - uid: 36
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-8.5
+      parent: 325
+  - uid: 37
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-9.5
+      parent: 325
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 325
+  - uid: 39
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-3.5
+      parent: 325
+  - uid: 44
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-8.5
+      parent: 325
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 325
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 325
+  - uid: 54
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 325
+  - uid: 55
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-3.5
+      parent: 325
+  - uid: 60
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-6.5
+      parent: 325
+  - uid: 61
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-6.5
+      parent: 325
+  - uid: 62
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 325
+  - uid: 63
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-3.5
+      parent: 325
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 325
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 325
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 325
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 325
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 325
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 325
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 325
+- proto: WallPlastitaniumDiagonal
+  entities:
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 325
+  - uid: 43
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 325
+  - uid: 68
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 325
+  - uid: 79
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 325
+  - uid: 82
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-3.5
+      parent: 325
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 325
+- proto: WindoorSecure
+  entities:
+  - uid: 166
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 325
+  - uid: 206
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
+      parent: 325
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 346
+...

--- a/Resources/Maps/_FarHorizons/Shuttles/ShuttleEvent/fhstriker.yml
+++ b/Resources/Maps/_FarHorizons/Shuttles/ShuttleEvent/fhstriker.yml
@@ -4,13 +4,13 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 06/22/2026 18:09:44
-  entityCount: 297
-maps:
-- 169
+  time: 06/22/2026 18:26:14
+  entityCount: 296
+maps: []
 grids:
-- 325
-orphans: []
+- 1
+orphans:
+- 1
 nullspace: []
 tilemap:
   0: Space
@@ -24,22 +24,12 @@ tilemap:
 entities:
 - proto: ""
   entities:
-  - uid: 169
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: GridTree
-    - type: Broadphase
-    - type: OccluderTree
-  - uid: 325
+  - uid: 1
     components:
     - type: MetaData
     - type: Transform
       pos: 0.5638949,0.47865233
-      parent: 169
+      parent: invalid
     - type: MapGrid
       chunks:
         -1,-1:
@@ -210,25 +200,25 @@ entities:
     - type: NavMap
 - proto: AirCanister
   entities:
-  - uid: 91
+  - uid: 2
     components:
     - type: Transform
       pos: -0.5,-8.5
-      parent: 325
+      parent: 1
 - proto: AmmoSelectionAmmoBagS
   entities:
-  - uid: 170
+  - uid: 3
     components:
     - type: Transform
-      pos: 1.561105,-0.41328236
-      parent: 325
+      pos: 1.6310666,-0.55677736
+      parent: 1
 - proto: APCBasic
   entities:
-  - uid: 107
+  - uid: 4
     components:
     - type: Transform
       pos: 0.5,-6.5
-      parent: 325
+      parent: 1
     - type: PowerNetworkBattery
       loadingNetworkDemand: 15107
       currentReceiving: 15106.935
@@ -238,476 +228,476 @@ entities:
       fixtures: {}
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 6
+  - uid: 5
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-1.5
-      parent: 325
+      parent: 1
 - proto: Bed
   entities:
-  - uid: 76
+  - uid: 6
     components:
     - type: Transform
       pos: 0.5,-5.5
-      parent: 325
+      parent: 1
 - proto: BedsheetSyndie
   entities:
-  - uid: 164
+  - uid: 7
     components:
     - type: Transform
       pos: 0.5,-5.5
-      parent: 325
+      parent: 1
 - proto: BlastDoorOpen
   entities:
-  - uid: 190
+  - uid: 8
     components:
     - type: Transform
       pos: 1.5,-5.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 331
-  - uid: 191
+          - 9
+  - uid: 10
     components:
     - type: Transform
       pos: 1.5,-4.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 332
-  - uid: 192
+          - 11
+  - uid: 12
     components:
     - type: Transform
       pos: -2.5,-5.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 333
-  - uid: 193
+          - 13
+  - uid: 14
     components:
     - type: Transform
       pos: -2.5,-4.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 334
-  - uid: 196
+          - 15
+  - uid: 16
     components:
     - type: Transform
       pos: 3.5,-1.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 337
-  - uid: 198
+          - 17
+  - uid: 18
     components:
     - type: Transform
       pos: -1.5,1.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 339
-  - uid: 199
+          - 19
+  - uid: 20
     components:
     - type: Transform
       pos: -1.5,2.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 340
-  - uid: 200
+          - 21
+  - uid: 22
     components:
     - type: Transform
       pos: -0.5,2.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 341
-  - uid: 201
+          - 23
+  - uid: 24
     components:
     - type: Transform
       pos: 0.5,2.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 342
-  - uid: 202
+          - 25
+  - uid: 26
     components:
     - type: Transform
       pos: 0.5,1.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 343
+          - 27
 - proto: BoxMRE
   entities:
-  - uid: 320
+  - uid: 28
     components:
     - type: Transform
       pos: 0.70504504,-7.29326
-      parent: 325
+      parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 120
+  - uid: 29
     components:
     - type: Transform
       pos: 0.5,-6.5
-      parent: 325
-  - uid: 121
+      parent: 1
+  - uid: 30
     components:
     - type: Transform
       pos: -0.5,-6.5
-      parent: 325
-  - uid: 122
+      parent: 1
+  - uid: 31
     components:
     - type: Transform
       pos: -0.5,-7.5
-      parent: 325
-  - uid: 123
+      parent: 1
+  - uid: 32
     components:
     - type: Transform
       pos: -0.5,-8.5
-      parent: 325
-  - uid: 124
+      parent: 1
+  - uid: 33
     components:
     - type: Transform
       pos: -1.5,-8.5
-      parent: 325
-  - uid: 125
+      parent: 1
+  - uid: 34
     components:
     - type: Transform
       pos: 0.5,-8.5
-      parent: 325
-  - uid: 126
+      parent: 1
+  - uid: 35
     components:
     - type: Transform
       pos: 1.5,-8.5
-      parent: 325
-  - uid: 127
+      parent: 1
+  - uid: 36
     components:
     - type: Transform
       pos: -2.5,-8.5
-      parent: 325
-  - uid: 128
+      parent: 1
+  - uid: 37
     components:
     - type: Transform
       pos: -3.5,-8.5
-      parent: 325
-  - uid: 129
+      parent: 1
+  - uid: 38
     components:
     - type: Transform
       pos: -3.5,-7.5
-      parent: 325
-  - uid: 130
+      parent: 1
+  - uid: 39
     components:
     - type: Transform
       pos: 2.5,-8.5
-      parent: 325
-  - uid: 131
+      parent: 1
+  - uid: 40
     components:
     - type: Transform
       pos: 2.5,-7.5
-      parent: 325
-  - uid: 132
+      parent: 1
+  - uid: 41
     components:
     - type: Transform
       pos: -0.5,-5.5
-      parent: 325
-  - uid: 133
+      parent: 1
+  - uid: 42
     components:
     - type: Transform
       pos: -0.5,-4.5
-      parent: 325
-  - uid: 134
+      parent: 1
+  - uid: 43
     components:
     - type: Transform
       pos: -0.5,-3.5
-      parent: 325
-  - uid: 135
+      parent: 1
+  - uid: 44
     components:
     - type: Transform
       pos: -0.5,-2.5
-      parent: 325
-  - uid: 136
+      parent: 1
+  - uid: 45
     components:
     - type: Transform
       pos: -0.5,-1.5
-      parent: 325
-  - uid: 137
+      parent: 1
+  - uid: 46
     components:
     - type: Transform
       pos: -0.5,-0.5
-      parent: 325
-  - uid: 138
+      parent: 1
+  - uid: 47
     components:
     - type: Transform
       pos: -0.5,0.5
-      parent: 325
-  - uid: 139
+      parent: 1
+  - uid: 48
     components:
     - type: Transform
       pos: -0.5,1.5
-      parent: 325
-  - uid: 140
+      parent: 1
+  - uid: 49
     components:
     - type: Transform
       pos: -0.5,2.5
-      parent: 325
-  - uid: 141
+      parent: 1
+  - uid: 50
     components:
     - type: Transform
       pos: -1.5,1.5
-      parent: 325
-  - uid: 143
+      parent: 1
+  - uid: 51
     components:
     - type: Transform
       pos: 0.5,1.5
-      parent: 325
-  - uid: 145
+      parent: 1
+  - uid: 52
     components:
     - type: Transform
       pos: -1.5,-1.5
-      parent: 325
-  - uid: 146
+      parent: 1
+  - uid: 53
     components:
     - type: Transform
       pos: -2.5,-1.5
-      parent: 325
-  - uid: 147
+      parent: 1
+  - uid: 54
     components:
     - type: Transform
       pos: -3.5,-1.5
-      parent: 325
-  - uid: 148
+      parent: 1
+  - uid: 55
     components:
     - type: Transform
       pos: -4.5,-1.5
-      parent: 325
-  - uid: 149
+      parent: 1
+  - uid: 56
     components:
     - type: Transform
       pos: 0.5,-1.5
-      parent: 325
-  - uid: 150
+      parent: 1
+  - uid: 57
     components:
     - type: Transform
       pos: 1.5,-1.5
-      parent: 325
-  - uid: 151
+      parent: 1
+  - uid: 58
     components:
     - type: Transform
       pos: 2.5,-1.5
-      parent: 325
-  - uid: 152
+      parent: 1
+  - uid: 59
     components:
     - type: Transform
       pos: 3.5,-1.5
-      parent: 325
-  - uid: 153
+      parent: 1
+  - uid: 60
     components:
     - type: Transform
       pos: 0.5,-4.5
-      parent: 325
-  - uid: 154
+      parent: 1
+  - uid: 61
     components:
     - type: Transform
       pos: 1.5,-4.5
-      parent: 325
-  - uid: 155
+      parent: 1
+  - uid: 62
     components:
     - type: Transform
       pos: 1.5,-5.5
-      parent: 325
-  - uid: 156
+      parent: 1
+  - uid: 63
     components:
     - type: Transform
       pos: -1.5,-4.5
-      parent: 325
-  - uid: 157
+      parent: 1
+  - uid: 64
     components:
     - type: Transform
       pos: -2.5,-4.5
-      parent: 325
-  - uid: 158
+      parent: 1
+  - uid: 65
     components:
     - type: Transform
       pos: -2.5,-5.5
-      parent: 325
+      parent: 1
 - proto: CableHV
   entities:
-  - uid: 111
+  - uid: 66
     components:
     - type: Transform
       pos: 1.5,-7.5
-      parent: 325
-  - uid: 112
+      parent: 1
+  - uid: 67
     components:
     - type: Transform
       pos: 0.5,-7.5
-      parent: 325
-  - uid: 113
+      parent: 1
+  - uid: 68
     components:
     - type: Transform
       pos: -0.5,-7.5
-      parent: 325
-  - uid: 114
+      parent: 1
+  - uid: 69
     components:
     - type: Transform
       pos: -1.5,-7.5
-      parent: 325
-  - uid: 115
+      parent: 1
+  - uid: 70
     components:
     - type: Transform
       pos: -2.5,-7.5
-      parent: 325
-  - uid: 116
+      parent: 1
+  - uid: 71
     components:
     - type: Transform
       pos: -1.5,-6.5
-      parent: 325
+      parent: 1
 - proto: CableHVStack1
   entities:
-  - uid: 235
+  - uid: 73
     components:
     - type: Transform
-      parent: 41
+      parent: 72
     - type: Stack
       count: 10
     - type: Physics
       canCollide: False
-  - uid: 239
+  - uid: 78
     components:
     - type: Transform
-      parent: 56
+      parent: 77
     - type: Stack
       count: 10
     - type: Physics
       canCollide: False
 - proto: CableMV
   entities:
-  - uid: 117
+  - uid: 82
     components:
     - type: Transform
       pos: -1.5,-6.5
-      parent: 325
-  - uid: 118
+      parent: 1
+  - uid: 83
     components:
     - type: Transform
       pos: -0.5,-6.5
-      parent: 325
-  - uid: 119
+      parent: 1
+  - uid: 84
     components:
     - type: Transform
       pos: 0.5,-6.5
-      parent: 325
+      parent: 1
 - proto: Carpet
   entities:
-  - uid: 74
+  - uid: 85
     components:
     - type: Transform
       pos: -0.5,-4.5
-      parent: 325
-  - uid: 89
+      parent: 1
+  - uid: 86
     components:
     - type: Transform
       pos: -0.5,-5.5
-      parent: 325
+      parent: 1
 - proto: Catwalk
   entities:
-  - uid: 159
+  - uid: 87
     components:
     - type: Transform
       pos: -1.5,-7.5
-      parent: 325
-  - uid: 160
+      parent: 1
+  - uid: 88
     components:
     - type: Transform
       pos: -0.5,-7.5
-      parent: 325
-  - uid: 161
+      parent: 1
+  - uid: 89
     components:
     - type: Transform
       pos: 0.5,-7.5
-      parent: 325
+      parent: 1
 - proto: ChairOfficeDark
   entities:
-  - uid: 93
+  - uid: 90
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-2.5
-      parent: 325
+      parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 78
+  - uid: 91
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,0.5
-      parent: 325
+      parent: 1
 - proto: ComputerIFFSyndicate
   entities:
-  - uid: 40
+  - uid: 92
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,0.5
-      parent: 325
+      parent: 1
 - proto: ComputerShuttleSyndie
   entities:
-  - uid: 64
+  - uid: 93
     components:
     - type: Transform
       pos: -0.5,1.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 245
+          - 94
         disk_slot: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -718,1111 +708,1111 @@ entities:
           ent: null
 - proto: CyberPen
   entities:
-  - uid: 77
+  - uid: 95
     components:
     - type: Transform
       pos: -1.1813428,-5.15565
-      parent: 325
+      parent: 1
 - proto: DoorElectronics
   entities:
-  - uid: 331
+  - uid: 9
     components:
     - type: Transform
-      parent: 190
+      parent: 8
     - type: Physics
       canCollide: False
-  - uid: 332
+  - uid: 11
     components:
     - type: Transform
-      parent: 191
+      parent: 10
     - type: Physics
       canCollide: False
-  - uid: 333
+  - uid: 13
     components:
     - type: Transform
-      parent: 192
+      parent: 12
     - type: Physics
       canCollide: False
-  - uid: 334
+  - uid: 15
     components:
     - type: Transform
-      parent: 193
+      parent: 14
     - type: Physics
       canCollide: False
-  - uid: 337
+  - uid: 17
     components:
     - type: Transform
-      parent: 196
+      parent: 16
     - type: Physics
       canCollide: False
-  - uid: 339
+  - uid: 19
     components:
     - type: Transform
-      parent: 198
+      parent: 18
     - type: Physics
       canCollide: False
-  - uid: 340
+  - uid: 21
     components:
     - type: Transform
-      parent: 199
+      parent: 20
     - type: Physics
       canCollide: False
-  - uid: 341
+  - uid: 23
     components:
     - type: Transform
-      parent: 200
+      parent: 22
     - type: Physics
       canCollide: False
-  - uid: 342
+  - uid: 25
     components:
     - type: Transform
-      parent: 201
+      parent: 24
     - type: Physics
       canCollide: False
-  - uid: 343
+  - uid: 27
     components:
     - type: Transform
-      parent: 202
+      parent: 26
     - type: Physics
       canCollide: False
-  - uid: 346
+  - uid: 97
     components:
     - type: Transform
-      parent: 206
+      parent: 96
     - type: Physics
       canCollide: False
 - proto: DresserFilled
   entities:
-  - uid: 85
+  - uid: 98
     components:
     - type: Transform
       pos: 0.5,-4.5
-      parent: 325
+      parent: 1
 - proto: DrinkNukieCan
   entities:
-  - uid: 144
+  - uid: 99
     components:
     - type: Transform
       pos: -2.6964839,-2.109029
-      parent: 325
+      parent: 1
 - proto: FaxMachineSyndie
   entities:
-  - uid: 46
+  - uid: 100
     components:
     - type: Transform
       pos: -1.5,-5.5
-      parent: 325
+      parent: 1
     - type: FaxMachine
       name: Striker
 - proto: FHAirlockExternalShuttleSyndicateLocked
   entities:
-  - uid: 142
+  - uid: 101
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-1.5
-      parent: 325
+      parent: 1
 - proto: FHAirlockSyndicateLocked
   entities:
-  - uid: 20
+  - uid: 102
     components:
     - type: Transform
       pos: -0.5,-3.5
-      parent: 325
-  - uid: 88
+      parent: 1
+  - uid: 103
     components:
     - type: Transform
       pos: -0.5,-6.5
-      parent: 325
+      parent: 1
 - proto: FHFoodBoxDonut
   entities:
-  - uid: 87
+  - uid: 104
     components:
     - type: Transform
       pos: -2.470145,-2.3953476
-      parent: 325
+      parent: 1
 - proto: filingCabinetRandom
   entities:
-  - uid: 75
+  - uid: 105
     components:
     - type: Transform
       pos: -1.5,-4.5
-      parent: 325
+      parent: 1
 - proto: Firelock
   entities:
-  - uid: 224
+  - uid: 106
     components:
     - type: Transform
       pos: -0.5,-3.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 350
+          - 107
     - type: DeviceNetwork
       address: 44a24659
       receiveFrequency: 1621
-  - uid: 225
+  - uid: 108
     components:
     - type: Transform
       pos: -0.5,-6.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 351
+          - 109
     - type: DeviceNetwork
       address: 6fdb75cf
       receiveFrequency: 1621
 - proto: FirelockElectronics
   entities:
-  - uid: 350
+  - uid: 107
     components:
     - type: Transform
-      parent: 224
+      parent: 106
     - type: Physics
       canCollide: False
-  - uid: 351
+  - uid: 109
     components:
     - type: Transform
-      parent: 225
+      parent: 108
     - type: Physics
       canCollide: False
 - proto: GasPipeFourway
   entities:
-  - uid: 216
+  - uid: 110
     components:
     - type: Transform
       pos: -0.5,-1.5
-      parent: 325
+      parent: 1
 - proto: GasPipeStraight
   entities:
-  - uid: 211
+  - uid: 111
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-6.5
-      parent: 325
-  - uid: 213
+      parent: 1
+  - uid: 112
     components:
     - type: Transform
       pos: -0.5,-4.5
-      parent: 325
-  - uid: 214
+      parent: 1
+  - uid: 113
     components:
     - type: Transform
       pos: -0.5,-3.5
-      parent: 325
-  - uid: 215
+      parent: 1
+  - uid: 114
     components:
     - type: Transform
       pos: -0.5,-2.5
-      parent: 325
-  - uid: 217
+      parent: 1
+  - uid: 115
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-0.5
-      parent: 325
+      parent: 1
 - proto: GasPipeTJunction
   entities:
-  - uid: 210
+  - uid: 116
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-7.5
-      parent: 325
-  - uid: 212
+      parent: 1
+  - uid: 117
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-5.5
-      parent: 325
+      parent: 1
 - proto: GasPort
   entities:
-  - uid: 59
+  - uid: 118
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-8.5
-      parent: 325
+      parent: 1
 - proto: GasVentPump
   entities:
-  - uid: 218
+  - uid: 119
     components:
     - type: Transform
       pos: -0.5,0.5
-      parent: 325
+      parent: 1
     - type: DeviceNetwork
       address: Vnt-5f41a0ae
       transmitFrequency: 1621
       receiveFrequency: 1621
-  - uid: 219
+  - uid: 120
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-1.5
-      parent: 325
+      parent: 1
     - type: DeviceNetwork
       address: Vnt-129c27d2
       transmitFrequency: 1621
       receiveFrequency: 1621
-  - uid: 220
+  - uid: 121
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-1.5
-      parent: 325
+      parent: 1
     - type: DeviceNetwork
       address: Vnt-11c4609d
       transmitFrequency: 1621
       receiveFrequency: 1621
-  - uid: 221
+  - uid: 122
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-5.5
-      parent: 325
+      parent: 1
     - type: DeviceNetwork
       address: Vnt-6859729f
       transmitFrequency: 1621
       receiveFrequency: 1621
-  - uid: 222
+  - uid: 123
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-7.5
-      parent: 325
+      parent: 1
     - type: DeviceNetwork
       address: Vnt-19d24c7f
       transmitFrequency: 1621
       receiveFrequency: 1621
 - proto: GeneratorBasic15kW
   entities:
-  - uid: 41
+  - uid: 72
     components:
     - type: Transform
       pos: -2.5,-7.5
-      parent: 325
+      parent: 1
     - type: PowerSupplier
       supplyRampPosition: 7552.5303
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           ents:
-          - 232
+          - 76
         machine_parts: !type:Container
           ents:
-          - 233
-          - 234
-          - 235
-  - uid: 56
+          - 74
+          - 75
+          - 73
+  - uid: 77
     components:
     - type: Transform
       pos: 1.5,-7.5
-      parent: 325
+      parent: 1
     - type: PowerSupplier
       supplyRampPosition: 7552.5303
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           ents:
-          - 236
+          - 81
         machine_parts: !type:Container
           ents:
-          - 237
-          - 238
-          - 239
+          - 79
+          - 80
+          - 78
 - proto: GravityGeneratorMini
   entities:
-  - uid: 57
+  - uid: 124
     components:
     - type: Transform
       pos: -1.5,-8.5
-      parent: 325
+      parent: 1
 - proto: Grille
   entities:
-  - uid: 1
+  - uid: 125
     components:
     - type: Transform
       pos: -0.5,2.5
-      parent: 325
-  - uid: 2
+      parent: 1
+  - uid: 126
     components:
     - type: Transform
       pos: -1.5,2.5
-      parent: 325
-  - uid: 3
+      parent: 1
+  - uid: 127
     components:
     - type: Transform
       pos: -1.5,1.5
-      parent: 325
-  - uid: 4
+      parent: 1
+  - uid: 128
     components:
     - type: Transform
       pos: 0.5,2.5
-      parent: 325
-  - uid: 5
+      parent: 1
+  - uid: 129
     components:
     - type: Transform
       pos: 0.5,1.5
-      parent: 325
-  - uid: 21
+      parent: 1
+  - uid: 130
     components:
     - type: Transform
       pos: 3.5,-1.5
-      parent: 325
-  - uid: 50
+      parent: 1
+  - uid: 131
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-5.5
-      parent: 325
-  - uid: 51
+      parent: 1
+  - uid: 132
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-4.5
-      parent: 325
-  - uid: 52
+      parent: 1
+  - uid: 133
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-5.5
-      parent: 325
-  - uid: 53
+      parent: 1
+  - uid: 134
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-4.5
-      parent: 325
+      parent: 1
 - proto: Gyroscope
   entities:
-  - uid: 58
+  - uid: 135
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-8.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 240
+          - 136
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 241
-          - 242
-          - 243
-          - 244
+          - 137
+          - 138
+          - 139
+          - 140
 - proto: GyroscopeMachineCircuitboard
   entities:
-  - uid: 240
+  - uid: 136
     components:
     - type: Transform
-      parent: 58
+      parent: 135
     - type: Physics
       canCollide: False
 - proto: HandheldStationMapNukeops
   entities:
-  - uid: 168
+  - uid: 141
     components:
     - type: Transform
       pos: 1.493886,-2.2168128
-      parent: 325
+      parent: 1
 - proto: MedkitCombatFilled
   entities:
-  - uid: 19
+  - uid: 142
     components:
     - type: Transform
       pos: 1.48298,-0.3211529
-      parent: 325
+      parent: 1
 - proto: MicroManipulatorStockPart
   entities:
-  - uid: 233
+  - uid: 74
     components:
     - type: Transform
-      parent: 41
+      parent: 72
     - type: Physics
       canCollide: False
-  - uid: 234
+  - uid: 75
     components:
     - type: Transform
-      parent: 41
+      parent: 72
     - type: Physics
       canCollide: False
-  - uid: 237
+  - uid: 79
     components:
     - type: Transform
-      parent: 56
+      parent: 77
     - type: Physics
       canCollide: False
-  - uid: 238
+  - uid: 80
     components:
     - type: Transform
-      parent: 56
+      parent: 77
     - type: Physics
       canCollide: False
-  - uid: 241
+  - uid: 137
     components:
     - type: Transform
-      parent: 58
+      parent: 135
     - type: Physics
       canCollide: False
-  - uid: 242
+  - uid: 138
     components:
     - type: Transform
-      parent: 58
+      parent: 135
     - type: Physics
       canCollide: False
-  - uid: 243
+  - uid: 139
     components:
     - type: Transform
-      parent: 58
+      parent: 135
     - type: Physics
       canCollide: False
-  - uid: 250
+  - uid: 144
     components:
     - type: Transform
-      parent: 95
+      parent: 143
     - type: Physics
       canCollide: False
-  - uid: 251
+  - uid: 145
     components:
     - type: Transform
-      parent: 95
+      parent: 143
     - type: Physics
       canCollide: False
-  - uid: 252
+  - uid: 146
     components:
     - type: Transform
-      parent: 95
+      parent: 143
     - type: Physics
       canCollide: False
-  - uid: 253
+  - uid: 147
     components:
     - type: Transform
-      parent: 95
+      parent: 143
     - type: Physics
       canCollide: False
-  - uid: 254
+  - uid: 148
     components:
     - type: Transform
-      parent: 95
+      parent: 143
     - type: Physics
       canCollide: False
-  - uid: 257
+  - uid: 152
     components:
     - type: Transform
-      parent: 96
+      parent: 151
     - type: Physics
       canCollide: False
-  - uid: 258
+  - uid: 153
     components:
     - type: Transform
-      parent: 96
+      parent: 151
     - type: Physics
       canCollide: False
-  - uid: 259
+  - uid: 154
     components:
     - type: Transform
-      parent: 96
+      parent: 151
     - type: Physics
       canCollide: False
-  - uid: 260
+  - uid: 155
     components:
     - type: Transform
-      parent: 96
+      parent: 151
     - type: Physics
       canCollide: False
-  - uid: 261
+  - uid: 156
     components:
     - type: Transform
-      parent: 96
+      parent: 151
     - type: Physics
       canCollide: False
-  - uid: 264
+  - uid: 160
     components:
     - type: Transform
-      parent: 97
+      parent: 159
     - type: Physics
       canCollide: False
-  - uid: 265
+  - uid: 161
     components:
     - type: Transform
-      parent: 97
+      parent: 159
     - type: Physics
       canCollide: False
-  - uid: 266
+  - uid: 162
     components:
     - type: Transform
-      parent: 97
+      parent: 159
     - type: Physics
       canCollide: False
-  - uid: 267
+  - uid: 163
     components:
     - type: Transform
-      parent: 97
+      parent: 159
     - type: Physics
       canCollide: False
-  - uid: 268
+  - uid: 164
     components:
     - type: Transform
-      parent: 97
+      parent: 159
     - type: Physics
       canCollide: False
-  - uid: 271
+  - uid: 168
     components:
     - type: Transform
-      parent: 98
+      parent: 167
     - type: Physics
       canCollide: False
-  - uid: 272
+  - uid: 169
     components:
     - type: Transform
-      parent: 98
+      parent: 167
     - type: Physics
       canCollide: False
-  - uid: 273
+  - uid: 170
     components:
     - type: Transform
-      parent: 98
+      parent: 167
     - type: Physics
       canCollide: False
-  - uid: 274
+  - uid: 171
     components:
     - type: Transform
-      parent: 98
+      parent: 167
     - type: Physics
       canCollide: False
-  - uid: 275
+  - uid: 172
     components:
     - type: Transform
-      parent: 98
+      parent: 167
     - type: Physics
       canCollide: False
-  - uid: 278
+  - uid: 176
     components:
     - type: Transform
-      parent: 99
+      parent: 175
     - type: Physics
       canCollide: False
-  - uid: 279
+  - uid: 177
     components:
     - type: Transform
-      parent: 99
+      parent: 175
     - type: Physics
       canCollide: False
-  - uid: 280
+  - uid: 178
     components:
     - type: Transform
-      parent: 99
+      parent: 175
     - type: Physics
       canCollide: False
-  - uid: 281
+  - uid: 179
     components:
     - type: Transform
-      parent: 99
+      parent: 175
     - type: Physics
       canCollide: False
-  - uid: 282
+  - uid: 180
     components:
     - type: Transform
-      parent: 99
+      parent: 175
     - type: Physics
       canCollide: False
-  - uid: 285
+  - uid: 184
     components:
     - type: Transform
-      parent: 100
+      parent: 183
     - type: Physics
       canCollide: False
-  - uid: 286
+  - uid: 185
     components:
     - type: Transform
-      parent: 100
+      parent: 183
     - type: Physics
       canCollide: False
-  - uid: 287
+  - uid: 186
     components:
     - type: Transform
-      parent: 100
+      parent: 183
     - type: Physics
       canCollide: False
-  - uid: 288
+  - uid: 187
     components:
     - type: Transform
-      parent: 100
+      parent: 183
     - type: Physics
       canCollide: False
-  - uid: 289
+  - uid: 188
     components:
     - type: Transform
-      parent: 100
+      parent: 183
     - type: Physics
       canCollide: False
-  - uid: 292
+  - uid: 192
     components:
     - type: Transform
-      parent: 101
+      parent: 191
     - type: Physics
       canCollide: False
-  - uid: 293
+  - uid: 193
     components:
     - type: Transform
-      parent: 101
+      parent: 191
     - type: Physics
       canCollide: False
-  - uid: 294
+  - uid: 194
     components:
     - type: Transform
-      parent: 101
+      parent: 191
     - type: Physics
       canCollide: False
-  - uid: 295
+  - uid: 195
     components:
     - type: Transform
-      parent: 101
+      parent: 191
     - type: Physics
       canCollide: False
-  - uid: 296
+  - uid: 196
     components:
     - type: Transform
-      parent: 101
+      parent: 191
     - type: Physics
       canCollide: False
-  - uid: 299
+  - uid: 200
     components:
     - type: Transform
-      parent: 102
+      parent: 199
     - type: Physics
       canCollide: False
-  - uid: 300
+  - uid: 201
     components:
     - type: Transform
-      parent: 102
+      parent: 199
     - type: Physics
       canCollide: False
-  - uid: 301
+  - uid: 202
     components:
     - type: Transform
-      parent: 102
+      parent: 199
     - type: Physics
       canCollide: False
-  - uid: 302
+  - uid: 203
     components:
     - type: Transform
-      parent: 102
+      parent: 199
     - type: Physics
       canCollide: False
-  - uid: 303
+  - uid: 204
     components:
     - type: Transform
-      parent: 102
+      parent: 199
     - type: Physics
       canCollide: False
 - proto: Mirror
   entities:
-  - uid: 321
+  - uid: 207
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-3.5
-      parent: 325
+      parent: 1
     - type: Fixtures
       fixtures: {}
 - proto: NitrogenTankFilled
   entities:
-  - uid: 105
+  - uid: 208
     components:
     - type: Transform
       pos: 1.373605,-0.2749618
-      parent: 325
+      parent: 1
 - proto: NukeCodePaper
   entities:
-  - uid: 323
+  - uid: 209
     components:
     - type: Transform
       pos: 1.561105,-2.5567772
-      parent: 325
+      parent: 1
 - proto: OxygenTankFilled
   entities:
-  - uid: 167
+  - uid: 210
     components:
     - type: Transform
       pos: 1.60798,-0.3062118
-      parent: 325
+      parent: 1
 - proto: PinpointerNuclear
   entities:
-  - uid: 162
+  - uid: 211
     components:
     - type: Transform
       pos: 1.3790641,-2.3161128
-      parent: 325
+      parent: 1
     - type: Physics
       canCollide: False
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 104
+  - uid: 212
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-0.5
-      parent: 325
-  - uid: 109
+      parent: 1
+  - uid: 213
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-0.5
-      parent: 325
+      parent: 1
 - proto: PlushieNuke
   entities:
-  - uid: 47
+  - uid: 214
     components:
     - type: Transform
       pos: 0.5061571,-5.233775
-      parent: 325
+      parent: 1
 - proto: PortableGeneratorSuperPacmanMachineCircuitboard
   entities:
-  - uid: 232
+  - uid: 76
     components:
     - type: Transform
-      parent: 41
+      parent: 72
     - type: Physics
       canCollide: False
-  - uid: 236
+  - uid: 81
     components:
     - type: Transform
-      parent: 56
+      parent: 77
     - type: Physics
       canCollide: False
 - proto: PosterContrabandC20r
   entities:
-  - uid: 24
+  - uid: 215
     components:
     - type: Transform
       pos: 2.5,-2.5
-      parent: 325
+      parent: 1
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandEnergySwords
   entities:
-  - uid: 227
+  - uid: 216
     components:
     - type: Transform
       pos: -2.5,-6.5
-      parent: 325
+      parent: 1
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandNuclearDeviceInformational
   entities:
-  - uid: 228
+  - uid: 217
     components:
     - type: Transform
       pos: -2.5,0.5
-      parent: 325
+      parent: 1
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandSyndicateRecruitment
   entities:
-  - uid: 229
+  - uid: 218
     components:
     - type: Transform
       pos: 0.5,-3.5
-      parent: 325
+      parent: 1
     - type: Fixtures
       fixtures: {}
 - proto: Poweredlight
   entities:
-  - uid: 94
+  - uid: 219
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,0.5
-      parent: 325
-  - uid: 110
+      parent: 1
+  - uid: 220
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-2.5
-      parent: 325
+      parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 182
+  - uid: 221
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-5.5
-      parent: 325
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 183
+  - uid: 222
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-5.5
-      parent: 325
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 184
+  - uid: 223
     components:
     - type: Transform
       pos: -1.5,-7.5
-      parent: 325
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
 - proto: PoweredSmallLight
   entities:
-  - uid: 204
+  - uid: 224
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-5.5
-      parent: 325
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
 - proto: Rack
   entities:
-  - uid: 83
+  - uid: 225
     components:
     - type: Transform
       pos: 1.5,-0.5
-      parent: 325
-  - uid: 84
+      parent: 1
+  - uid: 226
     components:
     - type: Transform
       pos: 1.5,-2.5
-      parent: 325
+      parent: 1
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 14
+  - uid: 227
     components:
     - type: Transform
       pos: -1.5,1.5
-      parent: 325
-  - uid: 15
+      parent: 1
+  - uid: 228
     components:
     - type: Transform
       pos: -1.5,2.5
-      parent: 325
-  - uid: 16
+      parent: 1
+  - uid: 229
     components:
     - type: Transform
       pos: -0.5,2.5
-      parent: 325
-  - uid: 17
+      parent: 1
+  - uid: 230
     components:
     - type: Transform
       pos: 0.5,2.5
-      parent: 325
-  - uid: 18
+      parent: 1
+  - uid: 231
     components:
     - type: Transform
       pos: 0.5,1.5
-      parent: 325
-  - uid: 26
+      parent: 1
+  - uid: 232
     components:
     - type: Transform
       pos: 3.5,-1.5
-      parent: 325
-  - uid: 42
+      parent: 1
+  - uid: 233
     components:
     - type: Transform
       pos: 1.5,-4.5
-      parent: 325
-  - uid: 70
+      parent: 1
+  - uid: 234
     components:
     - type: Transform
       pos: 1.5,-5.5
-      parent: 325
-  - uid: 71
+      parent: 1
+  - uid: 235
     components:
     - type: Transform
       pos: -2.5,-4.5
-      parent: 325
-  - uid: 72
+      parent: 1
+  - uid: 236
     components:
     - type: Transform
       pos: -2.5,-5.5
-      parent: 325
+      parent: 1
 - proto: RemoteSignaller
   entities:
-  - uid: 176
+  - uid: 237
     components:
     - type: Transform
       pos: 1.3427892,-2.379079
-      parent: 325
+      parent: 1
     - type: Physics
       canCollide: False
 - proto: SheetGlass1
   entities:
-  - uid: 244
+  - uid: 140
     components:
     - type: Transform
-      parent: 58
+      parent: 135
     - type: Stack
       count: 2
     - type: Physics
       canCollide: False
 - proto: SheetSteel1
   entities:
-  - uid: 255
+  - uid: 149
     components:
     - type: Transform
-      parent: 95
+      parent: 143
     - type: Stack
       count: 5
     - type: Physics
       canCollide: False
-  - uid: 262
+  - uid: 157
     components:
     - type: Transform
-      parent: 96
+      parent: 151
     - type: Stack
       count: 5
     - type: Physics
       canCollide: False
-  - uid: 269
+  - uid: 165
     components:
     - type: Transform
-      parent: 97
+      parent: 159
     - type: Stack
       count: 5
     - type: Physics
       canCollide: False
-  - uid: 276
+  - uid: 173
     components:
     - type: Transform
-      parent: 98
+      parent: 167
     - type: Stack
       count: 5
     - type: Physics
       canCollide: False
-  - uid: 283
+  - uid: 181
     components:
     - type: Transform
-      parent: 99
+      parent: 175
     - type: Stack
       count: 5
     - type: Physics
       canCollide: False
-  - uid: 290
+  - uid: 189
     components:
     - type: Transform
-      parent: 100
+      parent: 183
     - type: Stack
       count: 5
     - type: Physics
       canCollide: False
-  - uid: 297
+  - uid: 197
     components:
     - type: Transform
-      parent: 101
+      parent: 191
     - type: Stack
       count: 5
     - type: Physics
       canCollide: False
-  - uid: 304
+  - uid: 205
     components:
     - type: Transform
-      parent: 102
+      parent: 199
     - type: Stack
       count: 5
     - type: Physics
       canCollide: False
 - proto: SignalButton
   entities:
-  - uid: 205
+  - uid: 238
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-3.5
-      parent: 325
+      parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        193:
+        14:
         - - Pressed
           - Toggle
-        192:
+        12:
         - - Pressed
           - Toggle
-        190:
+        8:
         - - Pressed
           - Toggle
-        191:
+        10:
         - - Pressed
           - Toggle
-        196:
+        16:
         - - Pressed
           - Toggle
-        202:
+        26:
         - - Pressed
           - Toggle
-        201:
+        24:
         - - Pressed
           - Toggle
-        200:
+        22:
         - - Pressed
           - Toggle
-        199:
+        20:
         - - Pressed
           - Toggle
-        198:
+        18:
         - - Pressed
           - Toggle
     - type: Fixtures
       fixtures: {}
 - proto: SignSpace
   entities:
-  - uid: 230
+  - uid: 239
     components:
     - type: Transform
       pos: -3.5,-0.5
-      parent: 325
+      parent: 1
     - type: Fixtures
       fixtures: {}
 - proto: SoapSyndie
   entities:
-  - uid: 90
+  - uid: 240
     components:
     - type: Transform
       pos: 0.5436061,-7.5129323
-      parent: 325
+      parent: 1
 - proto: SpawnPointNukies
   entities:
-  - uid: 322
+  - uid: 241
     components:
     - type: Transform
       pos: -0.5,-4.5
-      parent: 325
+      parent: 1
 - proto: StealthBox
   entities:
-  - uid: 106
+  - uid: 242
     components:
     - type: Transform
       pos: 0.49860507,-2.4513345
-      parent: 325
+      parent: 1
     - type: Stealth
       enabled: False
     - type: EntityStorage
       open: True
 - proto: SubstationWallBasic
   entities:
-  - uid: 103
+  - uid: 243
     components:
     - type: Transform
       pos: -1.5,-6.5
-      parent: 325
+      parent: 1
     - type: PowerNetworkBattery
       loadingNetworkDemand: 15106.935
       currentReceiving: 15105.06
@@ -1830,27 +1820,27 @@ entities:
       supplyRampPosition: 1.875
 - proto: SuitStorageSyndie
   entities:
-  - uid: 67
+  - uid: 244
     components:
     - type: Transform
       pos: 2.5,-1.5
-      parent: 325
+      parent: 1
 - proto: SyndicateCommsComputerCircuitboard
   entities:
   - uid: 246
     components:
     - type: Transform
-      parent: 65
+      parent: 245
     - type: Physics
       canCollide: False
 - proto: SyndicateComputerComms
   entities:
-  - uid: 65
+  - uid: 245
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,0.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
@@ -1864,550 +1854,550 @@ entities:
           ent: null
 - proto: SyndicateIDCard
   entities:
-  - uid: 324
+  - uid: 247
     components:
     - type: Transform
       pos: 1.57673,-2.3849022
-      parent: 325
+      parent: 1
 - proto: SyndicateShuttleConsoleCircuitboard
   entities:
-  - uid: 245
+  - uid: 94
     components:
     - type: Transform
-      parent: 64
+      parent: 93
     - type: Physics
       canCollide: False
 - proto: Table
   entities:
-  - uid: 165
+  - uid: 248
     components:
     - type: Transform
       pos: -2.5,-2.5
-      parent: 325
+      parent: 1
 - proto: TableWood
-  entities:
-  - uid: 45
-    components:
-    - type: Transform
-      pos: -1.5,-5.5
-      parent: 325
-- proto: Thruster
-  entities:
-  - uid: 95
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-9.5
-      parent: 325
-    - type: ContainerContainer
-      containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 249
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 250
-          - 251
-          - 252
-          - 253
-          - 254
-          - 255
-  - uid: 96
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-9.5
-      parent: 325
-    - type: ContainerContainer
-      containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 256
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 257
-          - 258
-          - 259
-          - 260
-          - 261
-          - 262
-  - uid: 97
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-4.5
-      parent: 325
-    - type: ContainerContainer
-      containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 263
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 264
-          - 265
-          - 266
-          - 267
-          - 268
-          - 269
-  - uid: 98
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-5.5
-      parent: 325
-    - type: ContainerContainer
-      containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 270
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 271
-          - 272
-          - 273
-          - 274
-          - 275
-          - 276
-  - uid: 99
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-4.5
-      parent: 325
-    - type: ContainerContainer
-      containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 277
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 278
-          - 279
-          - 280
-          - 281
-          - 282
-          - 283
-  - uid: 100
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-5.5
-      parent: 325
-    - type: ContainerContainer
-      containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 284
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 285
-          - 286
-          - 287
-          - 288
-          - 289
-          - 290
-  - uid: 101
-    components:
-    - type: Transform
-      pos: -3.5,1.5
-      parent: 325
-    - type: ContainerContainer
-      containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 291
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 292
-          - 293
-          - 294
-          - 295
-          - 296
-          - 297
-  - uid: 102
-    components:
-    - type: Transform
-      pos: 2.5,1.5
-      parent: 325
-    - type: ContainerContainer
-      containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 298
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 299
-          - 300
-          - 301
-          - 302
-          - 303
-          - 304
-- proto: ThrusterMachineCircuitboard
   entities:
   - uid: 249
     components:
     - type: Transform
-      parent: 95
-    - type: Physics
-      canCollide: False
-  - uid: 256
+      pos: -1.5,-5.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 143
     components:
     - type: Transform
-      parent: 96
-    - type: Physics
-      canCollide: False
-  - uid: 263
+      rot: 3.141592653589793 rad
+      pos: -3.5,-9.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 150
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 144
+          - 145
+          - 146
+          - 147
+          - 148
+          - 149
+  - uid: 151
     components:
     - type: Transform
-      parent: 97
-    - type: Physics
-      canCollide: False
-  - uid: 270
+      rot: 3.141592653589793 rad
+      pos: 2.5,-9.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 158
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 152
+          - 153
+          - 154
+          - 155
+          - 156
+          - 157
+  - uid: 159
     components:
     - type: Transform
-      parent: 98
-    - type: Physics
-      canCollide: False
-  - uid: 277
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 166
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 160
+          - 161
+          - 162
+          - 163
+          - 164
+          - 165
+  - uid: 167
     components:
     - type: Transform
-      parent: 99
-    - type: Physics
-      canCollide: False
-  - uid: 284
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-5.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 174
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 168
+          - 169
+          - 170
+          - 171
+          - 172
+          - 173
+  - uid: 175
     components:
     - type: Transform
-      parent: 100
-    - type: Physics
-      canCollide: False
-  - uid: 291
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-4.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 182
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 176
+          - 177
+          - 178
+          - 179
+          - 180
+          - 181
+  - uid: 183
     components:
     - type: Transform
-      parent: 101
-    - type: Physics
-      canCollide: False
-  - uid: 298
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 190
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 184
+          - 185
+          - 186
+          - 187
+          - 188
+          - 189
+  - uid: 191
     components:
     - type: Transform
-      parent: 102
+      pos: -3.5,1.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 198
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 192
+          - 193
+          - 194
+          - 195
+          - 196
+          - 197
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 206
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 200
+          - 201
+          - 202
+          - 203
+          - 204
+          - 205
+- proto: ThrusterMachineCircuitboard
+  entities:
+  - uid: 150
+    components:
+    - type: Transform
+      parent: 143
+    - type: Physics
+      canCollide: False
+  - uid: 158
+    components:
+    - type: Transform
+      parent: 151
+    - type: Physics
+      canCollide: False
+  - uid: 166
+    components:
+    - type: Transform
+      parent: 159
+    - type: Physics
+      canCollide: False
+  - uid: 174
+    components:
+    - type: Transform
+      parent: 167
+    - type: Physics
+      canCollide: False
+  - uid: 182
+    components:
+    - type: Transform
+      parent: 175
+    - type: Physics
+      canCollide: False
+  - uid: 190
+    components:
+    - type: Transform
+      parent: 183
+    - type: Physics
+      canCollide: False
+  - uid: 198
+    components:
+    - type: Transform
+      parent: 191
+    - type: Physics
+      canCollide: False
+  - uid: 206
+    components:
+    - type: Transform
+      parent: 199
     - type: Physics
       canCollide: False
 - proto: ToolboxSyndicateFilled
   entities:
-  - uid: 177
+  - uid: 250
     components:
     - type: Transform
       pos: 1.5699697,-0.44908836
-      parent: 325
+      parent: 1
     - type: Physics
       canCollide: False
 - proto: ToyFigurineNukie
   entities:
-  - uid: 10
+  - uid: 251
     components:
     - type: Transform
       pos: -2.3371089,-2.140279
-      parent: 325
+      parent: 1
 - proto: VendingMachineSyndieDrobe
   entities:
-  - uid: 163
+  - uid: 252
     components:
     - type: Transform
       pos: -2.5,-0.5
-      parent: 325
+      parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 7
+  - uid: 253
     components:
     - type: Transform
       pos: -2.5,0.5
-      parent: 325
-  - uid: 8
+      parent: 1
+  - uid: 254
     components:
     - type: Transform
       pos: -3.5,0.5
-      parent: 325
-  - uid: 9
+      parent: 1
+  - uid: 255
     components:
     - type: Transform
       pos: -3.5,-0.5
-      parent: 325
-  - uid: 11
+      parent: 1
+  - uid: 256
     components:
     - type: Transform
       pos: 1.5,0.5
-      parent: 325
-  - uid: 12
+      parent: 1
+  - uid: 257
     components:
     - type: Transform
       pos: 2.5,0.5
-      parent: 325
-  - uid: 13
+      parent: 1
+  - uid: 258
     components:
     - type: Transform
       pos: -4.5,-0.5
-      parent: 325
-  - uid: 22
+      parent: 1
+  - uid: 259
     components:
     - type: Transform
       pos: 3.5,-0.5
-      parent: 325
-  - uid: 25
+      parent: 1
+  - uid: 260
     components:
     - type: Transform
       pos: 3.5,-2.5
-      parent: 325
-  - uid: 27
+      parent: 1
+  - uid: 261
     components:
     - type: Transform
       pos: -3.5,-2.5
-      parent: 325
-  - uid: 28
+      parent: 1
+  - uid: 262
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-6.5
-      parent: 325
-  - uid: 29
+      parent: 1
+  - uid: 263
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-6.5
-      parent: 325
-  - uid: 30
+      parent: 1
+  - uid: 264
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-6.5
-      parent: 325
-  - uid: 31
+      parent: 1
+  - uid: 265
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-8.5
-      parent: 325
-  - uid: 32
+      parent: 1
+  - uid: 266
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-8.5
-      parent: 325
-  - uid: 33
+      parent: 1
+  - uid: 267
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-6.5
-      parent: 325
-  - uid: 34
+      parent: 1
+  - uid: 268
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-3.5
-      parent: 325
-  - uid: 35
+      parent: 1
+  - uid: 269
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-9.5
-      parent: 325
-  - uid: 36
+      parent: 1
+  - uid: 270
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-8.5
-      parent: 325
-  - uid: 37
+      parent: 1
+  - uid: 271
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-9.5
-      parent: 325
-  - uid: 38
+      parent: 1
+  - uid: 272
     components:
     - type: Transform
       pos: -4.5,-2.5
-      parent: 325
-  - uid: 39
+      parent: 1
+  - uid: 273
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-3.5
-      parent: 325
-  - uid: 44
+      parent: 1
+  - uid: 274
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-8.5
-      parent: 325
-  - uid: 48
+      parent: 1
+  - uid: 275
     components:
     - type: Transform
       pos: 2.5,-7.5
-      parent: 325
-  - uid: 49
+      parent: 1
+  - uid: 276
     components:
     - type: Transform
       pos: -3.5,-7.5
-      parent: 325
-  - uid: 54
+      parent: 1
+  - uid: 277
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-3.5
-      parent: 325
-  - uid: 55
+      parent: 1
+  - uid: 278
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-3.5
-      parent: 325
-  - uid: 60
+      parent: 1
+  - uid: 279
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-6.5
-      parent: 325
-  - uid: 61
+      parent: 1
+  - uid: 280
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-6.5
-      parent: 325
-  - uid: 62
+      parent: 1
+  - uid: 281
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-3.5
-      parent: 325
-  - uid: 63
+      parent: 1
+  - uid: 282
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-3.5
-      parent: 325
-  - uid: 66
+      parent: 1
+  - uid: 283
     components:
     - type: Transform
       pos: 0.5,-9.5
-      parent: 325
-  - uid: 69
+      parent: 1
+  - uid: 284
     components:
     - type: Transform
       pos: -2.5,1.5
-      parent: 325
-  - uid: 73
+      parent: 1
+  - uid: 285
     components:
     - type: Transform
       pos: 1.5,1.5
-      parent: 325
-  - uid: 80
+      parent: 1
+  - uid: 286
     components:
     - type: Transform
       pos: 2.5,-2.5
-      parent: 325
-  - uid: 81
+      parent: 1
+  - uid: 287
     components:
     - type: Transform
       pos: 2.5,-0.5
-      parent: 325
-  - uid: 92
+      parent: 1
+  - uid: 288
     components:
     - type: Transform
       pos: -1.5,-9.5
-      parent: 325
-  - uid: 108
+      parent: 1
+  - uid: 289
     components:
     - type: Transform
       pos: -0.5,-9.5
-      parent: 325
+      parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 23
+  - uid: 290
     components:
     - type: Transform
       pos: -4.5,0.5
-      parent: 325
-  - uid: 43
+      parent: 1
+  - uid: 291
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,0.5
-      parent: 325
-  - uid: 68
+      parent: 1
+  - uid: 292
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,2.5
-      parent: 325
-  - uid: 79
+      parent: 1
+  - uid: 293
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-3.5
-      parent: 325
-  - uid: 82
+      parent: 1
+  - uid: 294
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-3.5
-      parent: 325
-  - uid: 86
+      parent: 1
+  - uid: 295
     components:
     - type: Transform
       pos: -2.5,2.5
-      parent: 325
+      parent: 1
 - proto: WindoorSecure
   entities:
-  - uid: 166
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-1.5
-      parent: 325
-  - uid: 206
+  - uid: 96
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-0.5
-      parent: 325
+      parent: 1
     - type: ContainerContainer
       containers:
         board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 346
+          - 97
+  - uid: 296
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
 ...

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -264,7 +264,7 @@
     boltClosed: null
   - type: Gun
     fireRate: 5.5
-    minAngle: 1
+    minAngle: 1 #FH
     maxAngle: 6
     angleIncrease: 1.5
     angleDecay: 6
@@ -276,10 +276,13 @@
     - Burst
     - FullAuto
     - SemiAuto
-  - type: Wieldable # Far Horizons
-    unwieldOnUse: false # Far Horizons
-  - type: GunWieldBonus # Far Horizons
-    maxAngle: -4 # Far Horizons
+#FH - Start
+  - type: Wieldable
+    unwieldOnUse: false
+  - type: GunWieldBonus
+    minAngle: -1
+    maxAngle: -4
+#FH - End
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -613,7 +613,7 @@
   # Yes, it is stupid
   - type: RuleGrids
   - type: LoadMapRule
-    gridPath: /Maps/Shuttles/ShuttleEvent/striker.yml
+    gridPath: /Maps/_FarHorizons/Shuttles/ShuttleEvent/fhstriker.yml
   # Far Horizons end
   - type: DynamicRuleCost
     cost: 75

--- a/Resources/Prototypes/_FarHorizons/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/_FarHorizons/Catalog/Fills/Backpacks/duffelbag.yml
@@ -347,7 +347,7 @@
           amount: 5
         - id: MagazineBoxAntiMateriel
           amount: 4
-        - id: MagazineMagnum
+        - id: MagazineMagnumFMJ
           amount: 4
 
 #region NeoSol


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Title.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Loneop doesn't have enough booolet. Flats mean they burn through bullets like nothing, so the default amount they get from buying guns just isn't enough and the ammo bundle ends up becoming a required purchase, eating up TC that could otherwise be used for other things.

I think it would be more fun for everyone if that TC sink was filled.
While I had the files open, I also fixed the FMJ ammo bundle spawning with .44 SP, as well as the WT spread being really fucked if you wield it.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="484" height="453" alt="udtgykuytgjk" src="https://github.com/user-attachments/assets/dacd4db1-ef87-492e-93bb-b75d432f5584" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Killer Tamashi
- add: Added Ammo Bundle Selector to Loneops Ship.
- fix: Fixed WT500 spread being somehow worse when wielded.
- fix: Fixed .44 Magnum magazines spawning as SP in the FMJ ammo bundle.