### PR TITLE
slight meat nerf

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Procedural/salvage_factions.yml
+++ b/Resources/Prototypes/_FarHorizons/Procedural/salvage_factions.yml
@@ -33,13 +33,13 @@
     - proto: MobDungeonMeatFast
       cost: 1
     - proto: MobDungeonMeatGuy
-      cost: 2
+      cost: 4
       prob: 0.7
     - proto: MobDungeonMeatFlying
       cost: 2
       prob: 0.6
     - proto: MobDungeonMeatGiant
-      cost: 4
+      cost: 6
       prob: 0.25
   difficulties: 
     - Easy


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
It was just a little bit too much meat

## Why we need to add this
To have lower quantities of meat

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- tweak: There's now a bit less meat spawning in meat expeditions
