### PR TITLE
Fire prevents mob splitting

### DIFF
--- a/Content.Shared/_FarHorizons/Mobs/MobSplittingComponent.cs
+++ b/Content.Shared/_FarHorizons/Mobs/MobSplittingComponent.cs
@@ -11,6 +11,7 @@ public sealed partial class MobSplittingComponent : Component
     [DataField(required: true)] public Dictionary<EntProtoId, MobSplittingConfig> SplitInto;
     [DataField] public SoundSpecifier? Sound;
     [DataField] public int ThrowRadius = 2;
+    [DataField] public bool FirePrevents = true;
 }
 
 [Serializable, NetSerializable, DataDefinition]

--- a/Content.Shared/_FarHorizons/Mobs/SharedMobSplittingSystem.cs
+++ b/Content.Shared/_FarHorizons/Mobs/SharedMobSplittingSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Atmos.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Throwing;
@@ -24,6 +25,11 @@ public sealed class SharedMobSplittingSystem : EntitySystem
     {
         if (!(args.NewMobState == MobState.Dead && args.OldMobState != MobState.Dead) ||
             TerminatingOrDeleted(ent))
+            return;
+
+        if (ent.Comp.FirePrevents &&
+            TryComp<FlammableComponent>(ent, out var flammable) &&
+            flammable.OnFire)
             return;
 
         _audio.PlayPredicted(ent.Comp.Sound, ent.Owner, ent.Owner);


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Mob splitting component (currently only meat) now comes with `firePrevents` argument that's on by default. When mob is burning it won't split

## Why we need to add this
General chat suggested it would be cool weakness to have

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/36863f58-f214-4567-b11a-d95352f62a66


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- tweak: Splitting flesh enemies in salvage dungeons won't split if they are on fire when they die
