### PR TITLE
proot visual fixes

### DIFF
--- a/Content.Shared/Body/VisualOrganMarkingsComponent.cs
+++ b/Content.Shared/Body/VisualOrganMarkingsComponent.cs
@@ -28,7 +28,7 @@ public sealed partial class VisualOrganMarkingsComponent : Component
     /// <summary>
     /// Layers that are eligible for hiding based on e.g. clothing
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField, AutoNetworkedField, AlwaysPushInheritance] // FH
     public HashSet<Enum> HideableLayers = new();
 
     /// <summary>

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -47,6 +47,11 @@
   parent: UnsensoredClothingUniformBase
   id: ClothingUniformBase
   #Far Horizons-Start
+  components:
+  - type: HideLayerClothing
+    slots:
+    - BodyCover
+    - BodyCoverCover
   # components:
   #- type: SuitSensor
   #- type: DeviceNetwork

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoArachnid.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoArachnid.yml
@@ -60,6 +60,12 @@
 - type: entity
   parent: [ OrganProtoArachnidExternal, OrganArachnidTorso ]
   id: OrganProtoArachnidTorso
+  components:
+  - type: VisualOrganMarkings
+    hideableLayers:
+    - enum.HumanoidVisualLayers.BodyCover
+    - enum.HumanoidVisualLayers.BodyCoverCover
+    - enum.HumanoidVisualLayers.TailCover
 
 - type: entity
   parent: [ OrganProtoArachnidExternal, OrganArachnidHead ]

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoArachnid.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoArachnid.yml
@@ -65,8 +65,7 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.BodyCover
     - enum.HumanoidVisualLayers.BodyCoverCover
-    - enum.HumanoidVisualLayers.TailCover
-
+    
 - type: entity
   parent: [ OrganProtoArachnidExternal, OrganArachnidHead ]
   id: OrganProtoArachnidHead

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoAvali.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoAvali.yml
@@ -70,6 +70,12 @@
 - type: entity
   parent: [ OrganProtoAvaliExternal, OrganAvaliTorso ]
   id: OrganProtoAvaliTorso
+  components:
+  - type: VisualOrganMarkings
+    hideableLayers:
+    - enum.HumanoidVisualLayers.BodyCover
+    - enum.HumanoidVisualLayers.BodyCoverCover
+    - enum.HumanoidVisualLayers.TailCover
 
 - type: entity
   parent: [ OrganProtoAvaliExternal, OrganAvaliHead ]

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoAvali.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoAvali.yml
@@ -75,7 +75,6 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.BodyCover
     - enum.HumanoidVisualLayers.BodyCoverCover
-    - enum.HumanoidVisualLayers.TailCover
 
 - type: entity
   parent: [ OrganProtoAvaliExternal, OrganAvaliHead ]

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoCyclops.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoCyclops.yml
@@ -75,8 +75,7 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.BodyCover
     - enum.HumanoidVisualLayers.BodyCoverCover
-    - enum.HumanoidVisualLayers.TailCover
-
+    
 - type: entity
   parent: [ OrganProtoCyclopsExternal, OrganCycloriteHead ]
   id: OrganProtoCyclopsHead

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoCyclops.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoCyclops.yml
@@ -70,6 +70,12 @@
 - type: entity
   parent: [ OrganProtoCyclopsExternal, OrganCycloriteTorso ]
   id: OrganProtoCyclopsTorso
+  components:
+  - type: VisualOrganMarkings
+    hideableLayers:
+    - enum.HumanoidVisualLayers.BodyCover
+    - enum.HumanoidVisualLayers.BodyCoverCover
+    - enum.HumanoidVisualLayers.TailCover
 
 - type: entity
   parent: [ OrganProtoCyclopsExternal, OrganCycloriteHead ]

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoDionae.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoDionae.yml
@@ -69,8 +69,7 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.BodyCover
     - enum.HumanoidVisualLayers.BodyCoverCover
-    - enum.HumanoidVisualLayers.TailCover
-
+    
 - type: entity
   parent: [ OrganProtoDionaeExternal, OrganDionaHead ]
   id: OrganProtoDionaeHead

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoDionae.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoDionae.yml
@@ -64,6 +64,12 @@
 - type: entity
   parent: [ OrganProtoDionaeExternal, OrganDionaTorso ]
   id: OrganProtoDionaeTorso
+  components:
+  - type: VisualOrganMarkings
+    hideableLayers:
+    - enum.HumanoidVisualLayers.BodyCover
+    - enum.HumanoidVisualLayers.BodyCoverCover
+    - enum.HumanoidVisualLayers.TailCover
 
 - type: entity
   parent: [ OrganProtoDionaeExternal, OrganDionaHead ]

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoFeline.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoFeline.yml
@@ -70,6 +70,12 @@
 - type: entity
   parent: [ OrganProtoFelineExternal, OrganFelionoidTorso ]
   id: OrganProtoFelineTorso
+  components:
+  - type: VisualOrganMarkings
+    hideableLayers:
+    - enum.HumanoidVisualLayers.BodyCover
+    - enum.HumanoidVisualLayers.BodyCoverCover
+    - enum.HumanoidVisualLayers.TailCover
 
 - type: entity
   parent: [ OrganProtoFelineExternal, OrganFelionoidHead ]

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoFeline.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoFeline.yml
@@ -75,8 +75,7 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.BodyCover
     - enum.HumanoidVisualLayers.BodyCoverCover
-    - enum.HumanoidVisualLayers.TailCover
-
+    
 - type: entity
   parent: [ OrganProtoFelineExternal, OrganFelionoidHead ]
   id: OrganProtoFelineHead

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoHumie.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoHumie.yml
@@ -60,6 +60,12 @@
 - type: entity
   parent: [ OrganProtoHumieExternal, OrganHumanTorso ]
   id: OrganProtoHumieTorso
+  components:
+  - type: VisualOrganMarkings
+    hideableLayers:
+    - enum.HumanoidVisualLayers.BodyCover
+    - enum.HumanoidVisualLayers.BodyCoverCover
+    - enum.HumanoidVisualLayers.TailCover
 
 - type: entity
   parent: [ OrganProtoHumieExternal, OrganHumanHead ]

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoHumie.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoHumie.yml
@@ -65,8 +65,7 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.BodyCover
     - enum.HumanoidVisualLayers.BodyCoverCover
-    - enum.HumanoidVisualLayers.TailCover
-
+    
 - type: entity
   parent: [ OrganProtoHumieExternal, OrganHumanHead ]
   id: OrganProtoHumieHead

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoKin.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoKin.yml
@@ -81,8 +81,7 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.BodyCover
     - enum.HumanoidVisualLayers.BodyCoverCover
-    - enum.HumanoidVisualLayers.TailCover
-
+    
 - type: entity
   parent: [ OrganProtoKinExternal, OrganShadekinHead ]
   id: OrganProtoKinHead

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoKin.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoKin.yml
@@ -76,6 +76,12 @@
 - type: entity
   parent: [ OrganProtoKinExternal, OrganShadekinTorso ]
   id: OrganProtoKinTorso
+  components:
+  - type: VisualOrganMarkings
+    hideableLayers:
+    - enum.HumanoidVisualLayers.BodyCover
+    - enum.HumanoidVisualLayers.BodyCoverCover
+    - enum.HumanoidVisualLayers.TailCover
 
 - type: entity
   parent: [ OrganProtoKinExternal, OrganShadekinHead ]

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoMoth.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoMoth.yml
@@ -64,6 +64,12 @@
 - type: entity
   parent: [ OrganProtoMothExternal, OrganMothTorso ]
   id: OrganProtoMothTorso
+  components:
+  - type: VisualOrganMarkings
+    hideableLayers:
+    - enum.HumanoidVisualLayers.BodyCover
+    - enum.HumanoidVisualLayers.BodyCoverCover
+    - enum.HumanoidVisualLayers.TailCover
 
 - type: entity
   parent: [ OrganProtoMothExternal, OrganMothHead ]

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoMoth.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoMoth.yml
@@ -69,8 +69,7 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.BodyCover
     - enum.HumanoidVisualLayers.BodyCoverCover
-    - enum.HumanoidVisualLayers.TailCover
-
+    
 - type: entity
   parent: [ OrganProtoMothExternal, OrganMothHead ]
   id: OrganProtoMothHead

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoReptile.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoReptile.yml
@@ -65,8 +65,7 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.BodyCover
     - enum.HumanoidVisualLayers.BodyCoverCover
-    - enum.HumanoidVisualLayers.TailCover
-
+    
 - type: entity
   parent: [ OrganProtoReptileExternal, OrganReptilianHead ]
   id: OrganProtoReptileHead

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoReptile.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoReptile.yml
@@ -60,6 +60,12 @@
 - type: entity
   parent: [ OrganProtoReptileExternal, OrganReptilianTorso ]
   id: OrganProtoReptileTorso
+  components:
+  - type: VisualOrganMarkings
+    hideableLayers:
+    - enum.HumanoidVisualLayers.BodyCover
+    - enum.HumanoidVisualLayers.BodyCoverCover
+    - enum.HumanoidVisualLayers.TailCover
 
 - type: entity
   parent: [ OrganProtoReptileExternal, OrganReptilianHead ]

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoResomi.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoResomi.yml
@@ -89,6 +89,12 @@
 - type: entity
   parent: [ OrganProtoResomiExternal, OrganResomiTorso ]
   id: OrganProtoResomiTorso
+  components:
+  - type: VisualOrganMarkings
+    hideableLayers:
+    - enum.HumanoidVisualLayers.BodyCover
+    - enum.HumanoidVisualLayers.BodyCoverCover
+    - enum.HumanoidVisualLayers.TailCover
 
 - type: entity
   parent: [ OrganProtoResomiExternal, OrganResomiHead ]

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoResomi.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoResomi.yml
@@ -94,8 +94,7 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.BodyCover
     - enum.HumanoidVisualLayers.BodyCoverCover
-    - enum.HumanoidVisualLayers.TailCover
-
+    
 - type: entity
   parent: [ OrganProtoResomiExternal, OrganResomiHead ]
   id: OrganProtoResomiHead

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoSlime.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoSlime.yml
@@ -58,6 +58,12 @@
 - type: entity
   parent: [ OrganProtoSlimePersonExternal, OrganSlimePersonTorso ]
   id: OrganProtoSlimePersonTorso
+  components:
+  - type: VisualOrganMarkings
+    hideableLayers:
+    - enum.HumanoidVisualLayers.BodyCover
+    - enum.HumanoidVisualLayers.BodyCoverCover
+    - enum.HumanoidVisualLayers.TailCover
 
 - type: entity
   parent: [ OrganProtoSlimePersonExternal, OrganSlimePersonHead ]

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoSlime.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoSlime.yml
@@ -63,8 +63,7 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.BodyCover
     - enum.HumanoidVisualLayers.BodyCoverCover
-    - enum.HumanoidVisualLayers.TailCover
-
+    
 - type: entity
   parent: [ OrganProtoSlimePersonExternal, OrganSlimePersonHead ]
   id: OrganProtoSlimePersonHead

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoThaven.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoThaven.yml
@@ -69,8 +69,7 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.BodyCover
     - enum.HumanoidVisualLayers.BodyCoverCover
-    - enum.HumanoidVisualLayers.TailCover
-
+    
 - type: entity
   parent: [ OrganProtoThavenExternal, OrganThavenHead ]
   id: OrganProtoThavenHead

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoThaven.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoThaven.yml
@@ -64,6 +64,12 @@
 - type: entity
   parent: [ OrganProtoThavenExternal, OrganThavenTorso ]
   id: OrganProtoThavenTorso
+  components:
+  - type: VisualOrganMarkings
+    hideableLayers:
+    - enum.HumanoidVisualLayers.BodyCover
+    - enum.HumanoidVisualLayers.BodyCoverCover
+    - enum.HumanoidVisualLayers.TailCover
 
 - type: entity
   parent: [ OrganProtoThavenExternal, OrganThavenHead ]

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoVox.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoVox.yml
@@ -81,6 +81,12 @@
 - type: entity
   parent: [ OrganProtoVoxExternalUnsprited, OrganVoxTorso ]
   id: OrganProtoVoxTorso
+  components:
+  - type: VisualOrganMarkings
+    hideableLayers:
+    - enum.HumanoidVisualLayers.BodyCover
+    - enum.HumanoidVisualLayers.BodyCoverCover
+    - enum.HumanoidVisualLayers.TailCover
 
 - type: entity
   parent: [ OrganProtoVoxExternalUnsprited, OrganVoxHead ]

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoVox.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoVox.yml
@@ -86,8 +86,7 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.BodyCover
     - enum.HumanoidVisualLayers.BodyCoverCover
-    - enum.HumanoidVisualLayers.TailCover
-
+    
 - type: entity
   parent: [ OrganProtoVoxExternalUnsprited, OrganVoxHead ]
   id: OrganProtoVoxHead

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoVulp.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoVulp.yml
@@ -69,6 +69,12 @@
 - type: entity
   parent: [ OrganBaseTorsoSexed, OrganBaseTorso, OrganProtoVulpExternal ]
   id: OrganProtoVulpTorso
+  components:
+  - type: VisualOrganMarkings
+    hideableLayers:
+    - enum.HumanoidVisualLayers.BodyCover
+    - enum.HumanoidVisualLayers.BodyCoverCover
+    - enum.HumanoidVisualLayers.TailCover
 
 - type: entity
   parent: [ OrganBaseHeadSexed, OrganBaseHead, OrganProtoVulpExternal ]

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoVulp.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoVulp.yml
@@ -74,8 +74,7 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.BodyCover
     - enum.HumanoidVisualLayers.BodyCoverCover
-    - enum.HumanoidVisualLayers.TailCover
-
+    
 - type: entity
   parent: [ OrganBaseHeadSexed, OrganBaseHead, OrganProtoVulpExternal ]
   id: OrganProtoVulpHead

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protogen.yml
@@ -294,8 +294,7 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.BodyCover
     - enum.HumanoidVisualLayers.BodyCoverCover
-    - enum.HumanoidVisualLayers.TailCover
-
+    
 - type: entity
   parent: [ OrganBaseHeadSexed, OrganBaseHead, OrganProtogenExternal ]
   id: OrganProtogenHead

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protogen.yml
@@ -289,6 +289,12 @@
 - type: entity
   parent: [ OrganBaseTorsoSexed, OrganBaseTorso, OrganProtogenExternal ]
   id: OrganProtogenTorso
+  components:
+  - type: VisualOrganMarkings
+    hideableLayers:
+    - enum.HumanoidVisualLayers.BodyCover
+    - enum.HumanoidVisualLayers.BodyCoverCover
+    - enum.HumanoidVisualLayers.TailCover
 
 - type: entity
   parent: [ OrganBaseHeadSexed, OrganBaseHead, OrganProtogenExternal ]

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
@@ -1988,6 +1988,11 @@
             32:
               sprite: _Starlight/Mobs/Species/Avali/displacement.rsi
               state: jumpsuit
+        outerClothing:
+          sizeMaps:
+            32:
+              sprite: _Starlight/Mobs/Species/Avali/displacement.rsi
+              state: outerclothing
         shoes:
           sizeMaps:
             32:
@@ -2008,12 +2013,22 @@
             32:
               sprite: _Starlight/Mobs/Species/Avali/displacement.rsi
               state: back
+        gloves:
+          sizeMaps:
+            32:
+              sprite: _Starlight/Mobs/Species/Avali/displacement.rsi
+              state: gloves
       femaleDisplacements:
         jumpsuit:
           sizeMaps:
             32:
               sprite: _Starlight/Mobs/Species/Avali/displacement.rsi
               state: jumpsuit
+        outerClothing:
+          sizeMaps:
+            32:
+              sprite: _Starlight/Mobs/Species/Avali/displacement.rsi
+              state: outerclothing
         shoes:
           sizeMaps:
             32:
@@ -2034,6 +2049,11 @@
             32:
               sprite: _Starlight/Mobs/Species/Avali/displacement.rsi
               state: back
+        gloves:
+          sizeMaps:
+            32:
+              sprite: _Starlight/Mobs/Species/Avali/displacement.rsi
+              state: gloves
     - type: Butcherable
       butcheringType: Spike
       spawned:

--- a/Resources/Prototypes/_FarHorizons/InventoryTemplates/protogen_inventory_template.yml
+++ b/Resources/Prototypes/_FarHorizons/InventoryTemplates/protogen_inventory_template.yml
@@ -89,7 +89,7 @@
       stripTime: 3
       uiWindowPos: 0,3
       strippingWindowPos: 0,5
-      dependsOn: jumpsuit
+      #dependsOn: jumpsuit # proot stuff :3
       displayName: Pocket 1
       stripHidden: true
     - name: pocket2
@@ -100,7 +100,7 @@
       stripTime: 3
       uiWindowPos: 2,3
       strippingWindowPos: 1,5
-      dependsOn: jumpsuit
+      #dependsOn: jumpsuit # proot stuff :3
       displayName: Pocket 2
       stripHidden: true
     - name: suitstorage


### PR DESCRIPTION
## Short description
add missing displacements for protoawawi and make the visibility of proot cybernetics follow basic logic

## Why we need to add this
bugfix and making proot cybers follow logic

## Media (Video/Screenshots)
<img width="250" height="262" alt="2026-06-27-214650_hyprshot" src="https://github.com/user-attachments/assets/2dbf38ce-3d9b-442e-b668-1f777ff683ad" />
<img width="216" height="260" alt="2026-06-27-214701_hyprshot" src="https://github.com/user-attachments/assets/eb0b8775-af59-4d51-b16d-b9b6557ffb00" />
<img width="223" height="240" alt="2026-06-27-214711_hyprshot" src="https://github.com/user-attachments/assets/93cce767-884f-4b21-a19e-125074740a06" />
<img width="218" height="253" alt="2026-06-27-214722_hyprshot" src="https://github.com/user-attachments/assets/9c9e74c0-abff-478a-a7ff-b31dc64bb768" />
<img width="1215" height="140" alt="2026-06-27-214741_hyprshot" src="https://github.com/user-attachments/assets/527f0e12-c30a-49cf-b636-803257e8c060" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**

:cl: qriqii
- tweak: Made proot cybernetics only visible when they logically should be visible.
- tweak: Allowed proots to use pockets regardless of clothing.
- fix: Fixed protoavali missing outerclothing displacements.
