### PR TITLE
actually save targetter settings

### DIFF
--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -42,7 +42,7 @@ public sealed partial class MiscTab : Control
         // Far Horizons start
         var limbTargetters = _prototypeManager.EnumeratePrototypes<LimbTargettingPrototype>()
             .Where(p => !p.HideInSettings).Select(p =>
-                new OptionDropDownCVar<ProtoId<LimbTargettingPrototype>>.ValueOption(p.ID, Loc.GetString(p.Name)))
+                new OptionDropDownCVar<string>.ValueOption(p.ID, Loc.GetString(p.Name)))
             .ToList();
         // Far Horizons end
 

--- a/Content.Client/_FarHorizons/LimbDamage/UI/LimbTargettingSystem.cs
+++ b/Content.Client/_FarHorizons/LimbDamage/UI/LimbTargettingSystem.cs
@@ -18,6 +18,8 @@ public sealed class LimbTargettingSystem : EntitySystem
 
     public Action<ProtoId<OrganCategoryPrototype>>? LocalTargetUpdated;
 
+    private const string DefaultStyle = "LimbTargetHuman";
+
     public override void Initialize()
     {
         base.Initialize();
@@ -57,6 +59,9 @@ public sealed class LimbTargettingSystem : EntitySystem
             _player.LocalSession?.AttachedEntity is { } playerEnt &&
             TryComp<LimbDamageableComponent>(playerEnt, out var limbDamageable))
             style = limbDamageable.Proto;
+
+        if (!_protoMan.HasIndex<LimbTargettingPrototype>(style))
+            style = DefaultStyle;
 
         return style;
     }

--- a/Content.Shared/_FarHorizons/CCVar/FHCCVars.cs
+++ b/Content.Shared/_FarHorizons/CCVar/FHCCVars.cs
@@ -23,12 +23,12 @@ public sealed partial class FHCCVars
     public static readonly CVarDef<int>
         VoteTimerFaction = CVarDef.Create("vote.timerfaction", 90, CVar.SERVERONLY);
 
-    public static readonly CVarDef<ProtoId<LimbTargettingPrototype>> LimbTargettingStyle =
-        CVarDef.Create("ui.limb_targetting_style", (ProtoId<LimbTargettingPrototype>)"LimbTargetHuman",
-            CVar.CLIENTONLY);
+    public static readonly CVarDef<string> LimbTargettingStyle =
+        CVarDef.Create("ui.limb_targetting_style", "LimbTargetHuman",
+            CVar.CLIENTONLY | CVar.ARCHIVE);
 
     public static readonly CVarDef<bool> LimbTargettingMatchSpecies =
-        CVarDef.Create("ui.limb_targetting_match_species", false, CVar.CLIENTONLY);
+        CVarDef.Create("ui.limb_targetting_match_species", false, CVar.CLIENTONLY | CVar.ARCHIVE);
 
 
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
I made an oopsie with last PR and settings you could configure would be lost when you close the game

## Why we need to add this
fix

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- fix: Customization you can set for limb targeting UI now actually saves when you close the game
