### PR TITLE
Blood

### DIFF
--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -347,10 +347,10 @@
 - type: entity
   parent: [ OrganBaseHeart, OrganMothInternal, OrganAnimalMetabolizer ]
   id: OrganMothHeart
-  components: 
+  components: #FH start
   - type: Metabolizer
     maxReagents: 2
-    metabolizerTypes: [ Moth ] 
+    metabolizerTypes: [ Moth ] #FH end
 
 - type: entity
   parent: [ OrganBaseStomach, OrganMothInternal, OrganMothMetabolizer ]

--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -274,6 +274,14 @@
         Brute:
           rsi: /Textures/Mobs/Effects/brute_damage.rsi
           color: "#808A51"
+
+- type: entity
+  parent: [ OrganBaseHeart, OrganMothInternal, OrganMothMetabolizer ] 
+  id: OrganMothHeart
+  components: 
+  - type: Metabolizer
+    maxReagents: 2
+    metabolizerTypes: [ Moth ] 
 # Far Horizons end
 
 - type: entity

--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -274,14 +274,6 @@
         Brute:
           rsi: /Textures/Mobs/Effects/brute_damage.rsi
           color: "#808A51"
-
-- type: entity
-  parent: [ OrganBaseHeart, OrganMothInternal, OrganMothMetabolizer ] 
-  id: OrganMothHeart
-  components: 
-  - type: Metabolizer
-    maxReagents: 2
-    metabolizerTypes: [ Moth ] 
 # Far Horizons end
 
 - type: entity
@@ -355,6 +347,10 @@
 - type: entity
   parent: [ OrganBaseHeart, OrganMothInternal, OrganAnimalMetabolizer ]
   id: OrganMothHeart
+  components: 
+  - type: Metabolizer
+    maxReagents: 2
+    metabolizerTypes: [ Moth ] 
 
 - type: entity
   parent: [ OrganBaseStomach, OrganMothInternal, OrganMothMetabolizer ]

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -64,7 +64,7 @@
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Arachnid ]
+          type: [ Arachnid, Cyclorite, Avali, Resomi, ProtoBird ] #FH
           inverted: true
         damage:
           types:
@@ -72,7 +72,7 @@
       - !type:ModifyBloodLevel
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Arachnid ]
+          type: [ Arachnid, Cyclorite, Avali, Resomi, ProtoBird ] #FH
         amount: 0.4
 
 - type: reagent
@@ -152,7 +152,7 @@
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Arachnid ]
+          type: [ Arachnid, Cyclorite ] #FH
         damage:
           types:
             Poison: 0.1
@@ -166,7 +166,7 @@
       - !type:ModifyBloodLevel
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Arachnid ]
+          type: [ Arachnid, Cyclorite ] #FH
           inverted: true
         amount: 0.4
   

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -64,7 +64,7 @@
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Arachnid, Cyclorite, Avali, Resomi, ProtoBird ] #FH
+          type: [ Arachnid, Cyclorite, Avali, Resomi, ProtoBird, Moth ] #FH
           inverted: true
         damage:
           types:
@@ -72,7 +72,7 @@
       - !type:ModifyBloodLevel
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Arachnid, Cyclorite, Avali, Resomi, ProtoBird ] #FH
+          type: [ Arachnid, Cyclorite, Avali, Resomi, ProtoBird, Moth ] #FH
         amount: 0.4
 
 - type: reagent
@@ -152,7 +152,7 @@
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Arachnid, Cyclorite ] #FH
+          type: [ Arachnid, Cyclorite, Moth ] #FH
         damage:
           types:
             Poison: 0.1
@@ -166,7 +166,7 @@
       - !type:ModifyBloodLevel
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Arachnid, Cyclorite ] #FH
+          type: [ Arachnid, Cyclorite, Moth ] #FH
           inverted: true
         amount: 0.4
   

--- a/Resources/Prototypes/_FarHorizons/Body/Species/cyclorite.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/cyclorite.yml
@@ -286,8 +286,12 @@
         canReact: false
 
 - type: entity
-  parent: [ OrganBaseHeart, OrganCycloriteInternal, OrganCycloriteMetabolizer ]
+  parent: [ OrganBaseHeart, OrganCycloriteInternal, OrganCycloriteMetabolizer ] 
   id: OrganCycloriteHeart
+  components: 
+  - type: Metabolizer
+    maxReagents: 2
+    metabolizerTypes: [ Cyclorite ] 
 
 - type: entity
   parent: [ OrganBaseStomach, OrganCycloriteInternal, OrganCycloriteMetabolizer ]

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoCyclops.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoCyclops.yml
@@ -33,7 +33,7 @@
       Tongue: OrganProtogenTongue
       Ears: OrganProtogenEars
       Lungs: OrganProtogenLungs
-      Heart: OrganProtogenHeart
+      Heart: OrganProtoCyclopsHeart
       Stomach: OrganProtogenStomach
       Liver: OrganProtogenLiver
       Kidneys: OrganProtogenKidneys
@@ -64,6 +64,14 @@
   - type: VisualOrganMarkings
     markingData:
       group: ProtoCyclops
+
+- type: entity 
+  parent: OrganProtogenHeart
+  id: OrganProtoCyclopsHeart
+  components:
+  - type: Metabolizer
+    maxReagents: 2
+    metabolizerTypes: [ Cyclorite ] 
 
 # Limbs
 

--- a/Resources/Prototypes/_FarHorizons/Body/Species/protoMoth.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/protoMoth.yml
@@ -33,7 +33,7 @@
       Tongue: OrganProtogenTongue
       Ears: OrganProtogenEars
       Lungs: OrganProtogenLungs
-      Heart: OrganProtogenHeart
+      Heart: OrganProtoMothHeart
       Stomach: OrganProtoMothStomach
       Liver: OrganProtogenLiver
       Kidneys: OrganProtogenKidneys
@@ -58,6 +58,14 @@
   - type: VisualOrganMarkings
     markingData:
       group: ProtoMoth
+
+- type: entity 
+  parent: OrganProtogenHeart
+  id: OrganProtoMothHeart
+  components:
+  - type: Metabolizer
+    maxReagents: 2
+    metabolizerTypes: [ Moth ] 
 
 # Limbs
 

--- a/Resources/Prototypes/_Starlight/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Reactions/medicine.yml
@@ -7,7 +7,7 @@
       amount: 1
     Carbon:
       amount: 1
-    Iron:
+    Copper: #FH
       amount: 1
   products:
     Amoxla: 2

--- a/Resources/ServerInfo/Guidebook/Mobs/Moth.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Moth.xml
@@ -6,7 +6,7 @@
   </Box>
 
   They can eat cotton, fabrics and clothing, but virtually none of the food that others would consider "edible". They prefer a somewhat lower temperature range than humans.
-  Their Insect Blood can't be metabolised from Iron like normal blood, requiring Copper instead.
+  Their Insect Blood can't be metabolised from Iron like normal blood, requiring Copper instead. <!-- FH edit -->
 
   Their wings give them better acceleration if there is no gravity on the station, but they still can't move without equipment when floating out in space.
 

--- a/Resources/ServerInfo/Guidebook/Mobs/Moth.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Moth.xml
@@ -6,7 +6,7 @@
   </Box>
 
   They can eat cotton, fabrics and clothing, but virtually none of the food that others would consider "edible". They prefer a somewhat lower temperature range than humans.
-  Their Insect Blood can't be metabolised from Iron like normal blood.
+  Their Insect Blood can't be metabolised from Iron like normal blood, requiring Copper instead.
 
   Their wings give them better acceleration if there is no gravity on the station, but they still can't move without equipment when floating out in space.
 

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Avali.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Avali.xml
@@ -22,6 +22,6 @@
   - Can only eat meat-related food items (including organs) and pills.
   - Heal airloss from Ammonia and Amoxla but..
   - ..Saline, Dex and Dex+ is lethal to you. Remember to remind doctors about it!
-  - Iron has an effect similar to Lead to you, Copper can be used in its place.
+  - Iron has an effect similar to Lead to you, Copper can be used in its place.  <!-- FH edit -->
   - Fall into crit at 90 and dead at 180.
 </Document>

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Avali.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Avali.xml
@@ -22,5 +22,6 @@
   - Can only eat meat-related food items (including organs) and pills.
   - Heal airloss from Ammonia and Amoxla but..
   - ..Saline, Dex and Dex+ is lethal to you. Remember to remind doctors about it!
+  - Iron has an effect similar to Lead to you, Copper can be used in its place.
   - Fall into crit at 90 and dead at 180.
 </Document>

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Cyclorite.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Cyclorite.xml
@@ -16,5 +16,6 @@ These intelligent inhabitants of the Abyss are emotionally reserved and have a s
   - They take [color=#ffa500]15% less blunt damage[/color] and [color=#ffa500]25% less slash damage[/color] than a comparable human.
   - Due to their size, they stretch external clothing to such an extent that they can fit two tanks on their back.
   - Their eyes are less sensitive to red colors but provide better vision in the dark."
+  - Their Blue Blood can't be metabolised from Iron, requiring Copper instead.
 
 </Document>

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Cyclorite.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Cyclorite.xml
@@ -16,6 +16,6 @@ These intelligent inhabitants of the Abyss are emotionally reserved and have a s
   - They take [color=#ffa500]15% less blunt damage[/color] and [color=#ffa500]25% less slash damage[/color] than a comparable human.
   - Due to their size, they stretch external clothing to such an extent that they can fit two tanks on their back.
   - Their eyes are less sensitive to red colors but provide better vision in the dark."
-  - Their Blue Blood can't be metabolised from Iron, requiring Copper instead.
+  - Their Blue Blood can't be metabolised from Iron, requiring Copper instead. <!-- FH edit -->
 
 </Document>

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Resomi.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Resomi.xml
@@ -44,7 +44,7 @@
   Resomi also prefer colder temperatures compared to humans, being roughly akin to Moths.
   Resomi heal airloss from [color=cyan]Ammonia[/color] and [color=cyan]Amoxla[/color], 
   but [color=red]Saline[/color], [color=red]Dex[/color], and [color=red]Dex+[/color] are lethal to them. Remember to remind doctors about this!
-  Resomi also slightly regenerate blood level from copper while having a deadly reaction to Iron.
+  Resomi also slightly regenerate blood level from copper while having a deadly reaction to Iron. <!-- FH edit -->
   
   ## Claw attack
   Resomi are able to slash at others with their claws.

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Resomi.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Resomi.xml
@@ -44,6 +44,7 @@
   Resomi also prefer colder temperatures compared to humans, being roughly akin to Moths.
   Resomi heal airloss from [color=cyan]Ammonia[/color] and [color=cyan]Amoxla[/color], 
   but [color=red]Saline[/color], [color=red]Dex[/color], and [color=red]Dex+[/color] are lethal to them. Remember to remind doctors about this!
+  Resomi also slightly regenerate blood level from copper while having a deadly reaction to Iron.
   
   ## Claw attack
   Resomi are able to slash at others with their claws.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
makes amoxla require copper instead of iron, make all copper blood species heal blood level from copper instead of iron

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
it made no sense that the species to whom iron is DEADLY required a chemical made with it, changed it to copper instead and made them heal blood level from copper (same as arachnid, they still get ultra poisoned from iron).

it also made no sense that cyclorites had the same blood as arachnids yet didn't regenerate it from copper.
it also also made no sense that moth blood is not regenerate from copper but iron instead despite their guidebook saying the opposite.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1062" height="375" alt="image" src="https://github.com/user-attachments/assets/8a996c4e-bc02-4c7b-81de-2677e3eb85bc" />
<img width="1053" height="456" alt="image" src="https://github.com/user-attachments/assets/c76c4c82-f826-46e0-8aef-f8fcff2c23e3" />

videos showcasing it working unable to be posted here due to file size limit, sent here instead:
https://discordapp.com/channels/1407077238876147783/1407276847422509167/1524571112976023652



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: rain_enjoyer
- tweak: Amoxla now requires copper instead of iron
- tweak: Avali, Resomi, Moths and Cyclorites (and protogen counterparts) now heal blood level from copper.
- tweak: Moths and Cyclorites no longer heal blood level from iron and take mild poison instead.
- fix: Cyclorites and Moths not having their metabolizer.
