### PR TITLE
faction radio prefixes

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.FarHorizons.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.FarHorizons.cs
@@ -1,0 +1,23 @@
+using Content.Shared._FarHorizons.CCVar;
+using Content.Shared.Chat;
+
+namespace Content.Client.UserInterface.Systems.Chat;
+
+public sealed partial class ChatUIController
+{
+    private bool _showRadioPrefix;
+
+    private void InitializeFH() => 
+        _config.OnValueChanged(FHCCVars.ChatShowFactionPrefix, (value) => _showRadioPrefix = value, true); // Far Horizons
+
+    private void ProcessRadioPrefix(ref ChatMessage msg) => 
+        msg.WrappedMessage = _showRadioPrefix && msg.RadioPrefix != null
+            ? msg.WrappedMessage.Replace("[radioPrefix/]", $"({msg.RadioPrefix})")
+            : msg.WrappedMessage.Replace("[radioPrefix/]", "");
+
+    public void UpdateRadioPrefix(bool value)
+    {
+        _config.SetCVar(FHCCVars.ChatShowFactionPrefix, value);
+        _config.SaveToFile();
+    }
+}

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -260,6 +260,7 @@ public sealed partial class ChatUIController : UIController
         _config.OnValueChanged(CCVars.ChatWindowOpacity, OnChatWindowOpacityChanged);
 
         InitializeHighlights();
+        InitializeFH(); // Far Horizons
     }
 
     public void OnScreenLoad()
@@ -873,6 +874,7 @@ public sealed partial class ChatUIController : UIController
 
     public void ProcessChatMessage(ChatMessage msg, bool speechBubble = true)
     {
+        ProcessRadioPrefix(ref msg); // Far Horizons
         // color the name unless it's something like "the old man"
         if ((msg.Channel == ChatChannel.Local || msg.Channel == ChatChannel.Whisper) && _chatNameColorsEnabled)
         {

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.FarHorizons.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.FarHorizons.xaml.cs
@@ -1,0 +1,19 @@
+using Content.Shared._FarHorizons.CCVar;
+using Robust.Shared.Configuration;
+using static Robust.Client.UserInterface.Controls.BaseButton;
+
+namespace Content.Client.UserInterface.Systems.Chat.Controls;
+
+public sealed partial class ChannelFilterPopup
+{
+    public event Action<bool>? OnShowRadioPrefixChanged;
+
+    private void InitializeFHOptions(IConfigurationManager cfg)
+    {
+        FHOptionsShowPrefixes.Pressed = cfg.GetCVar(FHCCVars.ChatShowFactionPrefix);
+        FHOptionsShowPrefixes.OnPressed += RadioPrefixChanged;
+    }
+
+    private void RadioPrefixChanged(ButtonEventArgs args) => 
+        OnShowRadioPrefixChanged?.Invoke(args.Button.Pressed);
+}

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml
@@ -5,18 +5,6 @@
     <PanelContainer Name="FilterPopupPanel" StyleClasses="BorderedWindowPanel">
         <BoxContainer Orientation="Horizontal" SeparationOverride="8" Margin="10 0">
             <BoxContainer Name="FilterVBox" MinWidth="105" Margin="0 10" Orientation="Vertical" SeparationOverride="4"/>
-            <BoxContainer Name="HighlightsVBox" MinWidth="120" Margin="0 10" Orientation="Vertical" SeparationOverride="4">
-                <Label Text="{Loc 'hud-chatbox-highlights'}"/>
-                <PanelContainer>
-                    <!-- Begin custom background for TextEdit -->
-                    <PanelContainer.PanelOverride>
-                        <gfx:StyleBoxFlat BackgroundColor="#323446"/>
-                    </PanelContainer.PanelOverride>
-                    <!-- End custom background -->
-                    <TextEdit Name="HighlightEdit" MinHeight="150" Margin="5 5"/>
-                </PanelContainer>
-                <Button Name="HighlightButton" Text="{Loc 'hud-chatbox-highlights-button'}" ToolTip="{Loc 'hud-chatbox-highlights-tooltip'}"/>
-            </BoxContainer>
             <!-- Starlight start -->
             <BoxContainer Name="TTSMuteVBox" MinWidth="120" Margin="0 10" Orientation="Vertical" SeparationOverride="4">
                 <Label Text="{Loc 'hud-chatbox-tts-mute'}"/>
@@ -26,6 +14,27 @@
                 <Button Name="TTSClearQueueButton" Text="{Loc 'hud-chatbox-tts-clear-queue'}"/>
             </BoxContainer>
             <!-- Starlight end -->
+            <!-- Far Horizons start moved highlights here -->
+            <BoxContainer Name="OptionsVBox" MinWidth="105" Margin="0 10" Orientation="Vertical" SeparationOverride="4">
+                <BoxContainer Name="FHOptionsVBox" Orientation="Vertical">
+                    <Label Text="{Loc 'hud-chatbox-fh-chat-options'}"/>
+                    <CheckBox Name="FHOptionsShowPrefixes" Text="{Loc 'hud-chatbox-fh-show-radio-prefix'}"/>
+                </BoxContainer>
+                <BoxContainer VerticalExpand="true" />
+                <BoxContainer Name="HighlightsVBox" Orientation="Vertical">
+                    <Label Text="{Loc 'hud-chatbox-highlights'}"/>
+                    <PanelContainer>
+                        <!-- Begin custom background for TextEdit -->
+                        <PanelContainer.PanelOverride>
+                            <gfx:StyleBoxFlat BackgroundColor="#323446"/>
+                        </PanelContainer.PanelOverride>
+                        <!-- End custom background -->
+                        <TextEdit Name="HighlightEdit" MinHeight="150" Margin="5 5"/>
+                    </PanelContainer>
+                    <Button Name="HighlightButton" Text="{Loc 'hud-chatbox-highlights-button'}" ToolTip="{Loc 'hud-chatbox-highlights-tooltip'}"/>
+                </BoxContainer>
+            </BoxContainer>
+            <!-- Far Horizons end -->
         </BoxContainer>
     </PanelContainer>
 </controls:ChannelFilterPopup>

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
@@ -68,6 +68,7 @@ public sealed partial class ChannelFilterPopup : Popup
         InitializeTTSMuteChannels();
         TTSClearQueueButton.OnPressed += _ => ClearQueue();
         // Starlight end
+        InitializeFHOptions(cfg); // Far Horizons
     }
     // Starlight start
 

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelSelectorButton.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelSelectorButton.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
 using Content.Shared.CollectiveMind;
 using Content.Shared.Chat;
+using Robust.Shared.Configuration;
+using Content.Shared._FarHorizons.CCVar;
 
 namespace Content.Client.UserInterface.Systems.Chat.Controls;
 
@@ -12,6 +14,8 @@ public sealed class ChannelSelectorButton : ChatPopupButton<ChannelSelectorPopup
 
     private const int SelectorDropdownOffset = 38;
 
+    private readonly IConfigurationManager _cfg; // Far Horizons
+
     public ChannelSelectorButton()
     {
         Name = "ChannelSelector";
@@ -22,6 +26,8 @@ public sealed class ChannelSelectorButton : ChatPopupButton<ChannelSelectorPopup
         {
             Select(firstSelector);
         }
+
+        _cfg = IoCManager.Resolve<IConfigurationManager>(); // Far Horizons
     }
 
     protected override UIBox2 GetPopupPosition()
@@ -74,7 +80,13 @@ public sealed class ChannelSelectorButton : ChatPopupButton<ChannelSelectorPopup
     {
         if (radio != null)
         {
-            Text = Loc.GetString(radio.Name);
+            // Far Horizons start
+            var name = Loc.GetString(radio.Name);
+            if (_cfg.GetCVar(FHCCVars.ChatShowFactionPrefix))
+                name = $"({radio.ChatPrefix}){name}";
+            
+            Text = name;
+            // Far Horizons end
             Modulate = radio?.Color ?? ChannelSelectColor(channel);
         }
         else if (collectiveMind != null)

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.FarHorizons.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.FarHorizons.xaml.cs
@@ -1,0 +1,10 @@
+namespace Content.Client.UserInterface.Systems.Chat.Widgets;
+
+public partial class ChatBox
+{
+    private void InitializeFHOptions() => 
+        ChatInput.FilterButton.Popup.OnShowRadioPrefixChanged += OnShowRadioPrefixChanged;
+
+    private void OnShowRadioPrefixChanged(bool value) => 
+        _controller.UpdateRadioPrefix(value);
+}

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -47,6 +47,7 @@ public partial class ChatBox : UIWidget
         _controller.MessageAdded += OnMessageAdded;
         _controller.HighlightsUpdated += OnHighlightsUpdated;
         _controller.RegisterChat(this);
+        InitializeFHOptions(); // Far Horizons
     }
 
     private void OnTextEntered(LineEditEventArgs args)

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -176,11 +176,11 @@ public sealed partial class RadioSystem : EntitySystem
 
         // most radios are relayed to chat, so lets parse the chat message beforehand
 
-        var msg = new ChatMessage(ChatChannel.Radio, content, wrappedMessage, NetEntity.Invalid, null); // Starlight
+        var msg = new ChatMessage(ChatChannel.Radio, content, wrappedMessage, NetEntity.Invalid, null, radioPrefix: channel.ChatPrefix); // Starlight; radioPrefix - Far Horizons
 
         var obfuscated = _language.ObfuscateSpeech(content, language);
         var obfuscatedWrapped = WrapRadioMessage(messageSource, channel, name, obfuscated, language, true);
-        var notUdsMsg = new ChatMessage(ChatChannel.Radio, obfuscated, obfuscatedWrapped, NetEntity.Invalid, null) { Chime = chime, };
+        var notUdsMsg = new ChatMessage(ChatChannel.Radio, obfuscated, obfuscatedWrapped, NetEntity.Invalid, null, radioPrefix: channel.ChatPrefix) { Chime = chime, }; // radioPrefix - Far Horizons
         var ev = new RadioReceiveEvent(messageSource, channel, msg, notUdsMsg, language, radioSource, []);
         // Starlight - End
 

--- a/Content.Shared/Chat/MsgChatMessage.cs
+++ b/Content.Shared/Chat/MsgChatMessage.cs
@@ -42,11 +42,12 @@ namespace Content.Shared.Chat
         public Color? MessageColorOverride;
         public string? AudioPath;
         public float AudioVolume;
+        public string? RadioPrefix;
 
         [NonSerialized]
         public bool Read;
 
-        public ChatMessage(ChatChannel channel, string message, string wrappedMessage, NetEntity source, int? senderKey, bool hideChat = false, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0)
+        public ChatMessage(ChatChannel channel, string message, string wrappedMessage, NetEntity source, int? senderKey, bool hideChat = false, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0, string? radioPrefix = null)
         {
             Channel = channel;
             Message = message;
@@ -57,6 +58,7 @@ namespace Content.Shared.Chat
             MessageColorOverride = colorOverride;
             AudioPath = audioPath;
             AudioVolume = audioVolume;
+            RadioPrefix = radioPrefix;
         }
     }
 

--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -223,7 +223,7 @@ public sealed partial class EncryptionKeySystem : EntitySystem
             examineEvent.PushMarkup(Loc.GetString(channelFTLPattern,
                 ("color", channel.Color),
                 ("key", key),
-                ("id", channel.LocalizedName),
+                ("id", $"({channel.ChatPrefix}){channel.LocalizedName}"), // Far Horizons
                 ("freq", channel.Frequency / 10f)));
         }
         // Far Horizons end

--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -49,6 +49,9 @@ public sealed partial class RadioChannelPrototype : IPrototype
 
     [DataField] 
     public RadioChannelType RadioChannelType = RadioChannelType.Radio;
+
+    [DataField]
+    public string? ChatPrefix = null;
     // Far Horizons end
 }
 

--- a/Content.Shared/_FarHorizons/CCVar/FHCCVars.cs
+++ b/Content.Shared/_FarHorizons/CCVar/FHCCVars.cs
@@ -35,4 +35,7 @@ public sealed partial class FHCCVars
     
     public static readonly CVarDef<string> UtilityTelegraphsColor = 
         CVarDef.Create("accessibility.utility_telegraphs_color", "#FFA500FF", CVar.CLIENTONLY | CVar.ARCHIVE);
+    
+    public static readonly CVarDef<bool> ChatShowFactionPrefix =
+        CVarDef.Create("chat.show_faction_prefix", false, CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Resources/Locale/en-US/_FarHorizons/chat/chat-box.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/chat/chat-box.ftl
@@ -1,2 +1,5 @@
 hud-chatbox-select-channel-Mentor = Mentor
 hud-chatbox-channel-MentorChat = Mentor Chat
+
+hud-chatbox-fh-chat-options = Chat Options:
+hud-chatbox-fh-show-radio-prefix = Faction Radio Prefix

--- a/Resources/Locale/en-US/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/headset/headset-component.ftl
@@ -1,10 +1,10 @@
 # Chat window radio wrap (prefix and postfix)
 
 # Starlight-edit: Languages
-chat-radio-message-wrap = [color={$color}]{$channel} [bold]{$name}[/bold] {$verb}, "[/color][font="{$fontType}" size={$fontSize}][color={$languageColor}]{$message}[/color][/font][color={$color}]"[/color]
+chat-radio-message-wrap = [color={$color}][radioPrefix/]{$channel} [bold]{$name}[/bold] {$verb}, "[/color][font="{$fontType}" size={$fontSize}][color={$languageColor}]{$message}[/color][/font][color={$color}]"[/color]
 
 # Starlight-edit: Languages
-chat-radio-message-wrap-bold = [color={$color}]{$channel} [bold]{$name}[/bold] {$verb}, "[/color][font="{$fontType}" size={$fontSize}][color={$languageColor}][bold]{$message}[/bold][/font][/color][color={$color}]"[/color]
+chat-radio-message-wrap-bold = [color={$color}][radioPrefix/]{$channel} [bold]{$name}[/bold] {$verb}, "[/color][font="{$fontType}" size={$fontSize}][color={$languageColor}][bold]{$message}[/bold][/font][/color][color={$color}]"[/color]
 
 examine-headset-default-channel = Use {$prefix} for the default channel ([color={$color}]{$channel}[/color]).
 

--- a/Resources/Prototypes/_FarHorizons/radio_channels.yml
+++ b/Resources/Prototypes/_FarHorizons/radio_channels.yml
@@ -52,6 +52,7 @@
   keycode: "c"
   frequency: 3368
   color: "#E0AA3E"
+  chatPrefix: NS
 
 - type: radioChannel
   id: SyndiSec
@@ -59,6 +60,7 @@
   keycode: "s"
   frequency: 3325
   color: "#8a1313"
+  chatPrefix: NS
 
 - type: radioChannel
   id: SyndiSci
@@ -66,6 +68,7 @@
   keycode: "n"
   frequency: 3371
   color: "#a94ac2"
+  chatPrefix: NS
 
 - type: radioChannel
   id: SyndiMed
@@ -73,6 +76,7 @@
   keycode: "m"
   frequency: 3333
   color: "#038ae1"
+  chatPrefix: NS
 
 - type: radioChannel
   id: SyndiEngi
@@ -80,6 +84,7 @@
   keycode: "e"
   frequency: 3364
   color: "#f27803"
+  chatPrefix: NS
 
 - type: radioChannel
   id: SyndiService
@@ -87,6 +92,7 @@
   keycode: "v"
   frequency: 3337
   color: "#F1C232"
+  chatPrefix: NS
 
 - type: radioChannel
   id: SyndiCommon
@@ -94,6 +100,7 @@
   keycode: ";"
   frequency: 3465
   color: "#2cdb2c"
+  chatPrefix: NS
 
 #region High Command Shit Yo
 

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -4,6 +4,7 @@
   keycode: ";"
   frequency: 1459
   color: "#2cdb2c"
+  chatPrefix: NT # Far Horizons
 
 - type: radioChannel
   id: CentCom
@@ -19,6 +20,7 @@
   keycode: 'c'
   frequency: 1353
   color: "#fcdf03"
+  chatPrefix: NT # Far Horizons
 
 - type: radioChannel
   id: Engineering
@@ -26,6 +28,7 @@
   keycode: 'e'
   frequency: 1357
   color: "#ff733c"
+  chatPrefix: NT # Far Horizons
 
 - type: radioChannel
   id: Medical
@@ -33,6 +36,7 @@
   keycode: 'm'
   frequency: 1355
   color: "#57b8f0"
+  chatPrefix: NT # Far Horizons
 
 - type: radioChannel
   id: Science
@@ -40,6 +44,7 @@
   keycode: 'n'
   frequency: 1351
   color: "#cd7ccd"
+  chatPrefix: NT # Far Horizons
 
 - type: radioChannel
   id: Security
@@ -47,6 +52,7 @@
   keycode: 's'
   frequency: 1359
   color: "#0082d9" # Far Horizons Blue sec'ing
+  chatPrefix: NT # Far Horizons
 
 - type: radioChannel
   id: Service
@@ -54,6 +60,7 @@
   keycode: 'v'
   frequency: 1349
   color: "#539c00"
+  chatPrefix: NT # Far Horizons
 
 # Far Horizons -> GSL Comms
 #- type: radioChannel


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Ability to show faction prefixes for radio channels, as well as showing the same prefix on headset

## Why we need to add this
So people with multiple of the similar channel (i.e NT and NS common) can tell them apart

## Media (Video/Screenshots)
<img width="391" height="241" alt="image" src="https://github.com/user-attachments/assets/bf0d14b2-9d9c-4ad6-9bc6-f14182ae9f53" />
<img width="505" height="164" alt="image" src="https://github.com/user-attachments/assets/04440513-f852-4cd3-9585-5488515a66d7" />
<img width="603" height="405" alt="image" src="https://github.com/user-attachments/assets/4d7a25eb-a846-48f1-ae04-b63848109a4b" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- add: New option for chat that enables faction prefixes for radio channels. So you can tell NT Command and NS command apart if you happen to listen/talk to both
- add: When inspecting headsets and encryption keys - the same prefix will also be shown
