### PR TITLE
Add a component defining whether a shuttle turret can shoot through a material in front of it

### DIFF
--- a/Content.Server/_FarHorizons/Shuttles/GunneryConsoleSystem.cs
+++ b/Content.Server/_FarHorizons/Shuttles/GunneryConsoleSystem.cs
@@ -27,8 +27,6 @@ public sealed class GunneryConsoleSystem : EntitySystem
     [Dependency] private readonly TransformSystem _transformSystem = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = null!;
 
-    private const CollisionGroup BulletCollisionMask = CollisionGroup.Impassable | CollisionGroup.BulletImpassable;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -73,6 +71,9 @@ public sealed class GunneryConsoleSystem : EntitySystem
             return;
 
         if (!EntityManager.HasComponent<GunComponent>(args.Sink))
+            return;
+
+        if (!EntityManager.HasComponent<GunneryManagedTargetingComponent>(args.Sink))
             return;
 
         if (comp.ConnectedTurrets.Contains(args.Sink))
@@ -180,6 +181,9 @@ public sealed class GunneryConsoleSystem : EntitySystem
             if (!EntityManager.TryGetComponent<GunComponent>(turret, out var gun) || xform == null)
                 continue;
 
+            if (!EntityManager.TryGetComponent<GunneryManagedTargetingComponent>(turret, out var targeting))
+                continue;
+
             if (!_gunSystem.CanShoot(gun))
                 continue;
 
@@ -191,13 +195,13 @@ public sealed class GunneryConsoleSystem : EntitySystem
             // The bullet is only 0.1 wide, but 0.2 gives buffer for jank collisions and ship movement
             var posOffset = (targetDir with { X = -targetDir.X }) * 0.2f;
 
-            var ray1 = new CollisionRay(globalPos + posOffset, targetDir, (int)BulletCollisionMask);
+            var ray1 = new CollisionRay(globalPos + posOffset, targetDir, (int)targeting.TargetingCollisionMask);
             var ray1CastResults = _physics.IntersectRay(xform.MapID, ray1, comp.CheckDistance, turret, false);
 
             if (ray1CastResults.Select(r => r.HitEntity).Any(u => Transform(u).ParentUid == xform.ParentUid))
                 continue;
 
-            var ray2 = new CollisionRay(globalPos - posOffset, targetDir, (int)BulletCollisionMask);
+            var ray2 = new CollisionRay(globalPos - posOffset, targetDir, (int)targeting.TargetingCollisionMask);
             var ray2CastResults = _physics.IntersectRay(xform.MapID, ray2, comp.CheckDistance, turret, false);
 
             if (ray2CastResults.Select(r => r.HitEntity).Any(u => Transform(u).ParentUid == xform.ParentUid))

--- a/Content.Server/_FarHorizons/Shuttles/GunneryManagedTargetingComponent.cs
+++ b/Content.Server/_FarHorizons/Shuttles/GunneryManagedTargetingComponent.cs
@@ -1,0 +1,16 @@
+using Content.Shared.Physics;
+
+namespace Content.Server._FarHorizons.Shuttles;
+
+/// <summary>
+/// Component used for targeting logic, holds data that acts to determine whether gunnery turret can shoot or not.
+/// </summary>
+[RegisterComponent]
+public sealed partial class GunneryManagedTargetingComponent : Component
+{
+    /// <summary>
+    /// A mask used to determine whether the gun can shoot, based on what material is in front of it, if any.
+    /// </summary>
+    [DataField]
+    public CollisionGroup TargetingCollisionMask = CollisionGroup.Impassable | CollisionGroup.BulletImpassable;
+}

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -23,6 +23,10 @@
     receiveFrequencyId: BasicDevice
   - type: WirelessNetworkConnection
     range: 200
+  - type: GunneryManagedTargeting
+    targetingCollisionMask:
+    - Impassable
+    - BulletImpassable
   - type: DeviceLinkSink
     ports:
     - Trigger
@@ -92,6 +96,9 @@
           tags:
             - PowerCell
             - PowerCellSmall
+  - type: GunneryManagedTargeting
+    targetingCollisionMask:
+      - Opaque
   - type: BatteryAmmoProvider
     proto: RedLightLaser
     fireCost: 50
@@ -148,6 +155,9 @@
         whitelist:
           tags:
             - PowerCage
+  - type: GunneryManagedTargeting
+    targetingCollisionMask:
+      - Opaque
   - type: BatteryAmmoProvider
     proto: RedShuttleLaser
     fireCost: 150

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -23,10 +23,12 @@
     receiveFrequencyId: BasicDevice
   - type: WirelessNetworkConnection
     range: 200
+    # FarHorizons edit start
   - type: GunneryManagedTargeting
     targetingCollisionMask:
     - Impassable
     - BulletImpassable
+    # FarHorizons edit end
   - type: DeviceLinkSink
     ports:
     - Trigger
@@ -96,9 +98,11 @@
           tags:
             - PowerCell
             - PowerCellSmall
+    # FarHorizons edit start
   - type: GunneryManagedTargeting
     targetingCollisionMask:
       - Opaque
+    # FarHorizons edit end
   - type: BatteryAmmoProvider
     proto: RedLightLaser
     fireCost: 50
@@ -155,9 +159,11 @@
         whitelist:
           tags:
             - PowerCage
+    # FarHorizons edit start
   - type: GunneryManagedTargeting
     targetingCollisionMask:
       - Opaque
+    # FarHorizons edit end
   - type: BatteryAmmoProvider
     proto: RedShuttleLaser
     fireCost: 150


### PR DESCRIPTION
## Short description
This PR allows to define per turret whether it can shoot through an object in front of it.

## Why we need to add this
This PR was a request from Killer for shuttle combat. This change is important for laser turrets, since they can shoot through windows, but also opens a possibility to override the settings with emags for example if someone wants to tackle this.

## Media (Video/Screenshots)
https://github.com/user-attachments/assets/c622a065-9d00-4b66-989a-0769b7b503c0

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- add: Added an option for shuttle turrets to shoot through windows.
