### PR TITLE
Added Neosol Crisis Button

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_FarHorizons/Catalog/Fills/Lockers/security.yml
@@ -1137,7 +1137,6 @@
   - type: StorageFill
     contents:
       - id: FlashlightSeclite
-      - id: CrisisButton_NS #temporary until NS SecTech
       - id: WeaponDisabler
       - id: ClothingUniformJumpsuitSecGreySyndi
         prob: 0.6
@@ -1162,8 +1161,6 @@
   - type: StorageFill
     contents:
       - id: FlashlightSeclite
-        amount: 2
-      - id: CrisisButton_NS #temporary until NS SecTech
         amount: 2
       - id: WeaponDisabler
         amount: 2
@@ -1202,8 +1199,6 @@
     contents:
       - id: FlashlightSeclite
         amount: 2
-      - id: CrisisButton_NS #temporary until NS SecTech
-        amount: 2
       - id: WeaponDisabler
         amount: 2
       - id: ClothingUniformJumpsuitSecGreySyndi
@@ -1240,8 +1235,6 @@
   - type: StorageFill
     contents:
       - id: FlashlightSeclite
-        amount: 3
-      - id: CrisisButton_NS #temporary until NS SecTech
         amount: 3
       - id: WeaponDisabler
         amount: 3
@@ -1280,8 +1273,6 @@
   - type: StorageFill
     contents:
       - id: FlashlightSeclite
-        amount: 2
-      - id: CrisisButton_NS #temporary until NS SecTech
         amount: 2
       - id: WeaponDisabler
         amount: 2

--- a/Resources/Prototypes/_FarHorizons/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_FarHorizons/Catalog/Fills/Lockers/security.yml
@@ -1137,6 +1137,7 @@
   - type: StorageFill
     contents:
       - id: FlashlightSeclite
+      - id: CrisisButton_NS #temporary until NS SecTech
       - id: WeaponDisabler
       - id: ClothingUniformJumpsuitSecGreySyndi
         prob: 0.6
@@ -1161,6 +1162,8 @@
   - type: StorageFill
     contents:
       - id: FlashlightSeclite
+        amount: 2
+      - id: CrisisButton_NS #temporary until NS SecTech
         amount: 2
       - id: WeaponDisabler
         amount: 2
@@ -1199,6 +1202,8 @@
     contents:
       - id: FlashlightSeclite
         amount: 2
+      - id: CrisisButton_NS #temporary until NS SecTech
+        amount: 2
       - id: WeaponDisabler
         amount: 2
       - id: ClothingUniformJumpsuitSecGreySyndi
@@ -1235,6 +1240,8 @@
   - type: StorageFill
     contents:
       - id: FlashlightSeclite
+        amount: 3
+      - id: CrisisButton_NS #temporary until NS SecTech
         amount: 3
       - id: WeaponDisabler
         amount: 3
@@ -1273,6 +1280,8 @@
   - type: StorageFill
     contents:
       - id: FlashlightSeclite
+        amount: 2
+      - id: CrisisButton_NS #temporary until NS SecTech
         amount: 2
       - id: WeaponDisabler
         amount: 2

--- a/Resources/Prototypes/_FarHorizons/Catalog/VendingMachines/Inventories/NeoSol-Tech.yml
+++ b/Resources/Prototypes/_FarHorizons/Catalog/VendingMachines/Inventories/NeoSol-Tech.yml
@@ -16,7 +16,7 @@
     ClothingEyeGlassesSecurityPrescription: 2 #Starlight
     ClothingBeltSecurityWebbingSyndi: 5
     CombatKnife: 3
-    CrisisButton: 5 #Starlight
+    CrisisButton_NS: 5
     Zipties: 12
     RiotShield: 2
     RiotLaserShield: 2

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Security/NS_crisisButton.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Security/NS_crisisButton.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: Crisis Button
   parent: BaseItem
-  id: CrisisButton
+  id: CrisisButton_NS
   description: Used to broadcast an distress call to security comms.
   components:
   - type: Sprite
@@ -16,11 +16,10 @@
         collection: TriggerActivate
   - type: TriggerOnUse
   - type: RattleOnTrigger
-    radioChannel: Security
+    radioChannel: SyndiSec
     targetUser: true
     messages:
       Alive: rattle-on-trigger-distress-message
   - type: Tag #FH
     tags: #FH
       - SecBeltEquip #FH
-    

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Security/crisisButton.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Security/crisisButton.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: Crisis Button
   parent: BaseItem
-  id: CrisisButton
+  id: CrisisButton #FH
   description: Used to broadcast an distress call to security comms.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Security/crisisButton.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Security/crisisButton.yml
@@ -1,7 +1,7 @@
 - type: entity
-  name: Crisis Button
+  name: Crisis Button #FH
   parent: BaseItem
-  id: CrisisButton #FH
+  id: CrisisButton
   description: Used to broadcast an distress call to security comms.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Security/crisisButton.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Security/crisisButton.yml
@@ -23,4 +23,3 @@
   - type: Tag #FH
     tags: #FH
       - SecBeltEquip #FH
-    


### PR DESCRIPTION

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Added a NS version of the Crisis button.
Uses the same sprite and name of the NT one for now 
Added to Neosol Sectech

## Why we need to add this
Not having a working Crisis Button kinda sucks and this will be useful later on

## Media (Video/Screenshots)
<img width="1111" height="714" alt="image" src="https://github.com/user-attachments/assets/0e16b133-0c50-4c60-905a-e7071050766f" />
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Ivn7011
- add: Neosol Crisis Button
- tweak: replaced NT Crisis Button with NS Crisis button in the NS sectech
- fix: Capitalization on NT Crisis Button