### PR TITLE
Fix Another Liaison Access

### DIFF
--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Law/Magistrate.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Law/Magistrate.yml
@@ -33,6 +33,7 @@
   - Chapel
   - ChapelNS # Far Horizons
   - External #Far Horizons
+  - ExternalNS #Far Horizons
   - Lawyer
   - LawyerNS # Far Horizons
   - Brig


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Add the External Neosol access to the Concord Liaison, who is missing it, despite having the External NanoTrasen access.
(And this time, I remembered to not use my master branch)

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Access, be missing

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/8f57878f-5068-4c75-8777-c23f6cac7765

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: RubiconLocked
- fix: The Liaison now has access to NeoSol externals.
