### PR TITLE
Increase tritium fire minimum temperature

### DIFF
--- a/Resources/Prototypes/Atmospherics/reactions.yml
+++ b/Resources/Prototypes/Atmospherics/reactions.yml
@@ -11,7 +11,7 @@
 - type: gasReaction
   id: TritiumFire
   priority: -1
-  minimumTemperature: 373.149 # Same as Atmospherics.FireMinimumTemperatureToExist
+  minimumTemperature: 773.149 # Far Horizons - increase tritium burn temperature to hydrogen autoignition temperature
   minimumRequirements: # In this case, same as minimum mole count.
     Oxygen: 0.01
     Tritium: 0.01


### PR DESCRIPTION
## Short description
Increases the ignition temp of tritium from 100C to 500C

## Why we need to add this
To match the ignition temp of real hydrogen, and to allow skill-based tritium farming like RCCT.

## Media (Video/Screenshots)
<img width="346" height="380" alt="image" src="https://github.com/user-attachments/assets/21e825eb-25da-4eb0-8100-c34fc8ead045" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**
:cl: jhrushbe
- tweak: Increased the ignition temperature of tritium to 500C.
