### PR TITLE
Fix Borg access when out of battery.

### DIFF
--- a/Content.Shared/_FarHorizons/Silicons/Borgs/SharedBorgSystem.Access.cs
+++ b/Content.Shared/_FarHorizons/Silicons/Borgs/SharedBorgSystem.Access.cs
@@ -18,6 +18,9 @@ public abstract partial class SharedBorgSystem
 
     private void OnAdditionalAccess(Entity<BorgChassisComponent> ent, ref GetAdditionalAccessEvent args)
     {
+        if(!TryComp<AccessComponent>(ent.Owner, out var access) || !access.Enabled)
+            return;
+
         foreach(var module in ent.Comp.ModuleContainer.ContainedEntities)
         {
             if(!HasComp<PassiveBorgModuleComponent>(module) || !HasComp<AccessComponent>(module))


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes an issue where borgs still had access with no battery.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Fix.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<video src="https://github.com/user-attachments/assets/6808f1eb-2bd3-41c2-bed5-18bdd7a29a7d"></video>


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: AthenaAI
- fix: Fixes an issue where borgs still had access with no battery.
