### PR TITLE
Ports: 3396 and fixes the issues with filtered crew monitors.

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringBoundUserInterface.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringBoundUserInterface.cs
@@ -5,15 +5,19 @@ using Content.Shared.Silicons.StationAi; // Starlight
 using Robust.Shared.Map; // Starlight
 using Robust.Shared.Player; // Starlight
 using System.Linq; // Starlight
+using Robust.Shared.Timing; // Starlight
 
 namespace Content.Client.Medical.CrewMonitoring;
 
 public sealed class CrewMonitoringBoundUserInterface : BoundUserInterface
 {
     [Dependency] private readonly ISharedPlayerManager _playerManager = default!; // Starlight
+    [Dependency] private readonly IGameTiming _gameTiming = default!; // Starlight
 
     [ViewVariables]
     private CrewMonitoringWindow? _menu;
+    
+    private TimeSpan _lastOpened = TimeSpan.Zero; // Starlight
 
     public CrewMonitoringBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
     {
@@ -27,6 +31,7 @@ public sealed class CrewMonitoringBoundUserInterface : BoundUserInterface
         // Starlight-start
         if (_menu != null)
             _menu.MapClicked -= OnMapClicked;
+        _lastOpened = _gameTiming.CurTime;
         // Starlight-end
 
         EntityUid? gridUid = null;
@@ -51,13 +56,14 @@ public sealed class CrewMonitoringBoundUserInterface : BoundUserInterface
     {
         base.UpdateState(state);
 
-
         switch (state)
         {
             case CrewMonitoringState st:
                 EntMan.TryGetComponent<TransformComponent>(Owner, out var xform);
                 // Starlight begin
-                if (EntMan.TryGetComponent<CrewMonitoringFilterComponent>(Owner, out var filter))
+                bool awaitingData = st.Timestamp < _lastOpened; // Know whether we have real data or are viewing a cached state.
+                bool serverOnline = _gameTiming.CurTime - st.LastUpdate < TimeSpan.FromSeconds(6); // After 6 seconds of radio silence, the server is presumed offline.
+                if (!awaitingData && EntMan.TryGetComponent<CrewMonitoringFilterComponent>(Owner, out var filter))
                 {
                     var filteredSensors = filter.ShownDepartments.Count == 0 ?
                         st.Sensors.ToList() // We ToList it to ensure we get a copy, for the off chance that someone sets AlwaysShowTrackingImplants without any ShownDepartments
@@ -87,12 +93,12 @@ public sealed class CrewMonitoringBoundUserInterface : BoundUserInterface
                     }
 
                     filteredSensors = filteredSensors.Distinct().ToList();
-                    _menu?.ShowSensors(filteredSensors, Owner, xform?.Coordinates);
+                    _menu?.ShowSensors(awaitingData, serverOnline, filteredSensors, Owner, xform?.Coordinates);
                     break;
                 }
                 // We let it flow into the upstream code if there's no CrewMonitoringComponent
+                _menu?.ShowSensors(awaitingData, serverOnline, st.Sensors, Owner, xform?.Coordinates);
                 // Starlight end
-                _menu?.ShowSensors(st.Sensors, Owner, xform?.Coordinates);
                 break;
         }
     }

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml
@@ -34,6 +34,14 @@
                             FontColorOverride="Red"
                             HorizontalAlignment="Center"
                             Visible="false"/>
+                    <!-- Starlight BEGIN -->
+                    <Label  Name="NoEligibleSensorsLabel"
+                            Text="{Loc crew-monitoring-ui-no-eligible-sensors-label}"
+                            StyleClasses="LabelHeading"
+                            FontColorOverride="Green"
+                            HorizontalAlignment="Center"
+                            Visible="false"/>
+                    <!-- Starlight END -->
                 </ScrollContainer>
             </BoxContainer>
         </BoxContainer>

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -69,18 +69,38 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
             TryToScrollToFocus();
     }
 
-    public void ShowSensors(List<SuitSensorStatus> sensors, EntityUid monitor, EntityCoordinates? monitorCoords)
+    public void ShowSensors(bool awaitingData, bool serverOnline, List<SuitSensorStatus> sensors, EntityUid monitor, EntityCoordinates? monitorCoords) // Starlight: Add first two params
     {
         ClearOutDatedData();
+        
+        // Starlight BEGIN
+        NoServerLabel.Visible = false;
+        NoEligibleSensorsLabel.Visible = false;
+        
+        // Show monitor on nav map, always.
+        if (monitorCoords != null && _blipTexture != null)
+        {
+            NavMap.TrackedEntities[_entManager.GetNetEntity(monitor)] = new NavMapBlip(monitorCoords.Value, _blipTexture, Color.Cyan, true, false);
+        }
+        
+        // Don't show outdated data.
+        if (awaitingData)
+            return;
 
         // No server label
-        if (sensors.Count == 0)
+        if (!serverOnline)
         {
             NoServerLabel.Visible = true;
             return;
         }
-
-        NoServerLabel.Visible = false;
+        
+        // No eligible sensors label
+        if (sensors.Count == 0)
+        {
+            NoEligibleSensorsLabel.Visible = true;
+            return;
+        }
+        // Starlight END
 
         // Collect one status per user, using the sensor with the most data available.
         Dictionary<NetEntity, SuitSensorStatus> uniqueSensorsMap = new();
@@ -164,12 +184,16 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
 
             PopulateDepartmentList(remainingSensors);
         }
-
+        
+        // Starlight BEGIN: Moved to top of function
+        /*
         // Show monitor on nav map
         if (monitorCoords != null && _blipTexture != null)
         {
             NavMap.TrackedEntities[_entManager.GetNetEntity(monitor)] = new NavMapBlip(monitorCoords.Value, _blipTexture, Color.Cyan, true, false);
         }
+        */
+        // Starlight END
     }
 
     private void PopulateDepartmentList(IEnumerable<SuitSensorStatus> departmentSensors)

--- a/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleComponent.cs
+++ b/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleComponent.cs
@@ -3,6 +3,7 @@ using Content.Shared.Medical.SuitSensor;
 namespace Content.Server.Medical.CrewMonitoring;
 
 [RegisterComponent]
+[AutoGenerateComponentPause] // Starlight
 [Access(typeof(CrewMonitoringConsoleSystem))]
 public sealed partial class CrewMonitoringConsoleComponent : Component
 {
@@ -10,6 +11,24 @@ public sealed partial class CrewMonitoringConsoleComponent : Component
     ///     List of all currently connected sensors to this console.
     /// </summary>
     public Dictionary<string, SuitSensorStatus> ConnectedSensors = new();
+
+    /// <summary>
+    ///     STARLIGHT: The rate at which this console transmits UI updates to clients.
+    /// </summary>
+    [DataField]
+    public TimeSpan InterfaceUpdateRate = TimeSpan.FromSeconds(3);
+
+    /// <summary>
+    ///     STARLIGHT: The time at which this console last transmitted a UI update.
+    /// </summary>
+    [AutoPausedField]
+    public TimeSpan LastInterfaceUpdate = TimeSpan.Zero;
+    
+    /// <summary>
+    ///     STARLIGHT: When the last update was received. Used to determine if the server is online.
+    /// </summary>
+    [DataField]
+    public TimeSpan LastSensorDataReceivedAt = TimeSpan.Zero;
 
     /// <summary>
     ///     After what time sensor consider to be lost.

--- a/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleSystem.cs
+++ b/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleSystem.cs
@@ -13,6 +13,7 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Log; // Starlight
 using Content.Shared.Silicons.StationAi; // Starlight
 using Robust.Shared.Map; // Starlight
+using Robust.Shared.Timing; // Starlight
 
 namespace Content.Server.Medical.CrewMonitoring;
 
@@ -21,6 +22,7 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
     [Dependency] private readonly PowerCellSystem _cell = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
     [Dependency] private readonly StationAiSystem _stationAiSystem = default!; // Starlight
+    [Dependency] private readonly IGameTiming _gameTiming = default!; // Starlight
 
     private readonly ISawmill _sawmill = Logger.GetSawmill("crewmonitoring"); // Starlight
 
@@ -31,6 +33,24 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
         SubscribeLocalEvent<CrewMonitoringConsoleComponent, DeviceNetworkPacketEvent>(OnPacketReceived);
         SubscribeLocalEvent<CrewMonitoringConsoleComponent, BoundUIOpenedEvent>(OnUIOpened);
         SubscribeLocalEvent<CrewMonitoringConsoleComponent, CrewMonitoringWarpRequestMessage>(OnWarpRequest); // Starlight
+    }
+
+    /// <summary>
+    ///     STARLIGHT: Periodically update the UI, even if there is no crew monitoring server transmitting.
+    /// </summary>
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        
+        // Periodically update the UI, per console.
+        var consoles = EntityQueryEnumerator<CrewMonitoringConsoleComponent>();
+        while (consoles.MoveNext(out var id, out var console))
+        {
+            if (console.LastInterfaceUpdate + console.InterfaceUpdateRate > _gameTiming.CurTime)
+                return;
+            
+            UpdateUserInterface(id, console);
+        }
     }
 
     private void OnRemove(EntityUid uid, CrewMonitoringConsoleComponent component, ComponentRemove args)
@@ -53,6 +73,7 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
             return;
 
         component.ConnectedSensors = sensorStatus;
+        component.LastSensorDataReceivedAt = _gameTiming.CurTime; // Starlight
         UpdateUserInterface(uid, component);
     }
 
@@ -68,6 +89,7 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
     {
         if (!Resolve(uid, ref component))
             return;
+        component.LastInterfaceUpdate = _gameTiming.CurTime; // Starlight
 
         if (!_uiSystem.IsUiOpen(uid, CrewMonitoringUIKey.Key))
             return;
@@ -80,7 +102,7 @@ public sealed class CrewMonitoringConsoleSystem : EntitySystem
 
         // Update all sensors info
         var allSensors = component.ConnectedSensors.Values.ToList();
-        _uiSystem.SetUiState(uid, CrewMonitoringUIKey.Key, new CrewMonitoringState(allSensors));
+        _uiSystem.SetUiState(uid, CrewMonitoringUIKey.Key, new CrewMonitoringState(_gameTiming.CurTime, component.LastSensorDataReceivedAt, allSensors)); // Starlight: Add two timestamps
     }
     // Starlight-start
     private void OnWarpRequest(EntityUid uid, CrewMonitoringConsoleComponent component, ref CrewMonitoringWarpRequestMessage args)

--- a/Content.Server/Medical/CrewMonitoring/CrewMonitoringServerSystem.cs
+++ b/Content.Server/Medical/CrewMonitoring/CrewMonitoringServerSystem.cs
@@ -66,7 +66,7 @@ public sealed class CrewMonitoringServerSystem : EntitySystem
     /// </summary>
     private void OnRemove(EntityUid uid, CrewMonitoringServerComponent component, ComponentRemove args)
     {
-        component.SensorStatus.Clear();
+        //component.SensorStatus.Clear(); // Starlight: Don't instantly wipe sensor list, let it time out instead.
     }
 
     /// <summary>

--- a/Content.Shared/Medical/CrewMonitoring/CrewMonitoringShared.cs
+++ b/Content.Shared/Medical/CrewMonitoring/CrewMonitoringShared.cs
@@ -13,10 +13,14 @@ public enum CrewMonitoringUIKey
 [Serializable, NetSerializable]
 public sealed class CrewMonitoringState : BoundUserInterfaceState
 {
+    public TimeSpan Timestamp; // Starlight: When this state was transmitted.
+    public TimeSpan LastUpdate; // Starlight: The last time the console got an update from the monitoring server.
     public List<SuitSensorStatus> Sensors;
 
-    public CrewMonitoringState(List<SuitSensorStatus> sensors)
+    public CrewMonitoringState(TimeSpan timestamp, TimeSpan lastUpdate, List<SuitSensorStatus> sensors) // Starlight
     {
+        Timestamp = timestamp; // Starlight
+        LastUpdate = lastUpdate; // Starlight
         Sensors = sensors;
     }
 }

--- a/Resources/Locale/en-US/_Starlight/medical/components/crew-monitoring-component.ftl
+++ b/Resources/Locale/en-US/_Starlight/medical/components/crew-monitoring-component.ftl
@@ -1,0 +1,3 @@
+﻿## UI
+
+crew-monitoring-ui-no-eligible-sensors-label = No eligible sensors found

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Medical/handheld_corpsman_crew_monitor.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Medical/handheld_corpsman_crew_monitor.yml
@@ -19,7 +19,7 @@
   - type: CrewMonitoringConsole
   - type: CrewMonitoringFilter
     shownDepartments:
-    - Security
+    - "Security Jobs - NT Corporate Security"
   - type: DeviceNetwork
     deviceNetId: Wireless
     receiveFrequencyId: CrewMonitor
@@ -38,6 +38,72 @@
   - type: Tag
     tags:
       - BrigmedicBeltEquip
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+
+- type: entity
+  id: HandheldCorpsmanCrewMonitorNS
+  parent: HandheldCorpsmanCrewMonitor
+  suffix: NS
+  components:
+  - type: CrewMonitoringFilter
+    shownDepartments:
+    - "Security Jobs - Aegis Corporate Securities"
+
+- type: entity
+  id: HandheldCorpsmanCrewMonitorNSEmpty
+  parent: HandheldCorpsmanCrewMonitorNS
+  suffix: NS, Empty
+  components:
+  - type: Tag
+    tags:
+      - BrigmedicBeltEquip
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+
+- type: entity
+  id: HandheldBrigmedicCrewMonitorNS
+  parent: HandheldBrigmedicCrewMonitor
+  suffix: NS
+  components:
+  - type: CrewMonitoringFilter
+    shownDepartments:
+    - "Security Jobs - Aegis Corporate Securities"
+
+- type: entity
+  id: HandheldBrigmedicCrewMonitorNSEmpty
+  parent: HandheldBrigmedicCrewMonitorNS
+  suffix: NS, Empty
+  components:
+  - type: Tag
+    tags:
+      - BrigmedicBeltEquip
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+
+- type: entity
+  name: CommandFriend™ X-02
+  parent: HandheldBSOCrewMonitor
+  id: HandheldBSOCrewMonitorNS
+  description: Does not monitor the competence levels of command members.
+  suffix: NS
+  components:
+  - type: CrewMonitoringFilter
+    shownDepartments:
+    - "Command Jobs - Cybersun and Major Executives From Leading Companies"
+    alwaysShowTrackingImplants: true
+
+- type: entity
+  id: HandheldBSOCrewMonitorNSEmpty
+  parent: HandheldBSOCrewMonitorNS
+  suffix: NS, Empty
+  components:
   - type: ItemSlots
     slots:
       cell_slot:

--- a/Resources/Prototypes/_FarHorizons/Factions/Loadouts/syndie_startingGear.yml
+++ b/Resources/Prototypes/_FarHorizons/Factions/Loadouts/syndie_startingGear.yml
@@ -19,7 +19,7 @@
     belt: ClothingBeltRedSwordWebbingFilled
     gloves: ClothingHandsGlovesCombat
     pocket1: WeaponMultiphaseGun
-    pocket2: HandheldBSOCrewMonitor
+    pocket2: HandheldBSOCrewMonitorNS
   storage:
     back:
     - Flash
@@ -238,7 +238,7 @@
   id: SyndieCorpsmanGear
   equipment:
     neck: ClothingNeckTieBlue
-    pocket2: HandheldCorpsmanCrewMonitor
+    pocket2: HandheldCorpsmanCrewMonitorNS
     id: NeoSolCorpsmanPDA
     ears: ClothingHeadsetSecMedSyndi
   storage:
@@ -251,7 +251,7 @@
   id: SyndieBrigmedicGear
   equipment:
     neck: ClothingNeckTieRed
-    pocket2: HandheldBrigmedicCrewMonitor
+    pocket2: HandheldBrigmedicCrewMonitorNS
     mask: ClothingMaskBreathMedicalSecurity
     id: NeoSolBrigmedicPDA
     ears: ClothingHeadsetSecMedSyndi

--- a/Resources/Prototypes/_Moffstation/Entities/Structures/Machines/crew_monitoring_server.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Structures/Machines/crew_monitoring_server.yml
@@ -1,0 +1,34 @@
+﻿# This was peeled off of upstream's `CrewMonitoringServer`. Changes to that prototype from upstream should be
+# carefully considered to be added here or there, depending on whether it should affect just the machine variant, or all
+# variants of the crewmon server.
+- type: entity
+  id: BaseCrewMonitoringServer
+  abstract: true
+  name: abstract crew monitoring server
+  description: Receives and relays the status of all active suit sensors on the station.
+  components:
+  - type: CrewMonitoringServer
+  - type: SingletonDeviceNetServer
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    transmitFrequencyId: CrewMonitor
+    receiveFrequencyId: SuitSensor
+    autoConnect: true # Starlight
+  - type: WirelessNetworkConnection
+    range: 500
+  - type: StationLimitedNetwork
+  - type: ApcPowerReceiver
+    powerLoad: 200
+  - type: ExtensionCableReceiver
+  - type: WiresPanel
+  - type: WiresVisuals
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.PowerDeviceVisuals.Powered:
+        enum.PowerDeviceVisualLayers.Powered:
+          True: { visible: true }
+          False: { visible: false }
+  - type: GuideHelp
+    guides:
+    - Medical

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/handheld_brigmedic_crew_monitor.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/handheld_brigmedic_crew_monitor.yml
@@ -3,6 +3,7 @@
   parent: [ BaseHandheldComputer, BaseSecurityContraband ]
   id: HandheldBrigmedicCrewMonitor
   description: So advanced it only tracks security personnel! Does not monitor emotional stability or competence levels of security members. Use at your own risk!
+  suffix: NT #FH
   components:
   - type: Tag
     tags:
@@ -21,7 +22,7 @@
   - type: CrewMonitoringConsole
   - type: CrewMonitoringFilter
     shownDepartments:
-    - Security
+    - "Security Jobs - NT Corporate Security" #FH
   - type: DeviceNetwork
     deviceNetId: Wireless
     receiveFrequencyId: CrewMonitor
@@ -35,7 +36,7 @@
 - type: entity
   id: HandheldBrigmedicCrewMonitorEmpty
   parent: HandheldBrigmedicCrewMonitor
-  suffix: Empty
+  suffix: NT, Empty #FH
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/handheld_bso_crew_monitor.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/handheld_bso_crew_monitor.yml
@@ -3,6 +3,7 @@
   parent: [ BaseHandheldComputer, BaseBlueshieldCommandContraband ] # FH
   id: HandheldBSOCrewMonitor
   description: Does not monitor the competence levels of command members.
+  suffix: NT #FH
   components:
 #  - type: Tag
 #    tags:
@@ -21,7 +22,7 @@
   - type: CrewMonitoringConsole
   - type: CrewMonitoringFilter
     shownDepartments:
-    - Command
+    - "Command Jobs - NT Executives" #FH
     alwaysShowTrackingImplants: true
   - type: DeviceNetwork
     deviceNetId: Wireless
@@ -32,7 +33,7 @@
 - type: entity
   id: HandheldBSOCrewMonitorEmpty
   parent: HandheldBSOCrewMonitor
-  suffix: Empty
+  suffix: NT, Empty #FH
   components:
 #  - type: Tag
 #    tags:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
- Ports 3396 by redmushie that improves the UX for crew monitors.
- Fixes the brigbuddy, corpbuddy and commandbuddy to track their designated targets.
- Updated all the loadouts for the syndiesn with their crew monitor counterpart.
Apparently how it filters the departments is by comparing the department in the manifest UX to the filter name.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Fixes

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1254" height="796" alt="image3" src="https://github.com/user-attachments/assets/35013c4f-9fb6-4b0b-9dac-66ecf86ba44a" />
<img width="1272" height="760" alt="Screenshot 2026-08-09 213941" src="https://github.com/user-attachments/assets/856a10d0-1dd4-4d94-adc9-622371f094a6" />
<img width="1265" height="777" alt="Screenshot 2026-08-09 214025" src="https://github.com/user-attachments/assets/217350e4-d863-488b-a3d5-65c9f4123351" />
<img width="1236" height="785" alt="Screenshot 2026-08-09 214047" src="https://github.com/user-attachments/assets/494d45f6-5407-4cc6-8e30-ff1b6d73dc4d" />
<img width="1227" height="727" alt="Screenshot 2026-08-09 215157" src="https://github.com/user-attachments/assets/28849093-e997-4610-94bb-42cc20d3c6b4" />
<img width="1290" height="804" alt="image" src="https://github.com/user-attachments/assets/3c38ad73-842e-4029-acd1-a9d1b59a470d" />
<img width="1240" height="783" alt="image2" src="https://github.com/user-attachments/assets/e83e93c6-5b1d-496b-9620-ef144b2db5f9" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: AthenaAI, redmushie
- add: Crew monitors now tell you if zero sensors match their built-in filter. (redmushie)
- tweak: Crew monitors now always show your own location, even if the server is offline. (redmushie)
- fix: Crew monitors now detect the server even when there are zero suit sensors transmitting. (redmushie)
- tweak: Crew monitors no longer instantly forget what is being displayed the instant the server goes offline and instead time-out after a while. (redmushie)
- fix: Crew monitors no longer briefly show old data when you open them. (redmushie)
- fix: Fixes the brigbuddy, corpbuddy and commandbuddy being unable to track their designated targets.
- tweak: Updated all the loadouts for the syndiesn with their crew monitor counterpart.