### PR TITLE
Change PKA and PKS to deal pierce instead of blunt

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -570,7 +570,7 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 25
+        Piercing: 25
         Structural: 30
   # Short lifespan
   - type: TimedDespawn

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -570,7 +570,7 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Piercing: 25
+        Piercing: 25 # Far Horizons- As it turns out, blunt guns are fucky with flat resists.
         Structural: 30
   # Short lifespan
   - type: TimedDespawn

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -16,7 +16,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 13
+        Piercing: 13
         Structural: 15
   - type: TimedDespawn
     lifetime: 0.2 # roughly 5 tiles


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

What it says on the tin, change the PKA and PKS projectiles to deal pierce rather than blunt. There's no change in damage values, only damage types.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

As it turns out, guns that deal blunt damage are really fucky with flat resists, leading to a shotgun that shreds through all armor.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.

https://github.com/user-attachments/assets/250549a9-eeab-4cbf-88d8-184528617293



-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Erophosea
- tweak: Changed the Protokinetic guns (Both PKA, PKS, and cybernetic PKA) to deal piercing damage rather than blunt, to remove unintended armor piercing.
