### PR TITLE
Give the NT Salvage Lead Report the "Nanotrasen Document" Category

### DIFF
--- a/Resources/Prototypes/_Starlight/Recipes/Lathes/printer.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Lathes/printer.yml
@@ -136,7 +136,8 @@
   id: PrintedDocumentSalvageLeadReportRecipe
   result: PrintedDocumentSalvageLeadReport
   categories:
-    - Reports
+  - Reports
+  - NanoTrasonDocument #FH
   completetime: 2
   applyMaterialDiscount: false
   materials:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
PR #1521 gave either the "Nanotrasen Document" or the "NeoSol Document" category to every document that can be printed by a Printer, except for the NT version of the Salvage Lead Report, which has neither, while the NS version of the Salvage Lead Report does have the "NeoSol Document" category. Of course, most of the time this makes no difference gameplay wise, but since  the cybernetic scribe arms have a printer with access to both NT and NS documents, filtering by "Nanotrasen Document" would make it so no Salvage Lead Report appears.

This PR gives the NT Salvage Lead Report the "Nanotrasen Document" category.

## Why we need to add this
Consistency and such.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="745" height="490" alt="Captura de pantalla 2026-08-14 190058" src="https://github.com/user-attachments/assets/a561d6d5-754f-4da6-8120-857e4adbc961" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: RubiconLocked
- fix: Salvage Lead Report is now correctly categorized.