### PR TITLE
Fix SMES and substation flatpack error

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -626,7 +626,7 @@
       componentRequirements:
         PowerCell:
           amount: 4
-          defaultPrototype: PowerCellSmall
+          defaultPrototype: PowerCellSmallPrinted # Far Horizons - band-aid flatpack fix
 
 - type: entity
   id: SMESAdvancedMachineCircuitboard
@@ -645,7 +645,7 @@
     componentRequirements:
       PowerCell:
         amount: 4
-        defaultPrototype: PowerCellMedium
+        defaultPrototype: PowerCellMediumPrinted # Far Horizons - band-aid flatpack fix
 
 - type: entity
   id: CellRechargerCircuitboard
@@ -766,7 +766,7 @@
       componentRequirements:
         PowerCell:
           amount: 1
-          defaultPrototype: PowerCellSmall
+          defaultPrototype: PowerCellSmallPrinted # Far Horizons - band-aid flatpack fix
     - type: PhysicalComposition
       materialComposition:
         Glass: 200


### PR DESCRIPTION
## Short description
Allows SMES and substations to be flatpacked again. Does not affect normal machine frame construction.

## Why we need to add this
Bugfix

## Media (Video/Screenshots)
<img width="222" height="307" alt="image" src="https://github.com/user-attachments/assets/a33d50e3-d292-490c-bb30-a42493f1a678" />
<img width="220" height="312" alt="image" src="https://github.com/user-attachments/assets/4af0c77c-e656-449e-9c91-eb925325bf2a" />
<img width="222" height="323" alt="image" src="https://github.com/user-attachments/assets/cf7031cd-22e4-4924-a172-585759a7b3b9" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**
:cl: jhrushbe
- fix: Fixed a bug that prevented SMES and substations from being flatpacked.
