### PR TITLE
Tamper seal announcement change

### DIFF
--- a/Resources/Locale/en-US/_FarHorizons/cargo/tamper-seal.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/cargo/tamper-seal.ftl
@@ -1,6 +1,6 @@
 # Performance failure announcement
-tamper-seal-performance-failure-sender = Interstellar Trade Guild
-tamper-seal-performance-failure-message = Repeated destruction of tamper-sealed orders detected. We encourage you to investigate the department responsible for handling your orders.
+tamper-seal-performance-failure-sender = Gemini Stellar Logistics
+tamper-seal-performance-failure-message = Repeated destruction of tamper-sealed orders detected. We encourage our employees to handle orders with more care.
 
 # Examine
 tamper-seal-examine-sealed-public = There is a [color=yellow]tamper seal[/color] present.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
changes the sender of the tamper seal announcement from the Interstellar Trade Guild to the GSL

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
We already have a third party company running cargo, I don't see why the announcement would be sent by someone else

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1103" height="138" alt="Screenshot 2026-08-16 170418" src="https://github.com/user-attachments/assets/f011a00c-f525-4695-9b33-279dfd122ed2" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: rain_enjoyer
- fix: Tamper seal related announcements now come from the GSL 
