### PR TITLE
Make proto moths as flammable as regular moths

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
@@ -1278,7 +1278,7 @@
   - type: Flammable
     damage:
       types:
-        Heat: 2.5
+        Heat: 4.5
   - type: Temperature
     currentTemperature: 310.15
     specificHeat: 46

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/protogen.yml
@@ -1758,9 +1758,9 @@
         layer:
           - MobLayer
   - type: IgnoreKudzu
-  - type: IgniteOnHeatDamage
-    fireStacks: 1
-    threshold: 12
+#  - type: IgniteOnHeatDamage #FH it sucks so bad // parity with regular diona
+#    fireStacks: 1
+#    threshold: 12
   - type: GibAction
     actionPrototype: DionaGibAction
     allowedStates:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR makes proto moths as  flammable as regular moths, i assume this change was lost, when SL increased their heat damage at some point, and missed proto moths.

This PR also changes proto diona igniting from heat damage - to maintain parity with regular diona.

## Why we need to add this
Their guidebook specifically says that they are still flammable.

As for diona, well, seems someone forgot ti include them.

## Media (Video/Screenshots)
<img width="2012" height="975" alt="image" src="https://github.com/user-attachments/assets/3aaf5586-309d-42d9-9ea9-0cbd55023e08" />
<img width="597" height="603" alt="image" src="https://github.com/user-attachments/assets/0028b0f0-3bc6-4a3f-b943-efca2e5bf658" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- tweak: Changed proto moths not burning as nicely as regular moths.
- tweak: Changed proto diona being a bit too flammable compared to their organic cousins.
