### PR TITLE
Cherry-pick 89e2e1ab7a6 from ss14-starlight to improve test times

### DIFF
--- a/Content.Client/Guidebook/Controls/GuideReagentGroupEmbed.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuideReagentGroupEmbed.xaml.cs
@@ -8,6 +8,7 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.XAML;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 
 namespace Content.Client.Guidebook.Controls;
 
@@ -22,6 +23,9 @@ public sealed partial class GuideReagentGroupEmbed : BoxContainer, IDocumentTag
 
     private readonly ISawmill _sawmill;
 
+    // Starlight
+    private List<ReagentPrototype>? _reagentsToAdd;
+
     public GuideReagentGroupEmbed()
     {
         RobustXamlLoader.Load(this);
@@ -34,11 +38,7 @@ public sealed partial class GuideReagentGroupEmbed : BoxContainer, IDocumentTag
     {
         var prototypes = _prototype.EnumeratePrototypes<ReagentPrototype>()
             .Where(p => p.Group.Equals(group)).OrderBy(p => p.LocalizedName);
-        foreach (var reagent in prototypes)
-        {
-            var embed = new GuideReagentEmbed(reagent);
-            GroupContainer.AddChild(embed);
-        }
+        _reagentsToAdd = prototypes.ToList(); // Starlight
     }
 
     public bool TryParseTag(Dictionary<string, string> args, [NotNullWhen(true)] out Control? control)
@@ -52,13 +52,30 @@ public sealed partial class GuideReagentGroupEmbed : BoxContainer, IDocumentTag
 
         var prototypes = _prototype.EnumeratePrototypes<ReagentPrototype>()
             .Where(p => p.Group.Equals(group)).OrderBy(p => p.LocalizedName);
-        foreach (var reagent in prototypes)
-        {
-            var embed = new GuideReagentEmbed(reagent);
-            GroupContainer.AddChild(embed);
-        }
+        _reagentsToAdd = prototypes.ToList(); // Starlight
 
         control = this;
         return true;
+    }
+
+    // Starlight
+    protected override void FrameUpdate(FrameEventArgs args)
+    {
+        base.FrameUpdate(args);
+
+        if (_reagentsToAdd == null)
+            return;
+
+        // Stop after adding 5 reagents, wait for next frame update
+        // This prevents it from lagging as much, and helps to not trigger
+        // the style update limit in engine
+        var count = _reagentsToAdd.Count;
+        for (var i = count - 1; i >= Math.Max(0, count - 5); i--)
+        {
+            var reagent = _reagentsToAdd[i];
+            _reagentsToAdd.RemoveAt(i);
+            var embed = new GuideReagentEmbed(reagent);
+            GroupContainer.AddChild(embed);
+        }
     }
 }

--- a/Content.Server/_Starlight/AlertArmory/AlertArmorySystem.cs
+++ b/Content.Server/_Starlight/AlertArmory/AlertArmorySystem.cs
@@ -1,35 +1,29 @@
-using System.Diagnostics.CodeAnalysis;
-using Content.Server.AlertLevel;
 using Content.Server.Chat.Systems;
 using Content.Server.Pinpointer;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
 using Content.Server.Shuttles.Systems;
-using Content.Server.Station.Components;
 using Content.Server.Station.Events;
 using Content.Server.Station.Systems;
 using Content.Shared.Shuttles.Components;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map;
-using Robust.Shared.Map.Components;
 using Robust.Shared.EntitySerialization.Systems;
-using Robust.Shared.EntitySerialization;
 using Robust.Shared.Utility;
 using Content.Shared.Station.Components;
 using Robust.Shared.Physics.Components;
 using System.Numerics;
-using System.Linq;
 using Content.Server._Starlight.Station;
+using Content.Shared.CCVar;
 using Content.Shared.Popups;
-using Content.Shared.Tag;
-using Robust.Shared.Prototypes;
 using Content.Shared.Mobs.Components;
-using Robust.Shared.Player;
+using Robust.Shared.Configuration;
 
 namespace Content.Server.Starlight.AlertArmory;
 
 public sealed partial class AlertArmorySystem : EntitySystem
 {
+    [Dependency] private IConfigurationManager _config = default!;
     [Dependency] private MapSystem _map = default!;
     [Dependency] private MetaDataSystem _meta = default!;
     [Dependency] private MapLoaderSystem _loader = default!;
@@ -63,7 +57,9 @@ public sealed partial class AlertArmorySystem : EntitySystem
     ///</summary>
     private void InitializeAlertArmoryStation(EntityUid uid, AlertArmoryStationComponent comp, StationPostInitEvent ev)
     {
-        //Starlight start
+        if (!_config.GetCVar(CCVars.GridFill))
+            return;
+
         if (TryComp<StationDataComponent>(uid, out var station))
             foreach (var grid in station.Grids)
             {
@@ -72,8 +68,7 @@ public sealed partial class AlertArmorySystem : EntitySystem
                     return;
                 break; // can break, we already found the grid that created this station
             }
-        //Starlight end
-        
+
         var map = _map.CreateMap(out var mapId);
         _meta.SetEntityName(map, $"AlertArmories {uid}");
 

--- a/Content.Shared/Abilities/Goliath/GoliathTentacleSystem.cs
+++ b/Content.Shared/Abilities/Goliath/GoliathTentacleSystem.cs
@@ -56,6 +56,9 @@ public sealed partial class GoliathTentacleSystem : DelayableEntitySystem
                 _turf.IsTileBlocked(tileRef, CollisionGroup.Impassable))
                 return;
 
+            if (TerminatingOrDeleted(pos.EntityId))
+                return;
+
             if (_net.IsServer)
                 Spawn(args.EntityId, pos);
             if ((Action<EntityCoordinates>?)action is not null && spawnPos.TryDequeue(out var newPos))


### PR DESCRIPTION
## Short description
Although the worst case of the test impact from the alert shuttles doesn't impact Far-Horizons because of a separate change to make AssignJobsTest not spawn as many maps, this does still improve our test times by about 15% on my system.

Original commit message below:

Fix tests failing and taking 10 thousand years to run, for the third time (#3989)

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

<!-- What do you propose to change with your PR? --> First https://github.com/ss14Starlight/space-station-14/pull/1504 and second https://github.com/ss14Starlight/space-station-14/pull/1529 for reference
Needless to say if I have to do this a fourth time I'm rebasing Afterlight to Far Horizons, where the tests actually reliably pass on a day to day basis
For the love of god, actually keep tests running this time, actually enforce them passing before merging a PR, and actually keep the tests running instead of timing out after 60 minutes on the Starlight branch (see here
https://github.com/ss14Starlight/space-station-14/actions/runs/23678277294/job/68985647664), like every other repo does, I do not feel like spending another 5 hours trying to figure this out with the help of wizden maintainers trying to figure out what the hell is going on here
The fact that this is a recurring issue is an embarassment, not just in this repo, but in Afterlight where we actually pay to run our tests, faster than GitHub, then have them time out anyways.

Also make sure you have grid_fill set to true on the live servers, which you should, presumably.
This also removes the Starlight Start and Starlight end markers added in I don't really know why the code is spawning a new map per station and then pre-loading two shuttles into it but this PR is about fixing test run times specifically, not that, which would be more involved.

**Edit:** Also wait for tests to pass here before merging this PR, this is the thing that stood out on my computer but my computer is not the GitHub runner which is a lot slower, I'll fix whatever else comes up from the CI run on this PR

<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This method alone makes a test that takes 30 seconds to run take TEN MINUTES on my R9 9900X CPU instead, that being AssignJobsTest This also applies to a lesser degree to any other test that re-creates the station using the game ticker

Other things:
- I removed the heap hard limit from the workflow since that shouldn't be doing anything anyways and if it is it's going to kill the process, which is suboptimal
- https://github.com/ss14Starlight/space-station-14/pull/3817 localized entity prototype names. Those are automatically localized. You should not be localizing them yourself, there is a test for this, it was ignored, and it was merged regardless. Use ent-{id} to localize them, the engine does this for you, which is one of the many reasons you should use entity prototypes for everything.
- SilverJug and GoldenJug lathe recipe costs did not match their physical composition
- Goliath tentacles delayed spawn would sometimes throw if spawning on a deleting grid
- Opening up the chemicals guidebook was queueing 27 thousand style updates, also known as lagging your client, also prompting a warning from the engine since thats above its 25 thousand sanity check limit. The chemicals guidebook now slowly adds reagents instead after being opened, 5 at a time.
- Decimus_Shuttle_Magnus had invalid YML, https://github.com/ss14Starlight/space-station-14/pull/3896 tried to fix the mistake in
https://github.com/ss14Starlight/space-station-14/commit/4dfd68fcc72a78d36696b9adc7092e466521f213 and assumed it was a list. It's not, it's a tuple. The component data is now gone since it was not doing anything anyways and the disk has that component by default.

<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
On my computer (R9 9900X, 32 GB RAM) for reference: After:
<img width="321" height="33" alt="image"
src="https://github.com/user-attachments/assets/a0421c99-25af-47c1-8dde-32bee656e2b6" />

Before:
There's no test runner screenshot here, it just ran for 10+ minutes. Profile, though:
<img width="1840" height="390" alt="image"
src="https://github.com/user-attachments/assets/b12ce249-1f30-44a5-8ecb-f4fcc186d43f" />

<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.



End of original commit message

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).