### PR TITLE
the great eshotty fix

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -370,7 +370,7 @@
   - type: Clothing
     sprite: _FarHorizons/Objects/Weapons/Guns/Battery/plasma_shotgun.rsi
   - type: Gun
-    fireRate: 1 # bring back to 2 when bullet spread is a thing
+    fireRate: 2 
     spread: 10
     soundGunshot:
       path: /Audio/_Starlight/Weapons/Energy/laser_shotgun.ogg
@@ -390,7 +390,12 @@
       fireCost: 150 # ~ 8 shots 
       visualState: lethal
       magState: lethal
-      heldPrefix: lethal 
+      heldPrefix: lethal
+    - proto: BoltPlasmaSingle
+      fireCost: 200 # ~ 6 shots 
+      visualState: lethal
+      magState: lethal
+      heldPrefix: lethal
   - type: Item
     size: Large
     sprite: _FarHorizons/Objects/Weapons/Guns/Battery/plasma_shotgun_inhands_64x.rsi
@@ -431,7 +436,7 @@
   - type: Clothing
     sprite: _FarHorizons/Objects/Weapons/Guns/Battery/laser_shotgun.rsi
   - type: Gun
-    fireRate: 1 # bring back to 2 when bullet spread is a thing
+    fireRate: 2
     spread: 10
     soundGunshot:
       path: /Audio/_Starlight/Weapons/Energy/laser_shotgun.ogg
@@ -458,6 +463,17 @@
         - gamma
     - proto: RedLaserBeamSpread
       fireCost: 150 # ~ 16 shots 
+      visualState: lethal
+      magState: lethal
+      heldPrefix: lethal
+      conditions:
+      - !type:AlertLevelCondition
+        alertLevels:
+        - violet
+        - red
+        - gamma
+    - proto: RedLaserBeamSingle
+      fireCost: 300 # ~ 8 shots 
       visualState: lethal
       magState: lethal
       heldPrefix: lethal

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -66,45 +66,80 @@
 
 #region Plasma
 - type: entity
-  id: BoltPlasmaSpread
-  name: Split Plasma Bolt
-  parent: BasicHitscanNoBeam
+  id: BoltPlasma
+  name: Plasma Bolt
+  parent: BasicHitscan
+  categories: [ HideSpawnMenu ]
   components:
   - type: HitscanReflect
     reflectiveType: NonEnergy
   - type: HitscanBasicDamage
     damage:
       types:
-        Heat: 50 # Change to a lower number when support is added # About as strong as slugs (and weaker than current eshotty), does a bit more damage to account for lack of AP. Will likely be stronger in practice due to majority species having heat weakness + flat heat being -4 instead of -5 - assuming you point blank someone with it.
-        Structural: 90 # Change to a lower number when support is added
+        Heat: 20 # 100 total damage with 20 getting eaten by flats. 
+        Structural: 20 # 100 total
   - type: HitscanBasicRaycast
-    maxDistance: 4
     collisionMask: BulletImpassable
-  - type: HitscanBasicVisuals
-    muzzleFlash:
-      sprite: Objects/Weapons/Guns/Projectiles/projectiles_tg.rsi
-      state: heavylaser_flash
-    bullet:
-      sprite:
-        sprite: Objects/Weapons/Guns/Projectiles/projectiles_tg.rsi # Resprite for plasma-y sprites eventually.
-        state: heavylaser
-#  count: 8
-#  spread: 30 # Immense heat warps the barrel, not very accurate.
+
+
+
+- type: entity
+  id: BoltPlasmaSpread
+  name: Split Plasma Bolt
+  parent: BaseItem #i dont know why but it doesn't work if you parent off of anything else, tried figuring out what's in base item that makes it work and was unable to
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: HitscanBasicDamage # this doesn't actually do anything, it only exists to allow you to inspect the gun to see damage values
+    damage:
+      types:
+        Heat: 15 
+        Structural: 18
+  - type: ProjectileSpread
+    proto: BoltPlasma
+    count: 5
+    spread: 30
+
+- type: entity
+  id: BoltPlasmaSingle
+  name: Single Plasma Bolt
+  parent: BasicHitscan
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: HitscanReflect
+    reflectiveType: NonEnergy
+  - type: HitscanBasicDamage
+    damage:
+      types:
+        Heat: 45
+        Structural: 150
+  - type: HitscanBasicRaycast
+    collisionMask: BulletImpassable
 
 #region Lasers
 - type: entity
-  id: RedLaserBeamSpread
-  name:  Split Laser Beam
+  id: RedLaserBeamShotgun
+  name: Laser Beam Spead
   parent: BasicHitscan
+  categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage
     damage:
       types:
-        Heat: 30 # Buckshot is 70 for reference. Performs a bit worse against a blood-red compared to buckshot, which is fine given it goes through glass.
-  - type: HitscanBasicRaycast
-    maxDistance: 5 #simulates spread, buckshot barely hits past this distance
-#  count: 8
-#  spread: 30
+        Heat: 10 # 50 total, goes though windows and has spread
+
+- type: entity
+  id: RedLaserBeamSpread
+  name:  Split Laser Beam
+  parent: BaseItem #i dont know why but it doesn't work if you parent off of anything else, tried figuring out what's in base item that makes it work and was unable to
+  components:
+  - type: HitscanBasicDamage # this doesn't actually do anything, it only exists to allow you to inspect the gun to see damage values
+    damage:
+      types:
+        Heat: 10
+  - type: ProjectileSpread
+    proto: RedLaserBeamShotgun
+    count: 5
+    spread: 30
 
 - type: entity
   id: DestroyBeamDominator

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -87,6 +87,7 @@
   id: BoltPlasmaSpread
   name: Split Plasma Bolt
   parent: BaseItem #i dont know why but it doesn't work if you parent off of anything else, tried figuring out what's in base item that makes it work and was unable to
+  abstract: true
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage # this doesn't actually do anything, it only exists to allow you to inspect the gun to see damage values
@@ -131,6 +132,7 @@
   id: RedLaserBeamSpread
   name:  Split Laser Beam
   parent: BaseItem #i dont know why but it doesn't work if you parent off of anything else, tried figuring out what's in base item that makes it work and was unable to
+  abstract: true
   components:
   - type: HitscanBasicDamage # this doesn't actually do anything, it only exists to allow you to inspect the gun to see damage values
     damage:

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -77,7 +77,7 @@
     damage:
       types:
         Heat: 20 # 100 total damage with 20 getting eaten by flats. 
-        Structural: 20 # 100 total
+        Structural: 15 # 75 total
   - type: HitscanBasicRaycast
     collisionMask: BulletImpassable
 
@@ -94,7 +94,7 @@
     damage:
       types:
         Heat: 20
-        Structural: 20
+        Structural: 15
   - type: ProjectileSpread
     proto: BoltPlasma
     count: 5
@@ -112,14 +112,14 @@
     damage:
       types:
         Heat: 45
-        Structural: 150
+        Structural: 75
   - type: HitscanBasicRaycast
     collisionMask: BulletImpassable
 
 #region Lasers
 - type: entity
   id: RedLaserBeamShotgun
-  name: Laser Beam Spead
+  name: Laser Beam Spread
   parent: BasicHitscan
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -93,8 +93,8 @@
   - type: HitscanBasicDamage # this doesn't actually do anything, it only exists to allow you to inspect the gun to see damage values
     damage:
       types:
-        Heat: 15 
-        Structural: 18
+        Heat: 20
+        Structural: 20
   - type: ProjectileSpread
     proto: BoltPlasma
     count: 5


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
finally makes the energy shotguns actually work like shotguns

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
it makes something work as intented

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
files too big, sent at https://discordapp.com/channels/1407077238876147783/1407276847422509167/1541478584512806944


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: rain_enjoyer
- fix: Energy shotguns now actually have spread
- tweak: The warden's shotgun now has 2 lethal modes, a single slug or a spread
