### PR TITLE
Paddy equipment fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -385,10 +385,10 @@
   parent: MechPaddyBattery
   suffix: Battery, Air, Filled
   components:
-  - type: Mech
-#    startingEquipment:
-#      - WeaponMechCombatDisabler
-#      - WeaponMechCombatFlashbangLauncher
+    - type: Mech
+      startingEquipment:
+      - WeaponMechCombatTaser
+      - WeaponMechCombatFlashbangLauncher
 #      - MechEquipmentSecGrabber
 
 # Clarke


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
makes the filled Paddy prototype actually filled instead of empty. More specifically it now spawns with a flashbang launcher and a mounted taser, replacing the original Paddy disabler since we dont like em around these parts.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Currently Paddy spawns in armory without any mech equipment because the mounted equipment was just commented out in an attempt to make tests not fail a while ago.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="761" height="477" alt="image" src="https://github.com/user-attachments/assets/f192dd34-c958-4728-84c7-e1b5413da302" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Vonte
- add: Gave Paddy back their starting equipment, now with taser instead of disabler because they are yucky.