### PR TITLE
Fix Speedloader ammo counter bugs

### DIFF
--- a/Content.IntegrationTests/Tests/_FarHorizons/Weapons/RevolverTests.cs
+++ b/Content.IntegrationTests/Tests/_FarHorizons/Weapons/RevolverTests.cs
@@ -1,0 +1,57 @@
+using Content.Client.Weapons.Ranged.Components;
+using Content.IntegrationTests.Tests.Helpers;
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Shared.Weapons.Ranged.Components;
+using ClientGunSystem = Content.Client.Weapons.Ranged.Systems.GunSystem;
+using Robust.Client.UserInterface;
+
+namespace Content.IntegrationTests.Tests._FarHorizons.Weapons;
+
+public sealed class RevolverTests : InteractionTest
+{
+    [Test]
+    public async Task SpeedloaderReloadRaisesClientAmmoCounterUpdate()
+    {
+        var revolver = await Spawn("WeaponRevolverInspector");
+        var speedloader = await Spawn("SpeedLoaderMagnumSP");
+        var serverRevolver = ToServer(revolver);
+        var clientRevolver = ToClient(revolver);
+        var revolverComp = SEntMan.GetComponent<RevolverAmmoProviderComponent>(serverRevolver);
+        var listener = CEntMan.System<AmmoCounterEventListenerSystem>();
+
+        await Server.WaitPost(() => SGun.EmptyRevolver((serverRevolver, revolverComp)));
+        await RunTicks(5);
+
+        await Client.WaitPost(() =>
+        {
+            var clientRevolverComp = CEntMan.GetComponent<RevolverAmmoProviderComponent>(clientRevolver);
+            Assert.That(clientRevolverComp.AmmoSlots, Is.All.Null);
+            Assert.That(clientRevolverComp.Chambers, Is.All.Null);
+            CEntMan.AddComponent<TestListenerComponent>(clientRevolver);
+            CEntMan.GetComponent<AmmoCounterComponent>(clientRevolver).Control = new Control();
+        });
+        await Client.WaitPost(() => listener.Clear(clientRevolver));
+
+        await Server.WaitPost(() =>
+        {
+            Assert.That(SGun.TryRevolverInsert(
+                (serverRevolver, revolverComp),
+                ToServer(speedloader),
+                null), Is.True);
+        });
+        await RunTicks(5);
+
+        await Client.WaitPost(() =>
+        {
+            var clientRevolverComp = CEntMan.GetComponent<RevolverAmmoProviderComponent>(clientRevolver);
+            Assert.That(clientRevolverComp.AmmoSlots, Has.Some.Not.Null);
+            Assert.That(clientRevolverComp.Chambers, Is.All.True,
+                "Speedloader-loaded cartridges should be shown as unfired.");
+        });
+
+        Assert.That(listener.Count(clientRevolver), Is.EqualTo(1),
+            "Replicated speedloader ammunition should raise UpdateAmmoCounterEvent on the client.");
+    }
+}
+
+public sealed class AmmoCounterEventListenerSystem : TestListenerSystem<ClientGunSystem.UpdateAmmoCounterEvent>;

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
@@ -77,6 +77,11 @@ public partial class SharedGunSystem
         if (args.Current is not RevolverAmmoProviderComponentState state)
             return;
 
+        // Far-Horizons start
+        var ammoChanged = false;
+        var oldChambers = ent.Comp.Chambers;
+        // Far-Horizons end
+
         var oldIndex = ent.Comp.CurrentIndex;
         ent.Comp.CurrentIndex = state.CurrentIndex;
         ent.Comp.Chambers = new bool?[state.Chambers.Length];
@@ -84,12 +89,19 @@ public partial class SharedGunSystem
         // Need to copy across the state rather than the ref.
         for (var i = 0; i < ent.Comp.AmmoSlots.Count; i++)
         {
-            ent.Comp.AmmoSlots[i] = EnsureEntity<RevolverAmmoProviderComponent>(state.AmmoSlots[i], ent);
+            // Far-Horizons edit: check if ammo has changed
+            var newAmmo = EnsureEntity<RevolverAmmoProviderComponent>(state.AmmoSlots[i], ent);
+            if (ent.Comp.AmmoSlots[i] != newAmmo || oldChambers[i] != state.Chambers[i])
+                ammoChanged = true;
+            ent.Comp.AmmoSlots[i] = newAmmo;
+            // End Far-Horizons edit
+
+            //ent.Comp.AmmoSlots[i] = EnsureEntity<RevolverAmmoProviderComponent>(state.AmmoSlots[i], ent); // FH edit - avoid double EnsureEntity call
             ent.Comp.Chambers[i] = state.Chambers[i];
         }
 
         // Handle spins
-        if (oldIndex != state.CurrentIndex)
+        if (oldIndex != state.CurrentIndex || ammoChanged) // Far-Horizons edit: add ammoChanged
         {
             UpdateAmmoCount(ent, prediction: false);
         }
@@ -152,7 +164,7 @@ public partial class SharedGunSystem
 
                 ent.Comp.AmmoSlots[index] = ammoEnt.Value;
                 Containers.Insert(ammoEnt.Value, ent.Comp.AmmoContainer);
-                SetChamber(ent, insertEnt, index);
+                SetChamber(ent, ammoEnt.Value, index); // FH edit: Don't insert the speedloader into the chamber, just the ammo
 
                 if (ev.Ammo.Count == 0)
                     break;


### PR DESCRIPTION
## Short description
One issue was that OnRevolverHandleState is the only part of the code that seems to update the ammo counter on the client for revolvers, and it only does so when the index of the revolver changes. This change makes the ammo counter update when the ammo changes as well, even if the index stays the same.

The other issue is that the upstream code was inserting the speedloader into each chamber tracker, rather than the ammo, so all of the chambers would show as fired if you used a speedloader.

## Why we need to add this
This improves readability of weapon state.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/98472dd6-95e4-420a-995b-6019c7052b3a


## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**

:cl: Penguinwizzard
- fix: Using a speedloader now updates your revolver's ammunition display, and displays the fired state of cartridges properly.
