### PR TITLE
Make muzzle flash effects emit light instead of the gun

### DIFF
--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
@@ -535,6 +535,8 @@ public sealed partial class GunSystem : SharedGunSystem
         var ent = Spawn(message.Prototype, coordinates);
         TransformSystem.SetWorldRotationNoLerp(ent, message.Angle);
 
+        gunUid = ent; // Far Horizons: Light from flash, not gun
+
         if (tracked != null)
         {
             var track = EnsureComp<TrackUserComponent>(ent);

--- a/Content.IntegrationTests/Tests/_FarHorizons/Weapons/MuzzleFlashTests.cs
+++ b/Content.IntegrationTests/Tests/_FarHorizons/Weapons/MuzzleFlashTests.cs
@@ -1,0 +1,38 @@
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Shared.Light;
+using Content.Shared.Light.Components;
+using Content.Shared.Weapons.Ranged.Events;
+using Robust.Client.GameObjects;
+using Robust.Shared.Maths;
+
+namespace Content.IntegrationTests.Tests._FarHorizons.Weapons;
+
+public sealed class MuzzleFlashTests : InteractionTest
+{
+    protected override string PlayerPrototype => "MobHuman";
+
+    [Test]
+    public async Task MuzzleFlashDoesNotDrainMk78Flashlight()
+    {
+        var mk78 = await PlaceInHands("WeaponPistolMk78");
+        var handheldLight = SEntMan.System<SharedHandheldLightSystem>();
+
+        await Server.WaitPost(() =>
+            handheldLight.SetActivated(ToServer(mk78), true, SEntMan.GetComponent<HandheldLightComponent>(ToServer(mk78))));
+        await RunTicks(5);
+
+        await Client.WaitPost(() =>
+            Assert.That(CEntMan.GetComponent<PointLightComponent>(CEntMan.GetEntity(mk78)).Energy, Is.GreaterThan(0f)));
+
+        await Client.WaitPost(() =>
+            CEntMan.EventBus.RaiseLocalEvent(
+                CEntMan.GetEntity(mk78),
+                new MuzzleFlashEvent(mk78, "MuzzleFlashEffect", Angle.Zero),
+                broadcast: true));
+        await Pair.RunSeconds(1f);
+
+        await Client.WaitPost(() =>
+            Assert.That(CEntMan.GetComponent<PointLightComponent>(CEntMan.GetEntity(mk78)).Energy, Is.GreaterThan(0f),
+                "The MK 78 flashlight should retain its energy after the muzzle flash animation ends."));
+    }
+}


### PR DESCRIPTION
## Short description
The light of muzzle flashes prior to this change comes from the gun, rather than the muzzle flash effect, which is inaccurate and results in adverse conflicts if we _do_ want the gun emitting light.

## Why we need to add this
This resolves the collision between the PointLightComponent for a gun's light and the light of a muzzle flash, so shooting a gun with a flashlight on it no longer breaks the flashlight.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/b90c7cec-b7e7-42c9-a9f9-37d3ac748bc4

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**

:cl: Penguinwizzard
- fix: Shooting a gun with a flashlight on it no longer breaks the flashlight.
