### PR TITLE
Abductor shuttle fixes

### DIFF
--- a/Resources/Maps/_FarHorizons/Shuttles/ShuttleEvent/FHAbductorShuttle.yml
+++ b/Resources/Maps/_FarHorizons/Shuttles/ShuttleEvent/FHAbductorShuttle.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 272.0.0
+  engineVersion: 288.1.0
   forkId: ""
   forkVersion: ""
-  time: 04/16/2026 08:39:29
-  entityCount: 840
+  time: 08/29/2026 17:06:36
+  entityCount: 837
 maps: []
 grids:
 - 1
@@ -25,8 +25,8 @@ entities:
     - type: MetaData
       name: grid
     - type: Transform
-      pos: -0.47916666,-0.47394118
       parent: invalid
+      pos: -0.47916666,-0.47394118
     - type: MapGrid
       chunks:
         0,0:
@@ -47,9 +47,9 @@ entities:
           version: 7
     - type: Broadphase
     - type: Physics
-      bodyStatus: InAir
       fixedRotation: False
       bodyType: Dynamic
+      bodyStatus: InAir
     - type: Fixtures
       fixtures: {}
     - type: OccluderTree
@@ -71,139 +71,141 @@ entities:
     - type: GridAtmosphere
       version: 2
       data:
+        uniqueMixes:
+        - temperature: 293.15
+          volume: 2500
+          moles:
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
+        - temperature: 293.15
+          volume: 2500
+          moles: {}
+        - volume: 2500
+          moles: {}
+          immutable: True
+        - temperature: 293.15
+          volume: 2500
+          moles:
+            Nitrogen: 6666.982
+        - temperature: 293.15
+          volume: 2500
+          moles:
+            Oxygen: 6666.982
         tiles:
           0,0:
             0: 53239
           0,-1:
             0: 30465
-            1: 4
+            2: 4
           -1,0:
-            0: 2252
+            0: 10444
           0,1:
             0: 32463
           -1,1:
             0: 15
-            2: 256
-            3: 1024
+            3: 256
+            4: 1024
           0,2:
             0: 51
-            4: 128
+            1: 128
           -1,2:
             0: 136
-            4: 33
-            1: 4112
+            1: 33
+            2: 4112
           1,0:
             0: 4415
           1,1:
             0: 17
-            4: 18432
+            1: 16384
           1,2:
-            4: 3
-            1: 4756
+            1: 3
+            2: 4756
           1,-1:
             0: 60928
           2,1:
-            4: 17
-            1: 8522
-          2,2:
             1: 1
+            2: 8522
+          2,2:
+            2: 1
           2,0:
-            4: 24640
-            1: 1024
+            1: 24640
+            2: 1024
           2,-1:
-            4: 16481
-            1: 1034
+            1: 16481
+            2: 1034
           0,-3:
-            4: 35328
-            1: 1024
+            1: 35328
+            2: 1024
           -1,-3:
-            4: 10752
-            1: 5136
+            1: 10752
+            2: 5136
           0,-2:
             0: 28672
           -1,-2:
             0: 32768
-            4: 1
+            1: 1
           -1,-1:
             0: 51404
           1,-3:
-            1: 37392
+            2: 37392
           1,-2:
-            4: 2115
-            1: 4
+            1: 3
+            2: 4
           2,-2:
-            1: 16673
-            4: 4096
+            2: 16673
+            1: 4096
           -3,0:
-            4: 49216
-            1: 1024
+            1: 49216
+            2: 1024
           -3,1:
-            1: 32842
+            2: 32842
           -3,-1:
-            4: 16576
-            1: 1034
+            1: 16576
+            2: 1034
           -2,1:
-            4: 16913
-            1: 264
+            1: 16385
+            2: 264
           -2,0:
-            4: 1194
+            1: 1194
           -2,2:
-            1: 2085
-            4: 8
+            2: 2085
+            1: 8
           -2,-1:
-            4: 41985
+            1: 41985
           -3,-2:
-            1: 16512
+            2: 16512
           -2,-2:
-            1: 261
-            4: 4680
+            2: 261
+            1: 4104
           -2,-3:
-            1: 10240
-        uniqueMixes:
-        - volume: 2500
-          temperature: 293.15
-          moles:
-            Oxygen: 21.824879
-            Nitrogen: 82.10312
-        - volume: 2500
-          immutable: True
-          moles: {}
-        - volume: 2500
-          temperature: 293.15
-          moles:
-            Nitrogen: 6666.982
-        - volume: 2500
-          temperature: 293.15
-          moles:
-            Oxygen: 6666.982
-        - volume: 2500
-          temperature: 293.15
-          moles: {}
+            2: 10240
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: ExplosionAirtightGrid
+    - type: ChunkContainer
+      chunkEntities: []
 - proto: AbductorAlienPad
   entities:
   - uid: 2
     components:
     - type: Transform
-      pos: 0.5,-3.5
       parent: 1
+      pos: 0.5,-3.5
 - proto: AbductorComputerShuttle
   entities:
   - uid: 309
     components:
     - type: Transform
-      pos: 0.5,9.5
       parent: 1
+      pos: 0.5,9.5
 - proto: AbductorConsole
   entities:
   - uid: 3
     components:
     - type: Transform
-      pos: -0.5,2.5
       parent: 1
+      pos: -0.5,2.5
     - type: DeviceLinkSource
       linkedPorts:
         4:
@@ -220,59 +222,59 @@ entities:
   - uid: 4
     components:
     - type: Transform
-      pos: 0.5,2.5
       parent: 1
+      pos: 0.5,2.5
 - proto: AbductorHandcuffs
   entities:
   - uid: 5
     components:
     - type: Transform
-      pos: 4.50539,3.5165226
       parent: 1
+      pos: 4.50539,3.5165226
   - uid: 6
     components:
     - type: Transform
-      pos: 4.4637237,3.818816
       parent: 1
+      pos: 4.4637237,3.818816
   - uid: 7
     components:
     - type: Transform
-      pos: 4.4533067,4.1211095
       parent: 1
+      pos: 4.4533067,4.1211095
   - uid: 8
     components:
     - type: Transform
-      pos: 4.4324737,4.4546742
       parent: 1
+      pos: 4.4324737,4.4546742
   - uid: 9
     components:
     - type: Transform
-      pos: 4.44289,4.819511
       parent: 1
+      pos: 4.44289,4.819511
   - uid: 10
     components:
     - type: Transform
-      pos: 4.4637237,5.173924
       parent: 1
+      pos: 4.4637237,5.173924
   - uid: 11
     components:
     - type: Transform
-      pos: 4.4533067,5.517913
       parent: 1
+      pos: 4.4533067,5.517913
 - proto: AbductorHumanObservationConsole
   entities:
   - uid: 12
     components:
     - type: Transform
-      pos: -1.5,-3.5
       parent: 1
+      pos: -1.5,-3.5
 - proto: AbductorOperatingTable
   entities:
   - uid: 13
     components:
     - type: Transform
-      pos: 0.5,0.5
       parent: 1
+      pos: 0.5,0.5
 - proto: AbductorPlushie
   entities:
   - uid: 14
@@ -280,15 +282,23 @@ entities:
     - type: MetaData
       desc: the plushie seems to have been strangled over many restless cycles
     - type: Transform
-      pos: 7.5598154,0.39310527
       parent: 1
+      pos: 7.5598154,0.39310527
 - proto: AirAlarmXeno
   entities:
   - uid: 736
     components:
     - type: Transform
-      pos: 0.5,5.5
       parent: 1
+      pos: 0.5,5.5
+    - type: DeviceList
+      devices:
+      - 379
+      - 376
+      - 377
+      - 375
+      - 378
+      - 374
     - type: AccessReader
       accessListsOriginal:
       - - Atmospherics
@@ -299,33 +309,33 @@ entities:
   - uid: 15
     components:
     - type: Transform
-      pos: 2.6553364,-0.4980872
       parent: 1
+      pos: 2.6553364,-0.4980872
   - uid: 16
     components:
     - type: Transform
-      pos: 2.3428364,-0.48766354
       parent: 1
+      pos: 2.3428364,-0.48766354
 - proto: AirSensor
   entities:
   - uid: 470
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -0.5,0.5
-      parent: 1
 - proto: AntiPoisonMedipen
   entities:
   - uid: 17
     components:
     - type: Transform
-      pos: 2.6449196,-0.6544459
       parent: 1
+      pos: 2.6449196,-0.6544459
   - uid: 18
     components:
     - type: Transform
-      pos: 2.3324196,-0.6440222
       parent: 1
+      pos: 2.3324196,-0.6440222
 - proto: APCBasic
   entities:
   - uid: 19
@@ -333,8 +343,8 @@ entities:
     - type: MetaData
       name: Inlaid APC (Thruster SW)
     - type: Transform
-      pos: -5.5,-5.5
       parent: 1
+      pos: -5.5,-6.5
     - type: AccessReader
       accessListsOriginal:
       - - Engineering
@@ -349,8 +359,8 @@ entities:
     - type: MetaData
       name: Inlaid APC (Thruster SE)
     - type: Transform
-      pos: 6.5,-5.5
       parent: 1
+      pos: 6.5,-6.5
     - type: AccessReader
       accessListsOriginal:
       - - Engineering
@@ -365,9 +375,9 @@ entities:
     - type: MetaData
       name: Inlaid APC (Thruster NW)
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -5.5,6.5
-      parent: 1
     - type: Fixtures
       fixtures: {}
     - type: Label
@@ -379,9 +389,9 @@ entities:
     - type: MetaData
       name: Inlaid APC (Thruster NE)
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 6.5,6.5
-      parent: 1
     - type: Fixtures
       fixtures: {}
     - type: Label
@@ -390,12 +400,9 @@ entities:
       baseName: Inlaid APC
   - uid: 23
     components:
-    - type: MetaData
-      name: Inlaid APC
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,5.5
       parent: 1
+      pos: -0.5,5.5
     - type: Fixtures
       fixtures: {}
   - uid: 24
@@ -403,9 +410,9 @@ entities:
     - type: MetaData
       name: Inlaid APC
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-1.5
       parent: 1
+      rot: 4.71238898038469 rad
+      pos: 3.5,-1.5
     - type: AccessReader
       accessListsOriginal:
       - - Engineering
@@ -416,9 +423,9 @@ entities:
     - type: MetaData
       name: APC (Engineering)
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -3.5,0.5
-      parent: 1
     - type: Fixtures
       fixtures: {}
     - type: Label
@@ -430,414 +437,414 @@ entities:
   - uid: 26
     components:
     - type: Transform
-      pos: -5.5,2.5
       parent: 1
+      pos: -5.5,2.5
   - uid: 27
     components:
     - type: Transform
-      pos: -4.5,0.5
       parent: 1
+      pos: -4.5,0.5
   - uid: 28
     components:
     - type: Transform
-      pos: -4.5,-0.5
       parent: 1
+      pos: -4.5,-0.5
   - uid: 29
     components:
     - type: Transform
-      pos: -6.5,-0.5
       parent: 1
+      pos: -6.5,-0.5
   - uid: 30
     components:
     - type: Transform
-      pos: -6.5,0.5
       parent: 1
+      pos: -6.5,0.5
   - uid: 31
     components:
     - type: Transform
-      pos: -6.5,1.5
       parent: 1
+      pos: -6.5,1.5
   - uid: 32
     components:
     - type: Transform
-      pos: -5.5,-1.5
       parent: 1
+      pos: -5.5,-1.5
   - uid: 33
     components:
     - type: Transform
-      pos: -4.5,1.5
       parent: 1
+      pos: -4.5,1.5
   - uid: 34
     components:
     - type: Transform
-      pos: -9.5,-0.5
       parent: 1
+      pos: -9.5,-0.5
   - uid: 35
     components:
     - type: Transform
-      pos: -9.5,-1.5
       parent: 1
+      pos: -9.5,-1.5
   - uid: 36
     components:
     - type: Transform
-      pos: -9.5,-2.5
       parent: 1
+      pos: -9.5,-2.5
   - uid: 37
     components:
     - type: Transform
-      pos: -8.5,-2.5
       parent: 1
+      pos: -8.5,-2.5
   - uid: 38
     components:
     - type: Transform
-      pos: -8.5,-3.5
       parent: 1
+      pos: -8.5,-3.5
   - uid: 39
     components:
     - type: Transform
-      pos: -7.5,-3.5
       parent: 1
+      pos: -7.5,-3.5
   - uid: 40
     components:
     - type: Transform
-      pos: -7.5,-4.5
       parent: 1
+      pos: -7.5,-4.5
   - uid: 41
     components:
     - type: Transform
-      pos: -7.5,-5.5
       parent: 1
+      pos: -7.5,-5.5
   - uid: 42
     components:
     - type: Transform
-      pos: -6.5,-5.5
       parent: 1
+      pos: -6.5,-5.5
   - uid: 43
     components:
     - type: Transform
-      pos: -5.5,-6.5
       parent: 1
+      pos: -5.5,-6.5
   - uid: 44
     components:
     - type: Transform
-      pos: -5.5,-7.5
       parent: 1
+      pos: -5.5,-7.5
   - uid: 45
     components:
     - type: Transform
-      pos: -4.5,-7.5
       parent: 1
+      pos: -4.5,-7.5
   - uid: 46
     components:
     - type: Transform
-      pos: -3.5,-7.5
       parent: 1
+      pos: -3.5,-7.5
   - uid: 47
     components:
     - type: Transform
-      pos: -3.5,-8.5
       parent: 1
+      pos: -3.5,-8.5
   - uid: 48
     components:
     - type: Transform
-      pos: -2.5,-8.5
       parent: 1
+      pos: -2.5,-8.5
   - uid: 49
     components:
     - type: Transform
-      pos: -2.5,-9.5
       parent: 1
+      pos: -2.5,-9.5
   - uid: 50
     components:
     - type: Transform
-      pos: -1.5,-9.5
       parent: 1
+      pos: -1.5,-9.5
   - uid: 51
     components:
     - type: Transform
-      pos: -0.5,-9.5
       parent: 1
+      pos: -0.5,-9.5
   - uid: 52
     components:
     - type: Transform
-      pos: 1.5,-9.5
       parent: 1
+      pos: 1.5,-9.5
   - uid: 53
     components:
     - type: Transform
-      pos: 2.5,-9.5
       parent: 1
+      pos: 2.5,-9.5
   - uid: 54
     components:
     - type: Transform
-      pos: 3.5,-9.5
       parent: 1
+      pos: 3.5,-9.5
   - uid: 55
     components:
     - type: Transform
-      pos: 3.5,-8.5
       parent: 1
+      pos: 3.5,-8.5
   - uid: 56
     components:
     - type: Transform
-      pos: 4.5,-8.5
       parent: 1
+      pos: 4.5,-8.5
   - uid: 57
     components:
     - type: Transform
-      pos: 4.5,-7.5
       parent: 1
+      pos: 4.5,-7.5
   - uid: 58
     components:
     - type: Transform
-      pos: 5.5,-7.5
       parent: 1
+      pos: 5.5,-7.5
   - uid: 59
     components:
     - type: Transform
-      pos: 6.5,-7.5
       parent: 1
+      pos: 6.5,-7.5
   - uid: 60
     components:
     - type: Transform
-      pos: 6.5,-6.5
       parent: 1
+      pos: 6.5,-6.5
   - uid: 61
     components:
     - type: Transform
-      pos: 8.5,-5.5
       parent: 1
+      pos: 8.5,-5.5
   - uid: 62
     components:
     - type: Transform
-      pos: 7.5,-5.5
       parent: 1
+      pos: 7.5,-5.5
   - uid: 63
     components:
     - type: Transform
-      pos: 8.5,-4.5
       parent: 1
+      pos: 8.5,-4.5
   - uid: 64
     components:
     - type: Transform
-      pos: 8.5,-3.5
       parent: 1
+      pos: 8.5,-3.5
   - uid: 65
     components:
     - type: Transform
-      pos: 9.5,-3.5
       parent: 1
+      pos: 9.5,-3.5
   - uid: 66
     components:
     - type: Transform
-      pos: 9.5,-2.5
       parent: 1
+      pos: 9.5,-2.5
   - uid: 67
     components:
     - type: Transform
-      pos: 10.5,-2.5
       parent: 1
+      pos: 10.5,-2.5
   - uid: 68
     components:
     - type: Transform
-      pos: 10.5,-1.5
       parent: 1
+      pos: 10.5,-1.5
   - uid: 69
     components:
     - type: Transform
-      pos: 10.5,-0.5
       parent: 1
+      pos: 10.5,-0.5
   - uid: 70
     components:
     - type: Transform
-      pos: 10.5,1.5
       parent: 1
+      pos: 10.5,1.5
   - uid: 71
     components:
     - type: Transform
-      pos: 10.5,2.5
       parent: 1
+      pos: 10.5,2.5
   - uid: 72
     components:
     - type: Transform
-      pos: 10.5,3.5
       parent: 1
+      pos: 10.5,3.5
   - uid: 73
     components:
     - type: Transform
-      pos: 9.5,3.5
       parent: 1
+      pos: 9.5,3.5
   - uid: 74
     components:
     - type: Transform
-      pos: 9.5,4.5
       parent: 1
+      pos: 9.5,4.5
   - uid: 75
     components:
     - type: Transform
-      pos: 8.5,4.5
       parent: 1
+      pos: 8.5,4.5
   - uid: 76
     components:
     - type: Transform
-      pos: 8.5,5.5
       parent: 1
+      pos: 8.5,5.5
   - uid: 77
     components:
     - type: Transform
-      pos: 8.5,6.5
       parent: 1
+      pos: 8.5,6.5
   - uid: 78
     components:
     - type: Transform
-      pos: 7.5,6.5
       parent: 1
+      pos: 7.5,6.5
   - uid: 79
     components:
     - type: Transform
-      pos: 6.5,7.5
       parent: 1
+      pos: 6.5,7.5
   - uid: 80
     components:
     - type: Transform
-      pos: 6.5,8.5
       parent: 1
+      pos: 6.5,8.5
   - uid: 81
     components:
     - type: Transform
-      pos: 5.5,8.5
       parent: 1
+      pos: 5.5,8.5
   - uid: 82
     components:
     - type: Transform
-      pos: 4.5,8.5
       parent: 1
+      pos: 4.5,8.5
   - uid: 83
     components:
     - type: Transform
-      pos: 4.5,9.5
       parent: 1
+      pos: 4.5,9.5
   - uid: 84
     components:
     - type: Transform
-      pos: 3.5,9.5
       parent: 1
+      pos: 3.5,9.5
   - uid: 85
     components:
     - type: Transform
-      pos: -2.5,9.5
       parent: 1
+      pos: -2.5,9.5
   - uid: 86
     components:
     - type: Transform
-      pos: -3.5,9.5
       parent: 1
+      pos: -3.5,9.5
   - uid: 87
     components:
     - type: Transform
-      pos: -3.5,8.5
       parent: 1
+      pos: -3.5,8.5
   - uid: 88
     components:
     - type: Transform
-      pos: -5.5,8.5
       parent: 1
+      pos: -5.5,8.5
   - uid: 89
     components:
     - type: Transform
-      pos: -4.5,8.5
       parent: 1
+      pos: -4.5,8.5
   - uid: 90
     components:
     - type: Transform
-      pos: -5.5,7.5
       parent: 1
+      pos: -5.5,7.5
   - uid: 91
     components:
     - type: Transform
-      pos: -6.5,6.5
       parent: 1
+      pos: -6.5,6.5
   - uid: 92
     components:
     - type: Transform
-      pos: -7.5,6.5
       parent: 1
+      pos: -7.5,6.5
   - uid: 93
     components:
     - type: Transform
-      pos: -7.5,5.5
       parent: 1
+      pos: -7.5,5.5
   - uid: 94
     components:
     - type: Transform
-      pos: -7.5,4.5
       parent: 1
+      pos: -7.5,4.5
   - uid: 95
     components:
     - type: Transform
-      pos: -8.5,4.5
       parent: 1
+      pos: -8.5,4.5
   - uid: 96
     components:
     - type: Transform
-      pos: -9.5,3.5
       parent: 1
+      pos: -9.5,3.5
   - uid: 97
     components:
     - type: Transform
-      pos: -9.5,2.5
       parent: 1
+      pos: -9.5,2.5
   - uid: 98
     components:
     - type: Transform
-      pos: -9.5,1.5
       parent: 1
+      pos: -9.5,1.5
   - uid: 99
     components:
     - type: Transform
-      pos: -8.5,3.5
       parent: 1
+      pos: -8.5,3.5
 - proto: AtmosFixNitrogenMarker
   entities:
   - uid: 100
     components:
     - type: Transform
-      pos: -3.5,6.5
       parent: 1
+      pos: -3.5,6.5
 - proto: AtmosFixOxygenMarker
   entities:
   - uid: 101
     components:
     - type: Transform
-      pos: -1.5,6.5
       parent: 1
+      pos: -1.5,6.5
 - proto: BedsheetPurple
   entities:
   - uid: 102
     components:
     - type: Transform
-      pos: 7.5,-1.5
       parent: 1
+      pos: 7.5,-1.5
   - uid: 103
     components:
     - type: Transform
-      pos: 7.5,0.5
       parent: 1
+      pos: 7.5,0.5
 - proto: BlastDoorXeno
   entities:
   - uid: 104
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 2.5,-3.5
-      parent: 1
     - type: AccessReader
       accessListsOriginal: []
   - uid: 105
     components:
     - type: Transform
-      pos: -4.5,4.5
       parent: 1
+      pos: -4.5,4.5
     - type: DeviceLinkSink
       invokeCounter: 1
 - proto: BlastDoorXenoOpen
@@ -845,1151 +852,1156 @@ entities:
   - uid: 106
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 0.5,10.5
-      parent: 1
   - uid: 107
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -0.5,10.5
-      parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 108
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 1.5,10.5
-      parent: 1
 - proto: Bloodpack
   entities:
   - uid: 109
     components:
     - type: Transform
-      pos: 2.0101137,-1.5958606
       parent: 1
+      pos: 2.0101137,-1.5958606
   - uid: 110
     components:
     - type: Transform
-      pos: 2.0101137,-1.3561107
       parent: 1
+      pos: 2.0101137,-1.3561107
 - proto: BloodpackAmmonia
   entities:
   - uid: 111
     components:
     - type: Transform
-      pos: 2.780947,-1.5854362
       parent: 1
+      pos: 2.780947,-1.5854362
   - uid: 112
     components:
     - type: Transform
-      pos: 2.7913637,-1.3144149
       parent: 1
+      pos: 2.7913637,-1.3144149
 - proto: BloodpackOil
   entities:
   - uid: 113
     components:
     - type: Transform
-      pos: 2.3955302,-1.5854362
       parent: 1
+      pos: 2.3955302,-1.5854362
   - uid: 114
     components:
     - type: Transform
-      pos: 2.405947,-1.324839
       parent: 1
+      pos: 2.405947,-1.324839
 - proto: ButtonFrameCaution
   entities:
   - uid: 115
     components:
     - type: Transform
-      pos: 0.5,9.5
       parent: 1
+      pos: 0.5,9.5
   - uid: 839
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -2.5,3.5
-      parent: 1
 - proto: ButtonFrameCautionSecurity
   entities:
   - uid: 116
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 2.5,8.5
-      parent: 1
   - uid: 117
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,3.5
-      parent: 1
   - uid: 118
     components:
     - type: Transform
-      pos: 6.5,1.5
       parent: 1
+      pos: 6.5,1.5
   - uid: 119
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -1.5,-1.5
-      parent: 1
 - proto: ButtonFrameJanitor
   entities:
   - uid: 120
     components:
     - type: Transform
-      pos: 1.5,9.5
       parent: 1
+      pos: 1.5,9.5
 - proto: CableApcExtension
   entities:
   - uid: 121
     components:
     - type: Transform
-      pos: -9.5,-0.5
       parent: 1
+      pos: -9.5,-0.5
   - uid: 122
     components:
     - type: Transform
-      pos: -9.5,-1.5
       parent: 1
+      pos: -9.5,-1.5
   - uid: 123
     components:
     - type: Transform
-      pos: -9.5,-2.5
       parent: 1
+      pos: -9.5,-2.5
   - uid: 124
     components:
     - type: Transform
-      pos: -8.5,-2.5
       parent: 1
+      pos: -8.5,-2.5
   - uid: 125
     components:
     - type: Transform
-      pos: -8.5,-3.5
       parent: 1
+      pos: -8.5,-3.5
   - uid: 126
     components:
     - type: Transform
-      pos: -7.5,-3.5
       parent: 1
+      pos: -7.5,-3.5
   - uid: 127
     components:
     - type: Transform
-      pos: -7.5,-4.5
       parent: 1
+      pos: -7.5,-4.5
   - uid: 128
     components:
     - type: Transform
-      pos: -7.5,-5.5
       parent: 1
+      pos: -7.5,-5.5
   - uid: 129
     components:
     - type: Transform
-      pos: -6.5,-5.5
       parent: 1
+      pos: -6.5,-5.5
   - uid: 130
     components:
     - type: Transform
-      pos: -5.5,-5.5
       parent: 1
+      pos: -5.5,-5.5
   - uid: 131
     components:
     - type: Transform
-      pos: -5.5,-6.5
       parent: 1
+      pos: -5.5,-6.5
   - uid: 132
     components:
     - type: Transform
-      pos: -5.5,-7.5
       parent: 1
+      pos: -5.5,-7.5
   - uid: 133
     components:
     - type: Transform
-      pos: -4.5,-7.5
       parent: 1
+      pos: -4.5,-7.5
   - uid: 134
     components:
     - type: Transform
-      pos: -3.5,-7.5
       parent: 1
+      pos: -3.5,-7.5
   - uid: 135
     components:
     - type: Transform
-      pos: -3.5,-8.5
       parent: 1
+      pos: -3.5,-8.5
   - uid: 136
     components:
     - type: Transform
-      pos: -2.5,-8.5
       parent: 1
+      pos: -2.5,-8.5
   - uid: 137
     components:
     - type: Transform
-      pos: -2.5,-9.5
       parent: 1
+      pos: -2.5,-9.5
   - uid: 138
     components:
     - type: Transform
-      pos: -1.5,-9.5
       parent: 1
+      pos: -1.5,-9.5
   - uid: 139
     components:
     - type: Transform
-      pos: -0.5,-9.5
       parent: 1
+      pos: -0.5,-9.5
   - uid: 140
     components:
     - type: Transform
-      pos: 1.5,-9.5
       parent: 1
+      pos: 1.5,-9.5
   - uid: 141
     components:
     - type: Transform
-      pos: 2.5,-9.5
       parent: 1
+      pos: 2.5,-9.5
   - uid: 142
     components:
     - type: Transform
-      pos: 3.5,-9.5
       parent: 1
+      pos: 3.5,-9.5
   - uid: 143
     components:
     - type: Transform
-      pos: 3.5,-8.5
       parent: 1
+      pos: 3.5,-8.5
   - uid: 144
     components:
     - type: Transform
-      pos: 4.5,-8.5
       parent: 1
+      pos: 4.5,-8.5
   - uid: 145
     components:
     - type: Transform
-      pos: 4.5,-7.5
       parent: 1
+      pos: 4.5,-7.5
   - uid: 146
     components:
     - type: Transform
-      pos: 5.5,-7.5
       parent: 1
+      pos: 5.5,-7.5
   - uid: 147
     components:
     - type: Transform
-      pos: 6.5,-7.5
       parent: 1
+      pos: 6.5,-7.5
   - uid: 148
     components:
     - type: Transform
-      pos: 6.5,-6.5
       parent: 1
+      pos: 6.5,-6.5
   - uid: 149
     components:
     - type: Transform
-      pos: 6.5,-5.5
       parent: 1
+      pos: 6.5,-5.5
   - uid: 150
     components:
     - type: Transform
-      pos: 7.5,-5.5
       parent: 1
+      pos: 7.5,-5.5
   - uid: 151
     components:
     - type: Transform
-      pos: 8.5,-5.5
       parent: 1
+      pos: 8.5,-5.5
   - uid: 152
     components:
     - type: Transform
-      pos: 8.5,-4.5
       parent: 1
+      pos: 8.5,-4.5
   - uid: 153
     components:
     - type: Transform
-      pos: 8.5,-3.5
       parent: 1
+      pos: 8.5,-3.5
   - uid: 154
     components:
     - type: Transform
-      pos: 9.5,-3.5
       parent: 1
+      pos: 9.5,-3.5
   - uid: 155
     components:
     - type: Transform
-      pos: 9.5,-2.5
       parent: 1
+      pos: 9.5,-2.5
   - uid: 156
     components:
     - type: Transform
-      pos: 10.5,-2.5
       parent: 1
+      pos: 10.5,-2.5
   - uid: 157
     components:
     - type: Transform
-      pos: 10.5,-1.5
       parent: 1
+      pos: 10.5,-1.5
   - uid: 158
     components:
     - type: Transform
-      pos: 10.5,-0.5
       parent: 1
+      pos: 10.5,-0.5
   - uid: 159
     components:
     - type: Transform
-      pos: 10.5,1.5
       parent: 1
+      pos: 10.5,1.5
   - uid: 160
     components:
     - type: Transform
-      pos: 10.5,2.5
       parent: 1
+      pos: 10.5,2.5
   - uid: 161
     components:
     - type: Transform
-      pos: 10.5,3.5
       parent: 1
+      pos: 10.5,3.5
   - uid: 162
     components:
     - type: Transform
-      pos: -5.5,6.5
       parent: 1
+      pos: -5.5,6.5
   - uid: 163
     components:
     - type: Transform
-      pos: 9.5,3.5
       parent: 1
+      pos: 9.5,3.5
   - uid: 164
     components:
     - type: Transform
-      pos: 9.5,4.5
       parent: 1
+      pos: 9.5,4.5
   - uid: 165
     components:
     - type: Transform
-      pos: 8.5,4.5
       parent: 1
+      pos: 8.5,4.5
   - uid: 166
     components:
     - type: Transform
-      pos: 8.5,5.5
       parent: 1
+      pos: 8.5,5.5
   - uid: 167
     components:
     - type: Transform
-      pos: 8.5,6.5
       parent: 1
+      pos: 8.5,6.5
   - uid: 168
     components:
     - type: Transform
-      pos: 7.5,6.5
       parent: 1
+      pos: 7.5,6.5
   - uid: 169
     components:
     - type: Transform
-      pos: 6.5,6.5
       parent: 1
+      pos: 6.5,6.5
   - uid: 170
     components:
     - type: Transform
-      pos: 6.5,7.5
       parent: 1
+      pos: 6.5,7.5
   - uid: 171
     components:
     - type: Transform
-      pos: 6.5,8.5
       parent: 1
+      pos: 6.5,8.5
   - uid: 172
     components:
     - type: Transform
-      pos: 5.5,8.5
       parent: 1
+      pos: 5.5,8.5
   - uid: 173
     components:
     - type: Transform
-      pos: 4.5,8.5
       parent: 1
+      pos: 4.5,8.5
   - uid: 174
     components:
     - type: Transform
-      pos: 4.5,9.5
       parent: 1
+      pos: 4.5,9.5
   - uid: 175
     components:
     - type: Transform
-      pos: 3.5,9.5
       parent: 1
+      pos: 3.5,9.5
   - uid: 176
     components:
     - type: Transform
-      pos: -6.5,6.5
       parent: 1
+      pos: -6.5,6.5
   - uid: 177
     components:
     - type: Transform
-      pos: -7.5,6.5
       parent: 1
+      pos: -7.5,6.5
   - uid: 178
     components:
     - type: Transform
-      pos: -7.5,5.5
       parent: 1
+      pos: -7.5,5.5
   - uid: 179
     components:
     - type: Transform
-      pos: -7.5,4.5
       parent: 1
+      pos: -7.5,4.5
   - uid: 180
     components:
     - type: Transform
-      pos: -8.5,4.5
       parent: 1
+      pos: -8.5,4.5
   - uid: 181
     components:
     - type: Transform
-      pos: -8.5,3.5
       parent: 1
+      pos: -8.5,3.5
   - uid: 182
     components:
     - type: Transform
-      pos: -9.5,3.5
       parent: 1
+      pos: -9.5,3.5
   - uid: 183
     components:
     - type: Transform
-      pos: -9.5,2.5
       parent: 1
+      pos: -9.5,2.5
   - uid: 184
     components:
     - type: Transform
-      pos: -9.5,1.5
       parent: 1
+      pos: -9.5,1.5
   - uid: 185
     components:
     - type: Transform
-      pos: -5.5,7.5
       parent: 1
+      pos: -5.5,7.5
   - uid: 186
     components:
     - type: Transform
-      pos: -5.5,8.5
       parent: 1
+      pos: -5.5,8.5
   - uid: 187
     components:
     - type: Transform
-      pos: -4.5,8.5
       parent: 1
+      pos: -4.5,8.5
   - uid: 188
     components:
     - type: Transform
-      pos: -3.5,8.5
       parent: 1
+      pos: -3.5,8.5
   - uid: 189
     components:
     - type: Transform
-      pos: -2.5,9.5
       parent: 1
+      pos: -2.5,9.5
   - uid: 190
     components:
     - type: Transform
+      parent: 1
       pos: -3.5,9.5
-      parent: 1
-  - uid: 191
-    components:
-    - type: Transform
-      pos: 0.5,5.5
-      parent: 1
   - uid: 192
     components:
     - type: Transform
-      pos: 0.5,4.5
       parent: 1
+      pos: 0.5,4.5
   - uid: 193
     components:
     - type: Transform
-      pos: -0.5,4.5
       parent: 1
+      pos: -0.5,4.5
   - uid: 194
     components:
     - type: Transform
-      pos: -1.5,4.5
       parent: 1
+      pos: -1.5,4.5
   - uid: 195
     components:
     - type: Transform
-      pos: -2.5,4.5
       parent: 1
+      pos: -2.5,4.5
   - uid: 196
     components:
     - type: Transform
-      pos: -3.5,4.5
       parent: 1
+      pos: -3.5,4.5
   - uid: 197
     components:
     - type: Transform
-      pos: 1.5,4.5
       parent: 1
+      pos: 1.5,4.5
   - uid: 198
     components:
     - type: Transform
-      pos: 2.5,4.5
       parent: 1
+      pos: 2.5,4.5
   - uid: 199
     components:
     - type: Transform
-      pos: 3.5,4.5
       parent: 1
+      pos: 3.5,4.5
   - uid: 200
     components:
     - type: Transform
-      pos: 3.5,5.5
       parent: 1
+      pos: 3.5,5.5
   - uid: 201
     components:
     - type: Transform
-      pos: 3.5,6.5
       parent: 1
+      pos: 3.5,6.5
   - uid: 202
     components:
     - type: Transform
-      pos: 2.5,6.5
       parent: 1
+      pos: 2.5,6.5
   - uid: 203
     components:
     - type: Transform
-      pos: 1.5,6.5
       parent: 1
+      pos: 1.5,6.5
   - uid: 204
     components:
     - type: Transform
-      pos: 1.5,7.5
       parent: 1
+      pos: 1.5,7.5
   - uid: 205
     components:
     - type: Transform
-      pos: 1.5,8.5
       parent: 1
+      pos: 1.5,8.5
   - uid: 206
     components:
     - type: Transform
-      pos: 2.5,-1.5
       parent: 1
+      pos: 2.5,-1.5
   - uid: 207
     components:
     - type: Transform
-      pos: 1.5,-1.5
       parent: 1
+      pos: 1.5,-1.5
   - uid: 208
     components:
     - type: Transform
-      pos: 0.5,-1.5
       parent: 1
+      pos: 0.5,-1.5
   - uid: 209
     components:
     - type: Transform
-      pos: -0.5,-1.5
       parent: 1
+      pos: -0.5,-1.5
   - uid: 210
     components:
     - type: Transform
-      pos: 3.5,-1.5
       parent: 1
+      pos: 3.5,-1.5
   - uid: 211
     components:
     - type: Transform
-      pos: -0.5,-2.5
       parent: 1
+      pos: -0.5,-2.5
   - uid: 212
     components:
     - type: Transform
-      pos: -0.5,-3.5
       parent: 1
+      pos: -0.5,-3.5
   - uid: 213
     components:
     - type: Transform
-      pos: -0.5,-4.5
       parent: 1
+      pos: -0.5,-4.5
   - uid: 214
     components:
     - type: Transform
-      pos: 0.5,-4.5
       parent: 1
+      pos: 0.5,-4.5
   - uid: 215
     components:
     - type: Transform
-      pos: 1.5,-4.5
       parent: 1
+      pos: 1.5,-4.5
   - uid: 216
     components:
     - type: Transform
-      pos: 2.5,-4.5
       parent: 1
+      pos: 2.5,-4.5
   - uid: 217
     components:
     - type: Transform
-      pos: -0.5,-0.5
       parent: 1
+      pos: -0.5,-0.5
   - uid: 218
     components:
     - type: Transform
-      pos: -0.5,0.5
       parent: 1
+      pos: -0.5,0.5
   - uid: 219
     components:
     - type: Transform
-      pos: -0.5,1.5
       parent: 1
+      pos: -0.5,1.5
   - uid: 220
     components:
     - type: Transform
-      pos: 0.5,1.5
       parent: 1
+      pos: 0.5,1.5
   - uid: 221
     components:
     - type: Transform
-      pos: 1.5,1.5
       parent: 1
+      pos: 1.5,1.5
   - uid: 222
     components:
     - type: Transform
-      pos: 2.5,1.5
       parent: 1
+      pos: 2.5,1.5
   - uid: 223
     components:
     - type: Transform
-      pos: 3.5,1.5
       parent: 1
+      pos: 3.5,1.5
   - uid: 224
     components:
     - type: Transform
-      pos: 4.5,1.5
       parent: 1
+      pos: 4.5,1.5
   - uid: 225
     components:
     - type: Transform
-      pos: 5.5,1.5
       parent: 1
+      pos: 5.5,1.5
   - uid: 226
     components:
     - type: Transform
-      pos: -3.5,0.5
       parent: 1
+      pos: -3.5,0.5
   - uid: 227
     components:
     - type: Transform
-      pos: -4.5,0.5
       parent: 1
+      pos: -4.5,0.5
   - uid: 228
     components:
     - type: Transform
-      pos: -5.5,0.5
       parent: 1
+      pos: -5.5,0.5
   - uid: 229
     components:
     - type: Transform
-      pos: -6.5,0.5
       parent: 1
+      pos: -6.5,0.5
+  - uid: 294
+    components:
+    - type: Transform
+      parent: 1
+      pos: -0.5,5.5
 - proto: CableHV
   entities:
   - uid: 230
     components:
     - type: Transform
-      pos: -5.5,-1.5
       parent: 1
+      pos: -5.5,-1.5
   - uid: 231
     components:
     - type: Transform
-      pos: -5.5,0.5
       parent: 1
+      pos: -5.5,0.5
   - uid: 232
     components:
     - type: Transform
-      pos: -5.5,2.5
       parent: 1
+      pos: -5.5,2.5
   - uid: 233
     components:
     - type: Transform
-      pos: -5.5,2.5
       parent: 1
+      pos: -5.5,2.5
   - uid: 234
     components:
     - type: Transform
-      pos: -6.5,1.5
       parent: 1
+      pos: -6.5,1.5
   - uid: 235
     components:
     - type: Transform
-      pos: -6.5,0.5
       parent: 1
+      pos: -6.5,0.5
   - uid: 236
     components:
     - type: Transform
-      pos: -6.5,-0.5
       parent: 1
+      pos: -6.5,-0.5
   - uid: 237
     components:
     - type: Transform
-      pos: -4.5,-0.5
       parent: 1
+      pos: -4.5,-0.5
   - uid: 238
     components:
     - type: Transform
-      pos: -4.5,0.5
       parent: 1
+      pos: -4.5,0.5
   - uid: 239
     components:
     - type: Transform
-      pos: -6.5,2.5
       parent: 1
+      pos: -6.5,2.5
   - uid: 240
     components:
     - type: Transform
-      pos: -5.5,-1.5
       parent: 1
+      pos: -5.5,-1.5
   - uid: 241
     components:
     - type: Transform
-      pos: -3.5,-0.5
       parent: 1
+      pos: -3.5,-0.5
   - uid: 242
     components:
     - type: Transform
-      pos: -6.5,-1.5
       parent: 1
+      pos: -6.5,-1.5
   - uid: 243
     components:
     - type: Transform
-      pos: -2.5,-0.5
       parent: 1
+      pos: -2.5,-0.5
   - uid: 244
     components:
     - type: Transform
-      pos: -1.5,-0.5
       parent: 1
+      pos: -1.5,-0.5
   - uid: 245
     components:
     - type: Transform
-      pos: -0.5,-0.5
       parent: 1
+      pos: -0.5,-0.5
   - uid: 246
     components:
     - type: Transform
-      pos: 0.5,-0.5
       parent: 1
+      pos: 0.5,-0.5
   - uid: 247
     components:
     - type: Transform
-      pos: 1.5,-0.5
       parent: 1
+      pos: 1.5,-0.5
   - uid: 248
     components:
     - type: Transform
-      pos: 2.5,-0.5
       parent: 1
+      pos: 2.5,-0.5
   - uid: 249
     components:
     - type: Transform
-      pos: 3.5,-0.5
       parent: 1
+      pos: 3.5,-0.5
   - uid: 250
     components:
     - type: Transform
-      pos: 5.5,-0.5
       parent: 1
+      pos: 5.5,-0.5
   - uid: 251
     components:
     - type: Transform
-      pos: 6.5,-0.5
       parent: 1
+      pos: 6.5,-0.5
   - uid: 252
     components:
     - type: Transform
-      pos: 7.5,-0.5
       parent: 1
+      pos: 7.5,-0.5
   - uid: 253
     components:
     - type: Transform
-      pos: 8.5,-0.5
       parent: 1
+      pos: 8.5,-0.5
   - uid: 254
     components:
     - type: Transform
-      pos: 4.5,-0.5
       parent: 1
+      pos: 4.5,-0.5
   - uid: 255
     components:
     - type: Transform
-      pos: 8.5,0.5
       parent: 1
+      pos: 8.5,0.5
 - proto: CableMV
   entities:
+  - uid: 191
+    components:
+    - type: Transform
+      parent: 1
+      pos: -5.5,-6.5
   - uid: 256
     components:
     - type: Transform
-      pos: -3.5,-0.5
       parent: 1
+      pos: -3.5,-0.5
   - uid: 257
     components:
     - type: Transform
-      pos: -3.5,-1.5
       parent: 1
+      pos: -3.5,-1.5
   - uid: 258
     components:
     - type: Transform
-      pos: -3.5,-2.5
       parent: 1
+      pos: -3.5,-2.5
   - uid: 259
     components:
     - type: Transform
-      pos: -3.5,-3.5
       parent: 1
+      pos: -3.5,-3.5
   - uid: 260
     components:
     - type: Transform
-      pos: -3.5,-4.5
       parent: 1
+      pos: -3.5,-4.5
   - uid: 261
     components:
     - type: Transform
-      pos: -3.5,-5.5
       parent: 1
+      pos: -3.5,-5.5
   - uid: 262
     components:
     - type: Transform
-      pos: -5.5,-5.5
       parent: 1
+      pos: -5.5,-5.5
   - uid: 263
     components:
     - type: Transform
-      pos: -4.5,-5.5
       parent: 1
+      pos: -4.5,-5.5
   - uid: 264
     components:
     - type: Transform
-      pos: -3.5,0.5
       parent: 1
+      pos: -3.5,0.5
   - uid: 265
     components:
     - type: Transform
-      pos: -3.5,1.5
       parent: 1
+      pos: -3.5,1.5
   - uid: 266
     components:
     - type: Transform
-      pos: -3.5,2.5
       parent: 1
+      pos: -3.5,2.5
   - uid: 267
     components:
     - type: Transform
-      pos: -3.5,3.5
       parent: 1
+      pos: -3.5,3.5
   - uid: 268
     components:
     - type: Transform
-      pos: -3.5,4.5
       parent: 1
+      pos: -3.5,4.5
   - uid: 269
     components:
     - type: Transform
-      pos: -4.5,4.5
       parent: 1
+      pos: -4.5,4.5
   - uid: 270
     components:
     - type: Transform
-      pos: -5.5,6.5
       parent: 1
+      pos: -5.5,6.5
   - uid: 271
     components:
     - type: Transform
-      pos: -5.5,5.5
       parent: 1
+      pos: -5.5,5.5
   - uid: 272
     components:
     - type: Transform
-      pos: -5.5,4.5
       parent: 1
+      pos: -5.5,4.5
   - uid: 273
     components:
     - type: Transform
-      pos: 8.5,0.5
       parent: 1
+      pos: 8.5,0.5
   - uid: 274
     components:
     - type: Transform
-      pos: 7.5,0.5
       parent: 1
+      pos: 7.5,0.5
   - uid: 275
     components:
     - type: Transform
-      pos: 6.5,0.5
       parent: 1
+      pos: 6.5,0.5
   - uid: 276
     components:
     - type: Transform
-      pos: 6.5,-0.5
       parent: 1
+      pos: 6.5,-0.5
   - uid: 277
     components:
     - type: Transform
-      pos: 6.5,-1.5
       parent: 1
+      pos: 6.5,-1.5
   - uid: 278
     components:
     - type: Transform
-      pos: 6.5,-2.5
       parent: 1
+      pos: 6.5,-2.5
   - uid: 279
     components:
     - type: Transform
-      pos: 6.5,-3.5
       parent: 1
+      pos: 6.5,-3.5
   - uid: 280
     components:
     - type: Transform
-      pos: 6.5,-4.5
       parent: 1
+      pos: 6.5,-4.5
   - uid: 281
     components:
     - type: Transform
-      pos: 6.5,-5.5
       parent: 1
+      pos: 6.5,-5.5
   - uid: 282
     components:
     - type: Transform
-      pos: 6.5,1.5
       parent: 1
+      pos: 6.5,1.5
   - uid: 283
     components:
     - type: Transform
-      pos: 6.5,2.5
       parent: 1
+      pos: 6.5,2.5
   - uid: 284
     components:
     - type: Transform
-      pos: 6.5,3.5
       parent: 1
+      pos: 6.5,3.5
   - uid: 285
     components:
     - type: Transform
-      pos: 6.5,4.5
       parent: 1
+      pos: 6.5,4.5
   - uid: 286
     components:
     - type: Transform
-      pos: 6.5,5.5
       parent: 1
+      pos: 6.5,5.5
   - uid: 287
     components:
     - type: Transform
-      pos: 6.5,6.5
       parent: 1
+      pos: 6.5,6.5
   - uid: 288
     components:
     - type: Transform
-      pos: 3.5,-1.5
       parent: 1
+      pos: 3.5,-1.5
   - uid: 289
     components:
     - type: Transform
-      pos: 4.5,-1.5
       parent: 1
+      pos: 4.5,-1.5
   - uid: 290
     components:
     - type: Transform
-      pos: 5.5,-1.5
       parent: 1
+      pos: 5.5,-1.5
   - uid: 291
     components:
     - type: Transform
-      pos: -2.5,4.5
       parent: 1
+      pos: -2.5,4.5
   - uid: 292
     components:
     - type: Transform
-      pos: -1.5,4.5
       parent: 1
+      pos: -1.5,4.5
   - uid: 293
     components:
     - type: Transform
+      parent: 1
       pos: -0.5,4.5
-      parent: 1
-  - uid: 294
-    components:
-    - type: Transform
-      pos: 0.5,4.5
-      parent: 1
   - uid: 295
     components:
     - type: Transform
-      pos: 0.5,5.5
       parent: 1
+      pos: -0.5,5.5
+  - uid: 834
+    components:
+    - type: Transform
+      parent: 1
+      pos: 6.5,-6.5
 - proto: CableTerminal
   entities:
   - uid: 296
     components:
     - type: Transform
-      pos: -4.5,0.5
       parent: 1
+      pos: -4.5,0.5
 - proto: CarpetPurple
   entities:
   - uid: 297
     components:
     - type: Transform
-      pos: 7.5,-0.5
       parent: 1
+      pos: 7.5,-0.5
   - uid: 298
     components:
     - type: Transform
-      pos: 7.5,0.5
       parent: 1
+      pos: 7.5,0.5
   - uid: 299
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 6.5,-0.5
-      parent: 1
   - uid: 300
     components:
     - type: Transform
-      pos: 7.5,-1.5
       parent: 1
+      pos: 7.5,-1.5
   - uid: 301
     components:
     - type: Transform
-      pos: 5.5,-0.5
       parent: 1
+      pos: 5.5,-0.5
 - proto: ChairPilotSeat
   entities:
   - uid: 302
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 0.5,8.5
-      parent: 1
 - proto: ClothingAbductorBelt
   entities:
   - uid: 303
     components:
     - type: Transform
-      pos: 6.4854016,-1.6594049
       parent: 1
+      pos: 6.4854016,-1.6594049
 - proto: ClothingBackpackDuffelAbductorFilled
   entities:
   - uid: 304
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 1.649822,-1.4591656
-      parent: 1
     - type: GroupExamine
       group:
-      - hoverMessage: ""
-        contextText: verb-examine-group-other
+      - title: null
         icon: /Textures/Interface/examine-star.png
-        components:
-        - Armor
-        - ClothingSpeedModifier
+        hoverMessage: ""
         entries:
-        - message: >-
+        - priority: 0
+          message: >-
             It provides the following protection:
 
             - [color=blue]Stamina[/color] damage reduced by [color=lightblue]0%[/color].
 
             - [color=orange]Explosion[/color] damage [color=white]to contents[/color] reduced by [color=lightblue]90%[/color].
-          priority: 0
           component: Armor
-        - message: This decreases your running speed by [color=yellow]10%[/color].
-          priority: 0
+        - priority: 0
+          message: This decreases your running speed by [color=yellow]10%[/color].
           component: ClothingSpeedModifier
-        title: null
+        contextText: verb-examine-group-other
+        components:
+        - Armor
+        - ClothingSpeedModifier
 - proto: ClothingEyesWeldingGoggles
   entities:
   - uid: 305
     components:
     - type: MetaData
-      desc: What some may call welding goggles, abductors call sleep-aids, protects the eyes from welders.
       name: Alien Eye Covers
+      desc: What some may call welding goggles, abductors call sleep-aids, protects the eyes from welders.
     - type: Transform
-      pos: 6.4854016,-1.3258401
       parent: 1
+      pos: 6.4854016,-1.3258401
   - uid: 306
     components:
     - type: MetaData
-      desc: What some may call welding goggles, abductors call sleep-aids, protects the eyes from welders.
       name: Alien Eye Covers
+      desc: What some may call welding goggles, abductors call sleep-aids, protects the eyes from welders.
     - type: Transform
-      pos: 6.549399,0.528616
       parent: 1
+      pos: 6.549399,0.528616
 - proto: ComputerAlert
   entities:
   - uid: 752
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -2.5,3.5
-      parent: 1
 - proto: ComputerIFF
   entities:
   - uid: 307
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -0.5,9.5
-      parent: 1
 - proto: ComputerRadar
   entities:
   - uid: 308
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -0.5,8.5
-      parent: 1
 - proto: CurtainsPurpleOpen
   entities:
   - uid: 310
     components:
     - type: Transform
-      pos: 7.5,0.5
       parent: 1
+      pos: 7.5,0.5
   - uid: 311
     components:
     - type: Transform
-      pos: 7.5,-1.5
       parent: 1
+      pos: 7.5,-1.5
 - proto: DefibrillatorAbductor
   entities:
   - uid: 312
     components:
     - type: Transform
-      pos: 0.85072744,-1.3857149
       parent: 1
+      pos: 0.85072744,-1.3857149
     - type: ContainerContainer
       containers:
         cell_slot: !type:ContainerSlot
+          ent: 313
           showEnts: False
           occludes: True
-          ent: 313
 - proto: EmergencyMedipen
   entities:
   - uid: 314
     components:
     - type: Transform
-      pos: 2.6511457,-0.32162133
       parent: 1
+      pos: 2.6511457,-0.32162133
   - uid: 315
     components:
     - type: Transform
-      pos: 2.328229,-0.34246925
       parent: 1
+      pos: 2.328229,-0.34246925
 - proto: FloorDrain
   entities:
   - uid: 316
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 0.5,0.5
-      parent: 1
     - type: Fixtures
       fixtures: {}
 - proto: GasMinerNitrogen
@@ -1997,56 +2009,31 @@ entities:
   - uid: 317
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -3.5,6.5
-      parent: 1
 - proto: GasMinerOxygen
   entities:
   - uid: 318
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -1.5,6.5
-      parent: 1
 - proto: GasMixerFlipped
   entities:
   - uid: 319
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -1.5,4.5
-      parent: 1
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: GasMixer
+      targetPressure: 300
       inletTwoConcentration: 0.20999998
       inletOneConcentration: 0.79
-      targetPressure: 300
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-- proto: GasOutletInjectorAlt1
-  entities:
-  - uid: 834
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 835
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 837
-    components:
-    - type: Transform
-      pos: 2.5,6.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasOutletInjectorAlt2
@@ -2054,9 +2041,9 @@ entities:
   - uid: 320
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -8.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPassiveVentAlt1
@@ -2064,15 +2051,15 @@ entities:
   - uid: 321
     components:
     - type: Transform
-      pos: -1.5,6.5
       parent: 1
+      pos: -1.5,6.5
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 322
     components:
     - type: Transform
-      pos: -3.5,6.5
       parent: 1
+      pos: -3.5,6.5
     - type: AtmosPipeColor
       color: '#FF1212FF'
 - proto: GasPipeBendAlt1
@@ -2080,62 +2067,54 @@ entities:
   - uid: 323
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -3.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 324
     components:
     - type: Transform
-      pos: 3.5,6.5
       parent: 1
+      pos: 3.5,6.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 325
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,6.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 326
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 1.5,2.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 327
     components:
     - type: Transform
-      pos: 4.5,2.5
       parent: 1
+      pos: 4.5,2.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 328
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,0.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 329
     components:
     - type: Transform
+      parent: 1
       pos: 5.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 836
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,5.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasPipeBendAlt2
@@ -2143,152 +2122,176 @@ entities:
   - uid: 330
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,6.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 331
     components:
     - type: Transform
-      pos: 3.5,6.5
       parent: 1
+      pos: 3.5,6.5
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 332
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,0.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 333
     components:
     - type: Transform
-      pos: 4.5,2.5
       parent: 1
+      pos: 4.5,2.5
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 334
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 1.5,2.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 335
     components:
     - type: Transform
-      pos: 1.5,8.5
       parent: 1
+      pos: 1.5,8.5
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPipeStraightAlt1
   entities:
+  - uid: 336
+    components:
+    - type: Transform
+      parent: 1
+      rot: 3.141592653589793 rad
+      pos: 1.5,1.5
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 337
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -1.5,5.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 338
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -3.5,5.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 339
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -2.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 340
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -0.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 341
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 0.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 342
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 1.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 343
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 2.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 344
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 2.5,2.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 345
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 2.5,6.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 346
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,7.5
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 347
+    components:
+    - type: Transform
       parent: 1
+      rot: 3.141592653589793 rad
+      pos: 3.5,5.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 348
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 3.5,3.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 349
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,1.5
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 350
+    components:
+    - type: Transform
       parent: 1
+      rot: 3.141592653589793 rad
+      pos: 5.5,-0.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 351
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,0.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasPipeStraightAlt2
@@ -2296,187 +2299,163 @@ entities:
   - uid: 352
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 2.5,2.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 353
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 2.5,6.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 354
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,7.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 355
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 3.5,5.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 356
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 3.5,3.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 357
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,1.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 358
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,1.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 359
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 2.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 360
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 1.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 361
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 0.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 362
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -0.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 363
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -1.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 364
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -2.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 365
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -3.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 366
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -4.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 367
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -5.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 368
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -6.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 369
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -7.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPipeTJunctionAlt1
   entities:
-  - uid: 336
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 347
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 350
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 370
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 3.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 371
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 3.5,2.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasPipeTJunctionAlt2
@@ -2484,17 +2463,17 @@ entities:
   - uid: 372
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 3.5,2.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 373
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 3.5,4.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasVentPumpAlt1
@@ -2502,50 +2481,68 @@ entities:
   - uid: 374
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,-0.5
-      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 736
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 375
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,-1.5
-      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 736
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 376
     components:
     - type: Transform
-      pos: 1.5,8.5
       parent: 1
+      pos: 1.5,8.5
+    - type: DeviceNetwork
+      deviceLists:
+      - 736
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
 - proto: GasVentScrubberAlt2
   entities:
   - uid: 377
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 5.5,0.5
-      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 736
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 378
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,0.5
-      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 736
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 379
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 0.5,8.5
-      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 736
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GeneratorBasic20kW
@@ -2553,330 +2550,330 @@ entities:
   - uid: 380
     components:
     - type: Transform
-      pos: -5.5,-1.5
       parent: 1
+      pos: -5.5,-1.5
   - uid: 381
     components:
     - type: Transform
-      pos: -6.5,0.5
       parent: 1
+      pos: -6.5,0.5
   - uid: 382
     components:
     - type: Transform
-      pos: -5.5,2.5
       parent: 1
+      pos: -5.5,2.5
   - uid: 383
     components:
     - type: Transform
-      pos: -6.5,1.5
       parent: 1
+      pos: -6.5,1.5
   - uid: 384
     components:
     - type: Transform
-      pos: -6.5,-0.5
       parent: 1
+      pos: -6.5,-0.5
 - proto: GravityGeneratorMini
   entities:
   - uid: 385
     components:
     - type: Transform
-      pos: -4.5,0.5
       parent: 1
+      pos: -4.5,0.5
 - proto: Grille
   entities:
   - uid: 386
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -3.5,5.5
-      parent: 1
   - uid: 387
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -1.5,5.5
-      parent: 1
   - uid: 388
     components:
     - type: Transform
-      pos: -1.5,11.5
       parent: 1
+      pos: -1.5,11.5
   - uid: 389
     components:
     - type: Transform
-      pos: -0.5,11.5
       parent: 1
+      pos: -0.5,11.5
   - uid: 390
     components:
     - type: Transform
-      pos: 0.5,11.5
       parent: 1
+      pos: 0.5,11.5
   - uid: 391
     components:
     - type: Transform
-      pos: 1.5,11.5
       parent: 1
+      pos: 1.5,11.5
   - uid: 392
     components:
     - type: Transform
-      pos: 1.5,10.5
       parent: 1
+      pos: 1.5,10.5
   - uid: 393
     components:
     - type: Transform
-      pos: -0.5,10.5
       parent: 1
+      pos: -0.5,10.5
   - uid: 394
     components:
     - type: Transform
-      pos: 0.5,10.5
       parent: 1
+      pos: 0.5,10.5
   - uid: 395
     components:
     - type: Transform
-      pos: 2.5,11.5
       parent: 1
+      pos: 2.5,11.5
 - proto: GrilleDiagonal
   entities:
   - uid: 396
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,-8.5
-      parent: 1
   - uid: 397
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -9.5,-1.5
-      parent: 1
   - uid: 398
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -8.5,-3.5
-      parent: 1
   - uid: 399
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -7.5,-5.5
-      parent: 1
   - uid: 400
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -9.5,-1.5
-      parent: 1
   - uid: 401
     components:
     - type: Transform
-      pos: -8.5,4.5
       parent: 1
+      pos: -8.5,4.5
   - uid: 402
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -1.5,-9.5
-      parent: 1
   - uid: 403
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -9.5,2.5
-      parent: 1
   - uid: 404
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -3.5,-8.5
-      parent: 1
   - uid: 405
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -1.5,-9.5
-      parent: 1
   - uid: 406
     components:
     - type: Transform
-      pos: 2.5,-9.5
       parent: 1
+      pos: 2.5,-9.5
   - uid: 407
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -5.5,-7.5
-      parent: 1
   - uid: 408
     components:
     - type: Transform
-      pos: -5.5,8.5
       parent: 1
+      pos: -5.5,8.5
   - uid: 409
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 2.5,-9.5
-      parent: 1
   - uid: 410
     components:
     - type: Transform
-      pos: -9.5,2.5
       parent: 1
+      pos: -9.5,2.5
   - uid: 411
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 6.5,8.5
-      parent: 1
   - uid: 412
     components:
     - type: Transform
-      pos: -3.5,9.5
       parent: 1
+      pos: -3.5,9.5
   - uid: 413
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 10.5,-1.5
-      parent: 1
   - uid: 414
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 10.5,2.5
-      parent: 1
   - uid: 415
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 4.5,9.5
-      parent: 1
   - uid: 416
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 10.5,-1.5
-      parent: 1
   - uid: 417
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 10.5,2.5
-      parent: 1
   - uid: 418
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 9.5,4.5
-      parent: 1
   - uid: 419
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 6.5,-7.5
-      parent: 1
   - uid: 420
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 9.5,-3.5
-      parent: 1
   - uid: 421
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 8.5,-5.5
-      parent: 1
   - uid: 422
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 6.5,8.5
-      parent: 1
   - uid: 423
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 4.5,9.5
-      parent: 1
   - uid: 424
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 9.5,4.5
-      parent: 1
   - uid: 425
     components:
     - type: Transform
-      pos: 9.5,-3.5
       parent: 1
+      pos: 9.5,-3.5
   - uid: 426
     components:
     - type: Transform
-      pos: 8.5,-5.5
       parent: 1
+      pos: 8.5,-5.5
   - uid: 427
     components:
     - type: Transform
-      pos: 6.5,-7.5
       parent: 1
+      pos: 6.5,-7.5
   - uid: 428
     components:
     - type: Transform
-      pos: 4.5,-8.5
       parent: 1
+      pos: 4.5,-8.5
   - uid: 429
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -3.5,-8.5
-      parent: 1
   - uid: 430
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -5.5,-7.5
-      parent: 1
   - uid: 431
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -7.5,-5.5
-      parent: 1
   - uid: 432
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -8.5,-3.5
-      parent: 1
   - uid: 433
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -8.5,4.5
-      parent: 1
   - uid: 434
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -5.5,8.5
-      parent: 1
   - uid: 435
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -3.5,9.5
-      parent: 1
 - proto: Gyroscope
   entities:
   - uid: 436
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -4.5,1.5
-      parent: 1
     - type: Thruster
       thrust: 4000
 - proto: MedkitAdvancedFilled
@@ -2884,37 +2881,37 @@ entities:
   - uid: 437
     components:
     - type: Transform
+      parent: 1
       rot: 6.283185307179586 rad
       pos: 2.5018084,0.51184094
-      parent: 1
   - uid: 438
     components:
     - type: Transform
+      parent: 1
       rot: 6.283185307179586 rad
       pos: 2.5018084,0.084460735
-      parent: 1
 - proto: NitrogenCanister
   entities:
   - uid: 439
     components:
     - type: Transform
-      pos: -3.5,6.5
       parent: 1
+      pos: -3.5,6.5
 - proto: OxygenCanister
   entities:
   - uid: 440
     components:
     - type: Transform
-      pos: -1.5,6.5
       parent: 1
+      pos: -1.5,6.5
 - proto: PosterLegitAnatomyPoster
   entities:
   - uid: 441
     components:
     - type: Transform
-      anchored: True
-      pos: 3.5,-0.5
       parent: 1
+      pos: 3.5,-0.5
+      anchored: True
     - type: Fixtures
       fixtures: {}
     missingComponents:
@@ -2932,84 +2929,84 @@ entities:
   - uid: 442
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -1.5,11.5
-      parent: 1
   - uid: 443
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 2.5,11.5
-      parent: 1
 - proto: PoweredlightPink
   entities:
   - uid: 444
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 7.5,-0.5
-      parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 445
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -1.5,0.5
-      parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 446
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,-4.5
-      parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 447
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 2.5,-1.5
-      parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 448
     components:
     - type: Transform
-      pos: 0.5,4.5
       parent: 1
+      pos: 0.5,4.5
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 449
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 4.5,4.5
-      parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 450
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -0.5,8.5
-      parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 451
     components:
     - type: Transform
-      pos: -3.5,6.5
       parent: 1
+      pos: -3.5,6.5
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 452
     components:
     - type: Transform
-      pos: -1.5,6.5
       parent: 1
+      pos: -1.5,6.5
     - type: DeviceLinkSink
       invokeCounter: 1
 - proto: PoweredStrobeLightShuttleSiren
@@ -3017,105 +3014,108 @@ entities:
   - uid: 453
     components:
     - type: MetaData
-      desc: you probably wont understand what it's used for or live long enough to find out
       name: Abductor Alert Siren
+      desc: you probably wont understand what it's used for or live long enough to find out
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 4.5,4.5
-      parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 454
     components:
     - type: MetaData
-      desc: you probably wont understand what it's used for or live long enough to find out
       name: Abductor Alert Siren
+      desc: you probably wont understand what it's used for or live long enough to find out
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 5.5,-0.5
-      parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 455
     components:
     - type: MetaData
-      desc: you probably wont understand what it's used for or live long enough to find out
       name: Abductor Alert Siren
+      desc: you probably wont understand what it's used for or live long enough to find out
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,-4.5
-      parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 457
     components:
     - type: MetaData
-      desc: you probably wont understand what it's used for or live long enough to find out
       name: Abductor Alert Siren
+      desc: you probably wont understand what it's used for or live long enough to find out
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -0.5,8.5
-      parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 458
     components:
     - type: MetaData
-      desc: you probably wont understand what it's used for or live long enough to find out
       name: Abductor Alert Siren
+      desc: you probably wont understand what it's used for or live long enough to find out
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 2.5,-0.5
-      parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 838
     components:
     - type: MetaData
-      desc: you probably wont understand what it's used for or live long enough to find out
       name: Abductor Alert Siren
+      desc: you probably wont understand what it's used for or live long enough to find out
     - type: Transform
-      pos: -2.5,4.5
       parent: 1
+      pos: -2.5,4.5
 - proto: RadAutoInjector
   entities:
   - uid: 459
     components:
     - type: Transform
-      pos: 2.6351137,-0.7827953
       parent: 1
+      pos: 2.6351137,-0.7827953
   - uid: 460
     components:
     - type: Transform
-      pos: 2.3330302,-0.7827953
       parent: 1
+      pos: 2.3330302,-0.7827953
 - proto: Railing
   entities:
   - uid: 461
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -4.5,4.5
-      parent: 1
   - uid: 462
     components:
     - type: Transform
-      pos: 2.5,-3.5
       parent: 1
+      pos: 2.5,-3.5
   - uid: 463
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -4.5,4.5
-      parent: 1
 - proto: SignalButton
   entities:
   - uid: 464
     components:
+    - type: MetaData
+      name: Spacing Button
+      desc: The text is unreadable, but the icon clearly means "no gas"
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 2.5,8.5
-      parent: 1
     - type: DeviceLinkSource
       linkedPorts:
         455:
@@ -3173,9 +3173,12 @@ entities:
       fixtures: {}
   - uid: 465
     components:
+    - type: MetaData
+      name: Shutters Button
+      desc: The text is unreadable, but the icons show an eye opening and closing
     - type: Transform
-      pos: 1.5,9.5
       parent: 1
+      pos: 1.5,9.5
     - type: DeviceLinkSource
       linkedPorts:
         108:
@@ -3191,10 +3194,13 @@ entities:
       fixtures: {}
   - uid: 466
     components:
+    - type: MetaData
+      name: Spacing Button
+      desc: The text is unreadable, but the icon clearly means "no gas"
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,3.5
-      parent: 1
     - type: DeviceLinkSource
       linkedPorts:
         458:
@@ -3249,9 +3255,12 @@ entities:
       fixtures: {}
   - uid: 467
     components:
+    - type: MetaData
+      name: Spacing Button
+      desc: The text is unreadable, but the icon clearly means "no gas"
     - type: Transform
-      pos: 6.5,1.5
       parent: 1
+      pos: 6.5,1.5
     - type: DeviceLinkSource
       linkedPorts:
         448:
@@ -3309,10 +3318,13 @@ entities:
       fixtures: {}
   - uid: 468
     components:
+    - type: MetaData
+      name: Spacing Button
+      desc: The text is unreadable, but the icon clearly means "no gas"
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -1.5,-1.5
-      parent: 1
     - type: DeviceLinkSource
       linkedPorts:
         104:
@@ -3371,11 +3383,11 @@ entities:
   - uid: 469
     components:
     - type: MetaData
-      desc: even without understanding whatever language this is, the big lightbulb icon is universal.
       name: Lights Button
+      desc: even without understanding whatever language this is, the big lightbulb icon is universal.
     - type: Transform
-      pos: 0.5,9.5
       parent: 1
+      pos: 0.5,9.5
     - type: DeviceLinkSource
       linkedPorts:
         443:
@@ -3389,12 +3401,12 @@ entities:
   - uid: 840
     components:
     - type: MetaData
-      desc: you cant read the text but the big air symbol flowing inwards to an object makes it's purpose clear.
       name: Air Pump Button
+      desc: you cant read the text but the big air symbol flowing inwards to an object makes it's purpose clear.
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -2.5,3.5
-      parent: 1
     - type: DeviceLinkSource
       linkedPorts:
         838:
@@ -3407,9 +3419,9 @@ entities:
   - uid: 471
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 1.5,-3.5
-      parent: 1
     - type: Fixtures
       fixtures: {}
 - proto: SMESAdvanced
@@ -3417,34 +3429,34 @@ entities:
   - uid: 472
     components:
     - type: Transform
-      pos: -4.5,-0.5
       parent: 1
+      pos: -4.5,-0.5
 - proto: SpawnPointAbductorAgent
   entities:
   - uid: 473
     components:
     - type: Transform
-      pos: 7.5,0.5
       parent: 1
+      pos: 7.5,0.5
 - proto: SpawnPointAbductorScientist
   entities:
   - uid: 474
     components:
     - type: Transform
-      pos: 7.5,-1.5
       parent: 1
+      pos: 7.5,-1.5
 - proto: StasisBed
   entities:
   - uid: 475
     components:
     - type: Transform
-      pos: 7.5,-1.5
       parent: 1
+      pos: 7.5,-1.5
   - uid: 476
     components:
     - type: Transform
-      pos: 7.5,0.5
       parent: 1
+      pos: 7.5,0.5
 - proto: SubstationWallBasic
   entities:
   - uid: 477
@@ -3452,307 +3464,307 @@ entities:
     - type: MetaData
       name: Inlaid Wallmount Substation
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,0.5
       parent: 1
+      rot: 4.71238898038469 rad
+      pos: 8.5,0.5
   - uid: 478
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -3.5,-0.5
-      parent: 1
 - proto: TableAbductor
   entities:
   - uid: 479
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 6.5,0.5
-      parent: 1
   - uid: 480
     components:
     - type: Transform
-      pos: 4.5,3.5
       parent: 1
+      pos: 4.5,3.5
   - uid: 481
     components:
     - type: Transform
-      pos: 2.5,-1.5
       parent: 1
+      pos: 2.5,-1.5
   - uid: 482
     components:
     - type: Transform
-      pos: 2.5,-0.5
       parent: 1
+      pos: 2.5,-0.5
   - uid: 483
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 1.5,-1.5
-      parent: 1
   - uid: 484
     components:
     - type: Transform
-      pos: 2.5,0.5
       parent: 1
+      pos: 2.5,0.5
   - uid: 485
     components:
     - type: Transform
-      pos: 4.5,5.5
       parent: 1
+      pos: 4.5,5.5
   - uid: 486
     components:
     - type: Transform
-      pos: 4.5,4.5
       parent: 1
+      pos: 4.5,4.5
   - uid: 487
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 6.5,-1.5
-      parent: 1
   - uid: 488
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 1.5,9.5
-      parent: 1
   - uid: 489
     components:
     - type: Transform
-      pos: 0.5,-1.5
       parent: 1
+      pos: 0.5,-1.5
 - proto: Thruster
   entities:
   - uid: 490
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -9.5,-0.5
-      parent: 1
   - uid: 491
     components:
     - type: Transform
-      pos: -9.5,-2.5
       parent: 1
+      pos: -9.5,-2.5
   - uid: 492
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -8.5,-2.5
-      parent: 1
   - uid: 493
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -7.5,-3.5
-      parent: 1
   - uid: 494
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -7.5,-4.5
-      parent: 1
   - uid: 495
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -4.5,-7.5
-      parent: 1
   - uid: 496
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -3.5,-7.5
-      parent: 1
   - uid: 497
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -2.5,-8.5
-      parent: 1
   - uid: 498
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -2.5,-9.5
-      parent: 1
   - uid: 499
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -0.5,-9.5
-      parent: 1
   - uid: 500
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 1.5,-9.5
-      parent: 1
   - uid: 501
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 3.5,-9.5
-      parent: 1
   - uid: 502
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 3.5,-8.5
-      parent: 1
   - uid: 503
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,-7.5
-      parent: 1
   - uid: 504
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 5.5,-7.5
-      parent: 1
   - uid: 505
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 8.5,-4.5
-      parent: 1
   - uid: 506
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 8.5,-3.5
-      parent: 1
   - uid: 507
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 9.5,-2.5
-      parent: 1
   - uid: 508
     components:
     - type: Transform
-      pos: 10.5,-2.5
       parent: 1
+      pos: 10.5,-2.5
   - uid: 509
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 10.5,-0.5
-      parent: 1
   - uid: 510
     components:
     - type: Transform
-      pos: 10.5,1.5
       parent: 1
+      pos: 10.5,1.5
   - uid: 511
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 10.5,3.5
-      parent: 1
   - uid: 512
     components:
     - type: Transform
-      pos: 9.5,3.5
       parent: 1
+      pos: 9.5,3.5
   - uid: 513
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 8.5,4.5
-      parent: 1
   - uid: 514
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 3.5,9.5
-      parent: 1
   - uid: 515
     components:
     - type: Transform
-      pos: 4.5,8.5
       parent: 1
+      pos: 4.5,8.5
   - uid: 516
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 5.5,8.5
-      parent: 1
   - uid: 517
     components:
     - type: Transform
-      pos: 6.5,7.5
       parent: 1
+      pos: 6.5,7.5
   - uid: 518
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -2.5,9.5
-      parent: 1
   - uid: 519
     components:
     - type: Transform
-      pos: -3.5,8.5
       parent: 1
+      pos: -3.5,8.5
   - uid: 520
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -4.5,8.5
-      parent: 1
   - uid: 521
     components:
     - type: Transform
-      pos: -5.5,7.5
       parent: 1
+      pos: -5.5,7.5
   - uid: 522
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -7.5,4.5
-      parent: 1
   - uid: 523
     components:
     - type: Transform
-      pos: -8.5,3.5
       parent: 1
+      pos: -8.5,3.5
   - uid: 524
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -9.5,3.5
-      parent: 1
   - uid: 525
     components:
     - type: Transform
-      pos: -9.5,1.5
       parent: 1
+      pos: -9.5,1.5
 - proto: TurboItemRecharger
   entities:
   - uid: 526
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 1.5,9.5
-      parent: 1
   - uid: 527
     components:
     - type: Transform
-      pos: 0.5,-1.5
       parent: 1
+      pos: 0.5,-1.5
 - proto: TwoWayLever
   entities:
   - uid: 528
     components:
     - type: MetaData
-      desc: Even without being able to understand what it says, you can tell from the bold characters that it's important.
       name: Emergency Fix Lever
+      desc: Even without being able to understand what it says, you can tell from the bold characters that it's important.
     - type: Transform
-      pos: 5.5,-1.5
       parent: 1
+      pos: 5.5,-1.5
     - type: DeviceLinkSource
       linkedPorts:
         104:
@@ -3845,1644 +3857,1644 @@ entities:
   - uid: 529
     components:
     - type: Transform
-      pos: -1.5,0.5
       parent: 1
+      pos: -1.5,0.5
 - proto: WallAbductor
   entities:
   - uid: 456
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -3.5,3.5
-      parent: 1
   - uid: 530
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -7.5,5.5
-      parent: 1
   - uid: 531
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 8.5,6.5
-      parent: 1
   - uid: 532
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 8.5,5.5
-      parent: 1
   - uid: 533
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -7.5,6.5
-      parent: 1
   - uid: 534
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -5.5,-6.5
-      parent: 1
   - uid: 535
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -6.5,-5.5
-      parent: 1
   - uid: 536
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 7.5,-5.5
-      parent: 1
   - uid: 537
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 6.5,-6.5
-      parent: 1
   - uid: 538
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 7.5,6.5
-      parent: 1
   - uid: 539
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -6.5,6.5
-      parent: 1
   - uid: 540
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -2.5,-3.5
-      parent: 1
   - uid: 541
     components:
     - type: Transform
-      pos: 5.5,-4.5
       parent: 1
+      pos: 5.5,-4.5
   - uid: 542
     components:
     - type: Transform
-      pos: 4.5,-4.5
       parent: 1
+      pos: 4.5,-4.5
   - uid: 543
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -2.5,-2.5
-      parent: 1
   - uid: 544
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -1.5,-1.5
-      parent: 1
   - uid: 545
     components:
     - type: Transform
-      pos: 6.5,-2.5
       parent: 1
+      pos: 6.5,-2.5
   - uid: 546
     components:
     - type: Transform
-      pos: 0.5,-8.5
       parent: 1
+      pos: 0.5,-8.5
   - uid: 547
     components:
     - type: Transform
-      pos: 10.5,0.5
       parent: 1
+      pos: 10.5,0.5
   - uid: 548
     components:
     - type: Transform
-      pos: 9.5,-1.5
       parent: 1
+      pos: 9.5,-1.5
   - uid: 549
     components:
     - type: Transform
-      pos: 0.5,-9.5
       parent: 1
+      pos: 0.5,-9.5
   - uid: 550
     components:
     - type: Transform
-      pos: -9.5,0.5
       parent: 1
+      pos: -9.5,0.5
   - uid: 551
     components:
     - type: Transform
-      pos: 1.5,-8.5
       parent: 1
+      pos: 1.5,-8.5
   - uid: 552
     components:
     - type: Transform
-      pos: 2.5,-7.5
       parent: 1
+      pos: 2.5,-7.5
   - uid: 553
     components:
     - type: Transform
-      pos: 3.5,-7.5
       parent: 1
+      pos: 3.5,-7.5
   - uid: 554
     components:
     - type: Transform
-      pos: 4.5,-6.5
       parent: 1
+      pos: 4.5,-6.5
   - uid: 555
     components:
     - type: Transform
-      pos: 5.5,-6.5
       parent: 1
+      pos: 5.5,-6.5
   - uid: 556
     components:
     - type: Transform
-      pos: 6.5,-5.5
       parent: 1
+      pos: 6.5,-5.5
   - uid: 557
     components:
     - type: Transform
-      pos: 6.5,-4.5
       parent: 1
+      pos: 6.5,-4.5
   - uid: 558
     components:
     - type: Transform
-      pos: 7.5,-4.5
       parent: 1
+      pos: 7.5,-4.5
   - uid: 559
     components:
     - type: Transform
-      pos: 7.5,-2.5
       parent: 1
+      pos: 7.5,-2.5
   - uid: 560
     components:
     - type: Transform
-      pos: 7.5,-3.5
       parent: 1
+      pos: 7.5,-3.5
   - uid: 561
     components:
     - type: Transform
-      pos: 8.5,-2.5
       parent: 1
+      pos: 8.5,-2.5
   - uid: 562
     components:
     - type: Transform
-      pos: 9.5,1.5
       parent: 1
+      pos: 9.5,1.5
   - uid: 563
     components:
     - type: Transform
-      pos: 8.5,1.5
       parent: 1
+      pos: 8.5,1.5
   - uid: 564
     components:
     - type: Transform
-      pos: 8.5,2.5
       parent: 1
+      pos: 8.5,2.5
   - uid: 565
     components:
     - type: Transform
-      pos: 8.5,3.5
       parent: 1
+      pos: 8.5,3.5
   - uid: 566
     components:
     - type: Transform
-      pos: 7.5,3.5
       parent: 1
+      pos: 7.5,3.5
   - uid: 567
     components:
     - type: Transform
-      pos: 7.5,4.5
       parent: 1
+      pos: 7.5,4.5
   - uid: 568
     components:
     - type: Transform
-      pos: 7.5,5.5
       parent: 1
+      pos: 7.5,5.5
   - uid: 569
     components:
     - type: Transform
-      pos: 6.5,5.5
       parent: 1
+      pos: 6.5,5.5
   - uid: 570
     components:
     - type: Transform
-      pos: 6.5,6.5
       parent: 1
+      pos: 6.5,6.5
   - uid: 571
     components:
     - type: Transform
-      pos: 5.5,7.5
       parent: 1
+      pos: 5.5,7.5
   - uid: 572
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 5.5,6.5
-      parent: 1
   - uid: 573
     components:
     - type: Transform
-      pos: 4.5,7.5
       parent: 1
+      pos: 4.5,7.5
   - uid: 574
     components:
     - type: Transform
-      pos: 3.5,8.5
       parent: 1
+      pos: 3.5,8.5
   - uid: 575
     components:
     - type: Transform
-      pos: 3.5,7.5
       parent: 1
+      pos: 3.5,7.5
   - uid: 576
     components:
     - type: Transform
-      pos: 2.5,8.5
       parent: 1
+      pos: 2.5,8.5
   - uid: 577
     components:
     - type: Transform
-      pos: 2.5,9.5
       parent: 1
+      pos: 2.5,9.5
   - uid: 578
     components:
     - type: Transform
-      pos: -1.5,9.5
       parent: 1
+      pos: -1.5,9.5
   - uid: 579
     components:
     - type: Transform
-      pos: -1.5,8.5
       parent: 1
+      pos: -1.5,8.5
   - uid: 580
     components:
     - type: Transform
-      pos: -2.5,8.5
       parent: 1
+      pos: -2.5,8.5
   - uid: 581
     components:
     - type: Transform
-      pos: -2.5,7.5
       parent: 1
+      pos: -2.5,7.5
   - uid: 582
     components:
     - type: Transform
-      pos: -3.5,7.5
       parent: 1
+      pos: -3.5,7.5
   - uid: 583
     components:
     - type: Transform
-      pos: -4.5,7.5
       parent: 1
+      pos: -4.5,7.5
   - uid: 584
     components:
     - type: Transform
-      pos: -4.5,6.5
       parent: 1
+      pos: -4.5,6.5
   - uid: 585
     components:
     - type: Transform
-      pos: -5.5,6.5
       parent: 1
+      pos: -5.5,6.5
   - uid: 586
     components:
     - type: Transform
-      pos: -5.5,5.5
       parent: 1
+      pos: -5.5,5.5
   - uid: 587
     components:
     - type: Transform
-      pos: -6.5,5.5
       parent: 1
+      pos: -6.5,5.5
   - uid: 588
     components:
     - type: Transform
-      pos: -6.5,4.5
       parent: 1
+      pos: -6.5,4.5
   - uid: 589
     components:
     - type: Transform
-      pos: -6.5,3.5
       parent: 1
+      pos: -6.5,3.5
   - uid: 590
     components:
     - type: Transform
-      pos: -7.5,3.5
       parent: 1
+      pos: -7.5,3.5
   - uid: 591
     components:
     - type: Transform
-      pos: -7.5,2.5
       parent: 1
+      pos: -7.5,2.5
   - uid: 592
     components:
     - type: Transform
-      pos: -8.5,2.5
       parent: 1
+      pos: -8.5,2.5
   - uid: 593
     components:
     - type: Transform
-      pos: -8.5,1.5
       parent: 1
+      pos: -8.5,1.5
   - uid: 594
     components:
     - type: Transform
-      pos: -8.5,0.5
       parent: 1
+      pos: -8.5,0.5
   - uid: 595
     components:
     - type: Transform
-      pos: -8.5,-0.5
       parent: 1
+      pos: -8.5,-0.5
   - uid: 596
     components:
     - type: Transform
-      pos: -7.5,-0.5
       parent: 1
+      pos: -7.5,-0.5
   - uid: 597
     components:
     - type: Transform
-      pos: -8.5,-1.5
       parent: 1
+      pos: -8.5,-1.5
   - uid: 598
     components:
     - type: Transform
-      pos: -7.5,-1.5
       parent: 1
+      pos: -7.5,-1.5
   - uid: 599
     components:
     - type: Transform
-      pos: -7.5,-2.5
       parent: 1
+      pos: -7.5,-2.5
   - uid: 600
     components:
     - type: Transform
-      pos: -6.5,-2.5
       parent: 1
+      pos: -6.5,-2.5
   - uid: 601
     components:
     - type: Transform
-      pos: -6.5,-3.5
       parent: 1
+      pos: -6.5,-3.5
   - uid: 602
     components:
     - type: Transform
-      pos: -6.5,-4.5
       parent: 1
+      pos: -6.5,-4.5
   - uid: 603
     components:
     - type: Transform
-      pos: -5.5,-4.5
       parent: 1
+      pos: -5.5,-4.5
   - uid: 604
     components:
     - type: Transform
-      pos: -5.5,-5.5
       parent: 1
+      pos: -5.5,-5.5
   - uid: 605
     components:
     - type: Transform
-      pos: -4.5,-5.5
       parent: 1
+      pos: -4.5,-5.5
   - uid: 606
     components:
     - type: Transform
-      pos: -4.5,-6.5
       parent: 1
+      pos: -4.5,-6.5
   - uid: 607
     components:
     - type: Transform
-      pos: -3.5,-6.5
       parent: 1
+      pos: -3.5,-6.5
   - uid: 608
     components:
     - type: Transform
-      pos: -2.5,-6.5
       parent: 1
+      pos: -2.5,-6.5
   - uid: 609
     components:
     - type: Transform
-      pos: -2.5,-7.5
       parent: 1
+      pos: -2.5,-7.5
   - uid: 610
     components:
     - type: Transform
-      pos: -1.5,-7.5
       parent: 1
+      pos: -1.5,-7.5
   - uid: 611
     components:
     - type: Transform
-      pos: -1.5,-8.5
       parent: 1
+      pos: -1.5,-8.5
   - uid: 612
     components:
     - type: Transform
-      pos: -0.5,-8.5
       parent: 1
+      pos: -0.5,-8.5
   - uid: 613
     components:
     - type: Transform
-      pos: -0.5,-7.5
       parent: 1
+      pos: -0.5,-7.5
   - uid: 614
     components:
     - type: Transform
-      pos: 1.5,-7.5
       parent: 1
+      pos: 1.5,-7.5
   - uid: 615
     components:
     - type: Transform
-      pos: 3.5,-6.5
       parent: 1
+      pos: 3.5,-6.5
   - uid: 616
     components:
     - type: Transform
-      pos: 5.5,-5.5
       parent: 1
+      pos: 5.5,-5.5
   - uid: 617
     components:
     - type: Transform
-      pos: 8.5,-1.5
       parent: 1
+      pos: 8.5,-1.5
   - uid: 618
     components:
     - type: Transform
-      pos: 9.5,-0.5
       parent: 1
+      pos: 9.5,-0.5
   - uid: 619
     components:
     - type: Transform
-      pos: 8.5,-0.5
       parent: 1
+      pos: 8.5,-0.5
   - uid: 620
     components:
     - type: Transform
-      pos: 9.5,2.5
       parent: 1
+      pos: 9.5,2.5
   - uid: 621
     components:
     - type: Transform
-      pos: -7.5,1.5
       parent: 1
+      pos: -7.5,1.5
   - uid: 622
     components:
     - type: Transform
-      pos: -7.5,0.5
       parent: 1
+      pos: -7.5,0.5
   - uid: 623
     components:
     - type: Transform
-      pos: -5.5,4.5
       parent: 1
+      pos: -5.5,4.5
   - uid: 624
     components:
     - type: Transform
-      pos: -4.5,5.5
       parent: 1
+      pos: -4.5,5.5
   - uid: 625
     components:
     - type: Transform
-      pos: -4.5,-2.5
       parent: 1
+      pos: -4.5,-2.5
   - uid: 626
     components:
     - type: Transform
-      pos: 9.5,0.5
       parent: 1
+      pos: 9.5,0.5
   - uid: 627
     components:
     - type: Transform
-      pos: 8.5,0.5
       parent: 1
+      pos: 8.5,0.5
   - uid: 628
     components:
     - type: Transform
-      pos: 0.5,-7.5
       parent: 1
+      pos: 0.5,-7.5
   - uid: 629
     components:
     - type: Transform
-      pos: 11.5,2.5
       parent: 1
+      pos: 11.5,2.5
   - uid: 630
     components:
     - type: Transform
-      pos: 11.5,1.5
       parent: 1
+      pos: 11.5,1.5
   - uid: 631
     components:
     - type: Transform
-      pos: 11.5,0.5
       parent: 1
+      pos: 11.5,0.5
   - uid: 632
     components:
     - type: Transform
-      pos: 11.5,-0.5
       parent: 1
+      pos: 11.5,-0.5
   - uid: 633
     components:
     - type: Transform
-      pos: 11.5,-1.5
       parent: 1
+      pos: 11.5,-1.5
   - uid: 634
     components:
     - type: Transform
-      pos: -1.5,-10.5
       parent: 1
+      pos: -1.5,-10.5
   - uid: 635
     components:
     - type: Transform
-      pos: -0.5,-10.5
       parent: 1
+      pos: -0.5,-10.5
   - uid: 636
     components:
     - type: Transform
-      pos: 0.5,-10.5
       parent: 1
+      pos: 0.5,-10.5
   - uid: 637
     components:
     - type: Transform
-      pos: 1.5,-10.5
       parent: 1
+      pos: 1.5,-10.5
   - uid: 638
     components:
     - type: Transform
-      pos: 2.5,-10.5
       parent: 1
+      pos: 2.5,-10.5
   - uid: 639
     components:
     - type: Transform
-      pos: 3.5,-10.5
       parent: 1
+      pos: 3.5,-10.5
   - uid: 640
     components:
     - type: Transform
-      pos: -2.5,-10.5
       parent: 1
+      pos: -2.5,-10.5
   - uid: 641
     components:
     - type: Transform
-      pos: -3.5,-9.5
       parent: 1
+      pos: -3.5,-9.5
   - uid: 642
     components:
     - type: Transform
-      pos: -4.5,-8.5
       parent: 1
+      pos: -4.5,-8.5
   - uid: 643
     components:
     - type: Transform
-      pos: -5.5,-8.5
       parent: 1
+      pos: -5.5,-8.5
   - uid: 644
     components:
     - type: Transform
-      pos: -6.5,-7.5
       parent: 1
+      pos: -6.5,-7.5
   - uid: 645
     components:
     - type: Transform
-      pos: -7.5,-6.5
       parent: 1
+      pos: -7.5,-6.5
   - uid: 646
     components:
     - type: Transform
-      pos: -8.5,-5.5
       parent: 1
+      pos: -8.5,-5.5
   - uid: 647
     components:
     - type: Transform
-      pos: -8.5,-4.5
       parent: 1
+      pos: -8.5,-4.5
   - uid: 648
     components:
     - type: Transform
-      pos: -9.5,-3.5
       parent: 1
+      pos: -9.5,-3.5
   - uid: 649
     components:
     - type: Transform
-      pos: -10.5,-2.5
       parent: 1
+      pos: -10.5,-2.5
   - uid: 650
     components:
     - type: Transform
-      pos: -10.5,-0.5
       parent: 1
+      pos: -10.5,-0.5
   - uid: 651
     components:
     - type: Transform
-      pos: -10.5,0.5
       parent: 1
+      pos: -10.5,0.5
   - uid: 652
     components:
     - type: Transform
-      pos: -10.5,1.5
       parent: 1
+      pos: -10.5,1.5
   - uid: 653
     components:
     - type: Transform
-      pos: -10.5,2.5
       parent: 1
+      pos: -10.5,2.5
   - uid: 654
     components:
     - type: Transform
-      pos: -10.5,-1.5
       parent: 1
+      pos: -10.5,-1.5
   - uid: 655
     components:
     - type: Transform
-      pos: -10.5,3.5
       parent: 1
+      pos: -10.5,3.5
   - uid: 656
     components:
     - type: Transform
-      pos: -9.5,4.5
       parent: 1
+      pos: -9.5,4.5
   - uid: 657
     components:
     - type: Transform
-      pos: -8.5,5.5
       parent: 1
+      pos: -8.5,5.5
   - uid: 658
     components:
     - type: Transform
-      pos: -8.5,6.5
       parent: 1
+      pos: -8.5,6.5
   - uid: 659
     components:
     - type: Transform
-      pos: 11.5,-2.5
       parent: 1
+      pos: 11.5,-2.5
   - uid: 660
     components:
     - type: Transform
-      pos: 10.5,-3.5
       parent: 1
+      pos: 10.5,-3.5
   - uid: 661
     components:
     - type: Transform
-      pos: 9.5,-4.5
       parent: 1
+      pos: 9.5,-4.5
   - uid: 662
     components:
     - type: Transform
-      pos: 9.5,-5.5
       parent: 1
+      pos: 9.5,-5.5
   - uid: 663
     components:
     - type: Transform
-      pos: 8.5,-6.5
       parent: 1
+      pos: 8.5,-6.5
   - uid: 664
     components:
     - type: Transform
-      pos: 7.5,-7.5
       parent: 1
+      pos: 7.5,-7.5
   - uid: 665
     components:
     - type: Transform
-      pos: 6.5,-8.5
       parent: 1
+      pos: 6.5,-8.5
   - uid: 666
     components:
     - type: Transform
-      pos: 5.5,-8.5
       parent: 1
+      pos: 5.5,-8.5
   - uid: 667
     components:
     - type: Transform
-      pos: 4.5,-9.5
       parent: 1
+      pos: 4.5,-9.5
   - uid: 668
     components:
     - type: Transform
-      pos: -7.5,7.5
       parent: 1
+      pos: -7.5,7.5
   - uid: 669
     components:
     - type: Transform
-      pos: -6.5,8.5
       parent: 1
+      pos: -6.5,8.5
   - uid: 670
     components:
     - type: Transform
-      pos: -5.5,9.5
       parent: 1
+      pos: -5.5,9.5
   - uid: 671
     components:
     - type: Transform
-      pos: -4.5,9.5
       parent: 1
+      pos: -4.5,9.5
   - uid: 672
     components:
     - type: Transform
-      pos: -3.5,10.5
       parent: 1
+      pos: -3.5,10.5
   - uid: 673
     components:
     - type: Transform
-      pos: -2.5,11.5
       parent: 1
+      pos: -2.5,11.5
   - uid: 674
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 3.5,10.5
-      parent: 1
   - uid: 675
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 4.5,6.5
-      parent: 1
   - uid: 676
     components:
     - type: Transform
-      pos: -1.5,10.5
       parent: 1
+      pos: -1.5,10.5
   - uid: 677
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -2.5,10.5
-      parent: 1
   - uid: 678
     components:
     - type: Transform
-      pos: 3.5,11.5
       parent: 1
+      pos: 3.5,11.5
   - uid: 679
     components:
     - type: Transform
-      pos: 4.5,10.5
       parent: 1
+      pos: 4.5,10.5
   - uid: 680
     components:
     - type: Transform
-      pos: 6.5,9.5
       parent: 1
+      pos: 6.5,9.5
   - uid: 681
     components:
     - type: Transform
-      pos: 5.5,9.5
       parent: 1
+      pos: 5.5,9.5
   - uid: 682
     components:
     - type: Transform
-      pos: 7.5,8.5
       parent: 1
+      pos: 7.5,8.5
   - uid: 683
     components:
     - type: Transform
-      pos: 8.5,7.5
       parent: 1
+      pos: 8.5,7.5
   - uid: 684
     components:
     - type: Transform
-      pos: 9.5,6.5
       parent: 1
+      pos: 9.5,6.5
   - uid: 685
     components:
     - type: Transform
-      pos: 9.5,5.5
       parent: 1
+      pos: 9.5,5.5
   - uid: 686
     components:
     - type: Transform
-      pos: 10.5,4.5
       parent: 1
+      pos: 10.5,4.5
   - uid: 687
     components:
     - type: Transform
-      pos: 11.5,3.5
       parent: 1
+      pos: 11.5,3.5
   - uid: 688
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 2.5,-8.5
-      parent: 1
   - uid: 689
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -1.5,7.5
-      parent: 1
   - uid: 690
     components:
     - type: Transform
-      pos: 3.5,-5.5
       parent: 1
+      pos: 3.5,-5.5
   - uid: 691
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -1.5,3.5
-      parent: 1
   - uid: 692
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -3.5,-4.5
-      parent: 1
   - uid: 693
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -0.5,-5.5
-      parent: 1
   - uid: 694
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -1.5,-6.5
-      parent: 1
   - uid: 695
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -0.5,7.5
-      parent: 1
   - uid: 696
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -0.5,6.5
-      parent: 1
   - uid: 697
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -0.5,5.5
-      parent: 1
   - uid: 698
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -0.5,3.5
-      parent: 1
   - uid: 699
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 0.5,6.5
-      parent: 1
   - uid: 700
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 0.5,5.5
-      parent: 1
   - uid: 701
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 0.5,3.5
-      parent: 1
   - uid: 702
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 1.5,5.5
-      parent: 1
   - uid: 703
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 1.5,3.5
-      parent: 1
   - uid: 704
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,-2.5
-      parent: 1
   - uid: 705
     components:
     - type: Transform
-      pos: -5.5,-0.5
       parent: 1
+      pos: -5.5,-0.5
   - uid: 706
     components:
     - type: Transform
-      pos: -5.5,1.5
       parent: 1
+      pos: -5.5,1.5
   - uid: 707
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 2.5,-2.5
-      parent: 1
   - uid: 708
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 2.5,-6.5
-      parent: 1
   - uid: 709
     components:
     - type: Transform
-      pos: 3.5,0.5
       parent: 1
+      pos: 3.5,0.5
   - uid: 710
     components:
     - type: Transform
-      pos: 3.5,-1.5
       parent: 1
+      pos: 3.5,-1.5
   - uid: 711
     components:
     - type: Transform
-      pos: 3.5,-0.5
       parent: 1
+      pos: 3.5,-0.5
   - uid: 712
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 3.5,-2.5
-      parent: 1
   - uid: 713
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -2.5,-5.5
-      parent: 1
   - uid: 714
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 4.5,-0.5
-      parent: 1
   - uid: 715
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 1.5,-5.5
-      parent: 1
   - uid: 716
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 5.5,5.5
-      parent: 1
   - uid: 717
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 5.5,4.5
-      parent: 1
   - uid: 718
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 5.5,2.5
-      parent: 1
   - uid: 719
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 4.5,-1.5
-      parent: 1
   - uid: 720
     components:
     - type: Transform
-      pos: 0.5,-6.5
       parent: 1
+      pos: 0.5,-6.5
   - uid: 721
     components:
     - type: Transform
-      pos: 5.5,-3.5
       parent: 1
+      pos: 5.5,-3.5
   - uid: 722
     components:
     - type: Transform
-      pos: 1.5,-6.5
       parent: 1
+      pos: 1.5,-6.5
   - uid: 723
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 5.5,3.5
-      parent: 1
   - uid: 724
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 4.5,-5.5
-      parent: 1
   - uid: 725
     components:
     - type: Transform
-      pos: 3.5,-4.5
       parent: 1
+      pos: 3.5,-4.5
   - uid: 726
     components:
     - type: Transform
-      pos: -0.5,-6.5
       parent: 1
+      pos: -0.5,-6.5
   - uid: 727
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 6.5,1.5
-      parent: 1
   - uid: 728
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 6.5,2.5
-      parent: 1
   - uid: 729
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 6.5,4.5
-      parent: 1
   - uid: 730
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 6.5,3.5
-      parent: 1
   - uid: 731
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 7.5,2.5
-      parent: 1
   - uid: 732
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 7.5,1.5
-      parent: 1
   - uid: 733
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 2.5,-5.5
-      parent: 1
   - uid: 734
     components:
     - type: Transform
-      pos: -2.5,6.5
       parent: 1
+      pos: -2.5,6.5
   - uid: 735
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -3.5,-2.5
-      parent: 1
   - uid: 737
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -2.5,2.5
-      parent: 1
   - uid: 738
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -2.5,1.5
-      parent: 1
   - uid: 739
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -2.5,0.5
-      parent: 1
   - uid: 740
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -2.5,5.5
-      parent: 1
   - uid: 741
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -2.5,-0.5
-      parent: 1
   - uid: 742
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -2.5,-1.5
-      parent: 1
   - uid: 743
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 0.5,-5.5
-      parent: 1
   - uid: 744
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -3.5,-5.5
-      parent: 1
   - uid: 745
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -1.5,-5.5
-      parent: 1
   - uid: 746
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -2.5,-4.5
-      parent: 1
   - uid: 747
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -3.5,-1.5
-      parent: 1
   - uid: 748
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -3.5,-0.5
-      parent: 1
   - uid: 749
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -3.5,0.5
-      parent: 1
   - uid: 750
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -3.5,1.5
-      parent: 1
   - uid: 751
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -3.5,2.5
-      parent: 1
   - uid: 753
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
-      parent: 1
   - uid: 754
     components:
     - type: Transform
-      pos: -5.5,0.5
       parent: 1
+      pos: -5.5,0.5
   - uid: 755
     components:
     - type: Transform
-      pos: -4.5,3.5
       parent: 1
+      pos: -4.5,3.5
   - uid: 756
     components:
     - type: Transform
-      pos: -4.5,2.5
       parent: 1
+      pos: -4.5,2.5
   - uid: 757
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -4.5,-3.5
-      parent: 1
   - uid: 758
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -4.5,-4.5
-      parent: 1
   - uid: 759
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -5.5,-3.5
-      parent: 1
   - uid: 760
     components:
     - type: Transform
-      pos: -6.5,-1.5
       parent: 1
+      pos: -6.5,-1.5
   - uid: 761
     components:
     - type: Transform
-      pos: -6.5,2.5
       parent: 1
+      pos: -6.5,2.5
   - uid: 762
     components:
     - type: Transform
-      pos: -4.5,-1.5
       parent: 1
+      pos: -4.5,-1.5
   - uid: 763
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -5.5,3.5
-      parent: 1
   - uid: 764
     components:
     - type: Transform
-      pos: -6.5,-6.5
       parent: 1
+      pos: -6.5,-6.5
   - uid: 765
     components:
     - type: Transform
-      pos: -6.5,7.5
       parent: 1
+      pos: -6.5,7.5
   - uid: 766
     components:
     - type: Transform
-      pos: 7.5,7.5
       parent: 1
+      pos: 7.5,7.5
   - uid: 767
     components:
     - type: Transform
-      pos: 7.5,-6.5
       parent: 1
+      pos: 7.5,-6.5
   - uid: 768
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -1.5,2.5
-      parent: 1
   - uid: 769
     components:
     - type: Transform
-      pos: 2.5,10.5
       parent: 1
+      pos: 2.5,10.5
   - uid: 770
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -3.5,-3.5
-      parent: 1
   - uid: 771
     components:
     - type: Transform
-      pos: 3.5,-3.5
       parent: 1
+      pos: 3.5,-3.5
   - uid: 772
     components:
     - type: Transform
-      pos: 4.5,-3.5
       parent: 1
+      pos: 4.5,-3.5
   - uid: 773
     components:
     - type: Transform
-      pos: 6.5,-3.5
       parent: 1
+      pos: 6.5,-3.5
   - uid: 774
     components:
     - type: Transform
-      pos: 1.5,-3.5
       parent: 1
+      pos: 1.5,-3.5
   - uid: 775
     components:
     - type: Transform
-      pos: 5.5,-2.5
       parent: 1
+      pos: 5.5,-2.5
   - uid: 776
     components:
     - type: Transform
-      pos: 4.5,-2.5
       parent: 1
+      pos: 4.5,-2.5
   - uid: 777
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -1.5,-4.5
-      parent: 1
   - uid: 778
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 0.5,-2.5
-      parent: 1
 - proto: WallAbductorDiagonal
   entities:
   - uid: 779
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -1.5,-0.5
-      parent: 1
   - uid: 780
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -1.5,-2.5
-      parent: 1
   - uid: 781
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 5.5,1.5
-      parent: 1
   - uid: 782
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 4.5,0.5
-      parent: 1
   - uid: 783
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 4.5,2.5
-      parent: 1
   - uid: 784
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -1.5,1.5
-      parent: 1
   - uid: 785
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 3.5,1.5
-      parent: 1
   - uid: 786
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 11.5,-3.5
-      parent: 1
   - uid: 787
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 10.5,-4.5
-      parent: 1
   - uid: 788
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 9.5,-6.5
-      parent: 1
   - uid: 789
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 8.5,-7.5
-      parent: 1
   - uid: 790
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 7.5,-8.5
-      parent: 1
   - uid: 791
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,-9.5
-      parent: 1
   - uid: 792
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,-10.5
-      parent: 1
   - uid: 793
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -10.5,-3.5
-      parent: 1
   - uid: 794
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -9.5,-4.5
-      parent: 1
   - uid: 795
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -8.5,-6.5
-      parent: 1
   - uid: 796
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -7.5,-7.5
-      parent: 1
   - uid: 797
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -6.5,-8.5
-      parent: 1
   - uid: 798
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -4.5,-9.5
-      parent: 1
   - uid: 799
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -3.5,-10.5
-      parent: 1
   - uid: 800
     components:
     - type: Transform
-      pos: -10.5,4.5
       parent: 1
+      pos: -10.5,4.5
   - uid: 801
     components:
     - type: Transform
-      pos: -9.5,5.5
       parent: 1
+      pos: -9.5,5.5
   - uid: 802
     components:
     - type: Transform
-      pos: -8.5,7.5
       parent: 1
+      pos: -8.5,7.5
   - uid: 803
     components:
     - type: Transform
-      pos: -7.5,8.5
       parent: 1
+      pos: -7.5,8.5
   - uid: 804
     components:
     - type: Transform
-      pos: -6.5,9.5
       parent: 1
+      pos: -6.5,9.5
   - uid: 805
     components:
     - type: Transform
-      pos: -4.5,10.5
       parent: 1
+      pos: -4.5,10.5
   - uid: 806
     components:
     - type: Transform
-      pos: -3.5,11.5
       parent: 1
+      pos: -3.5,11.5
   - uid: 807
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 11.5,4.5
-      parent: 1
   - uid: 808
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 10.5,5.5
-      parent: 1
   - uid: 809
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 9.5,7.5
-      parent: 1
   - uid: 810
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 8.5,8.5
-      parent: 1
   - uid: 811
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 7.5,9.5
-      parent: 1
   - uid: 812
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 5.5,10.5
-      parent: 1
   - uid: 813
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 4.5,11.5
-      parent: 1
   - uid: 814
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 3.5,6.5
-      parent: 1
   - uid: 815
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 2.5,7.5
-      parent: 1
   - uid: 816
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 0.5,7.5
-      parent: 1
   - uid: 817
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 3.5,6.5
-      parent: 1
   - uid: 818
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 2.5,3.5
-      parent: 1
   - uid: 819
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 1.5,6.5
-      parent: 1
   - uid: 820
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 2.5,5.5
-      parent: 1
   - uid: 821
     components:
     - type: Transform
-      pos: 2.5,1.5
       parent: 1
+      pos: 2.5,1.5
   - uid: 822
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,2.5
-      parent: 1
   - uid: 823
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -0.5,-4.5
-      parent: 1
 - proto: XenoResinWindow
   entities:
   - uid: 824
     components:
     - type: Transform
-      pos: 2.5,11.5
       parent: 1
+      pos: 2.5,11.5
   - uid: 825
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -3.5,5.5
-      parent: 1
   - uid: 826
     components:
     - type: Transform
-      pos: -0.5,11.5
       parent: 1
+      pos: -0.5,11.5
   - uid: 827
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -1.5,5.5
-      parent: 1
   - uid: 828
     components:
     - type: Transform
-      pos: 0.5,11.5
       parent: 1
+      pos: 0.5,11.5
   - uid: 829
     components:
     - type: Transform
-      pos: 1.5,11.5
       parent: 1
+      pos: 1.5,11.5
   - uid: 830
     components:
     - type: Transform
-      pos: -1.5,11.5
       parent: 1
+      pos: -1.5,11.5
   - uid: 831
     components:
     - type: Transform
-      pos: -0.5,10.5
       parent: 1
+      pos: -0.5,10.5
   - uid: 832
     components:
     - type: Transform
-      pos: 1.5,10.5
       parent: 1
+      pos: 1.5,10.5
   - uid: 833
     components:
     - type: Transform
-      pos: 0.5,10.5
       parent: 1
+      pos: 0.5,10.5
 ...


### PR DESCRIPTION
## Short description
This fixes the abductor shuttle overpressurizing to 3 MPa when distro is turned on by removing the gas injectors from distro, moves and rotates a few devices to fix them being buried inside walls, labels several of the signal buttons so that it's a bit easier to parse, and links the atmos devices to the air alarm.

## Why we need to add this
Right now the shuttle overpressurizes aggressively if distro is turned on, because the air injectors force air out of the distribution pipes into the main room of the ship.

## Media (Video/Screenshots)
<img width="1038" height="1114" alt="image" src="https://github.com/user-attachments/assets/b979df2a-43b7-44c1-8dd6-7aa0ec03dde2" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**

:cl: Penguinwizzard
- fix: Abductor shuttle distro no longer targets 3MPa
- fix: Abductor shuttle devices no longer unintentionally buried in walls
- fix: More abductor shuttle signal buttons are labeled.
