### PR TITLE
Holographic Field DO NOT MAP marking

### DIFF
--- a/Content.Shared/_FarHorizons/GenericFieldGenerator/Components/GenericFieldGeneratorComponent.cs
+++ b/Content.Shared/_FarHorizons/GenericFieldGenerator/Components/GenericFieldGeneratorComponent.cs
@@ -46,7 +46,7 @@ public sealed partial class GenericFieldGeneratorComponent : Component
     /// The masks the raycast should not go through
     /// </summary>
     [DataField("collisionMask")]
-    public int CollisionMask = (int) (CollisionGroup.MobMask | CollisionGroup.Impassable | CollisionGroup.MachineMask | CollisionGroup.Opaque);
+    public int CollisionMask = (int)  CollisionGroup.Impassable ;
 
     /// <summary>
     /// A collection of connections that the generator has based on direction.

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Holographic/holofield.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Holographic/holofield.yml
@@ -258,7 +258,7 @@
   name: Holographic Field
   description: A Holographic Field that blocks airflow.
   suffix: DO NOT MAP
-  categories: [ HideSpawnMenu, DoNotMap ]
+  categories: [ DoNotMap ]
   placement:
     mode: SnapgridCenter
   components:
@@ -311,7 +311,7 @@
   name: Holographic Barrier
   description: A Holographic Barrier that blocks projectiles and crew.
   suffix: DO NOT MAP
-  categories: [ HideSpawnMenu, DoNotMap ]
+  categories: [ DoNotMap ]
   placement:
     mode: SnapgridCenter
   components:

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Holographic/holofield.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Holographic/holofield.yml
@@ -258,6 +258,7 @@
   name: Holographic Field
   description: A Holographic Field that blocks airflow.
   suffix: DO NOT MAP
+  categories: [ HideSpawnMenu, DoNotMap ]
   placement:
     mode: SnapgridCenter
   components:
@@ -310,6 +311,7 @@
   name: Holographic Barrier
   description: A Holographic Barrier that blocks projectiles and crew.
   suffix: DO NOT MAP
+  categories: [ HideSpawnMenu, DoNotMap ]
   placement:
     mode: SnapgridCenter
   components:

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Holographic/holofield.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Holographic/holofield.yml
@@ -257,6 +257,7 @@
   id: HolographicField
   name: Holographic Field
   description: A Holographic Field that blocks airflow.
+  suffix: DO NOT MAP
   placement:
     mode: SnapgridCenter
   components:
@@ -308,6 +309,7 @@
   id: HolographicFieldBarrier
   name: Holographic Barrier
   description: A Holographic Barrier that blocks projectiles and crew.
+  suffix: DO NOT MAP
   placement:
     mode: SnapgridCenter
   components:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
marks the 2 holographic fields as DO NOT MAP to prevent future issues.
also updated the mask used to check if a field can be formed to only use the Impassable mask
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
https://discord.com/channels/1407077238876147783/1543701218306826251
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/4fc83811-4888-4ae0-bec9-8406b86c77a4


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: KarusKardin
- tweak: Marked HolographicField as DO NOT MAP
- tweak: Marked HolographicFieldBarrier as DO NOT MAP
- tweak: The Holographic Generator cannot be stopped by your weak flesh, only a solid wall of steel can stop it. (Impassable Mask)
