### PR TITLE
Antag Encryption Key Tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -327,7 +327,7 @@
     - type: ContainerFill
       containers:
         key_slots:
-        - EncryptionKeyStationMaster
+        - EncryptionKeyBlackmarket #FH
     - type: Sprite
       sprite: Clothing/Ears/Headsets/wizard.rsi
     - type: Clothing
@@ -345,3 +345,10 @@
     sprite: Clothing/Ears/Headsets/ninja.rsi
   - type: EmpResistance
     strengthMultiplier: 0
+  - type: ContainerFill #FH start
+    containers:
+      key_slots:
+      - EncryptionKeyCommon
+      - EncryptionKeySyndiCommon 
+  - type: EncryptionKeyHolder
+    keySlots: 5 #FH end

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -174,7 +174,7 @@
     - type: ContainerFill
       containers:
         key_slots:
-        - EncryptionKeyStationMaster
+        - EncryptionKeyBlackmarket #FH
     - type: Sprite
       sprite: Clothing/Ears/Headsets/wizard.rsi
     - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -66,6 +66,7 @@
     containers:
       key_slots:
       - EncryptionKeyCommon
+      - EncryptionKeySyndiCommon #FH
   - type: IPCRadio #Far Horizons
     copyHeadsetKeys: true
   - type: EncryptionKeyHolder #Starlight pAI comms rework, see PR #3299

--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -29,7 +29,7 @@
     outerClothing: ClothingOuterSuitSpaceNinja
     shoes: ClothingShoesSpaceNinja
     id: AgentIDCard
-    ears: ClothingHeadsetAssistantNinja # Starlight
+    ears: ClothingHeadsetNinja # Starlight #FH, the green headset is better
     pocket1: SpiderCharge
     pocket2: PinpointerStation
     belt: EnergyKatana

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Ears/headsets_alt.yml
@@ -25,7 +25,7 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyStationMaster
+      - EncryptionKeyBlackmarket #FH
   - type: Sprite
     sprite: _Starlight/Clothing/Ears/Headsets/abductor.rsi
   - type: Clothing


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Updates several antag radios that previously used EncryptionKeyStationMaster to instead use EncryptionKeyBlackmarket
also gives ninja their cool green headset back
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Several antags are missing comms they would normally have on an NT station
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="368" height="231" alt="dotnet_czQGH47QBJ" src="https://github.com/user-attachments/assets/1bff77b7-4239-4047-89cb-50000add19f5" />
<img width="359" height="539" alt="dotnet_uC5kWROQtz" src="https://github.com/user-attachments/assets/e626abd8-2970-43d6-8b58-251602538e59" />
<img width="375" height="562" alt="dotnet_rUsWrpQF9a" src="https://github.com/user-attachments/assets/25a95fd7-a303-42e5-a04f-09f79c54c9e9" />
<img width="372" height="555" alt="dotnet_odbBn6lLwH" src="https://github.com/user-attachments/assets/216037a2-728c-4ebb-b795-ec79b1f2a0a9" />

https://github.com/user-attachments/assets/99e16b79-0e11-41d8-bb44-d2c485018580


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: KarusKardin
- tweak: Swapped Ninja's Headset back to their original green headset
- tweak: Gave Ninja's Headset an EncryptionKeySyndiCommon and slightly increased the number of encryption keys it can fit
- tweak: replaced EncryptionKeyStationMaster used by Abductors and Wizards with EncryptionKeyBlackmarket