### PR TITLE
Nerf nuggets

### DIFF
--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -60,6 +60,8 @@ namespace Content.Server.Atmos.EntitySystems
 
         private readonly Dictionary<Entity<FlammableComponent>, float> _fireEvents = new();
 
+        private const float LIMB_DAMAGE_MULTIPLIER = 2f; // Far Horizons - deal this much more damage to limbs as dealt to torso (damage is randomly split between all available limbs)
+
         public override void Initialize()
         {
             UpdatesAfter.Add(typeof(AtmosphereSystem));
@@ -464,7 +466,7 @@ namespace Content.Server.Atmos.EntitySystems
                         _inventory.RelayEvent((uid, inv), ref ev);
 
                     _damageableSystem.TryChangeDamage(uid, flammable.Damage * flammable.FireStacks * ev.Multiplier, interruptsDoAfters: false);
-                    _limbDamage.ChangeDamageAll(uid, flammable.Damage * flammable.FireStacks * ev.Multiplier, interruptsDoAfters: false); // Far Horizons
+                    _limbDamage.ChangeDamageRandom(uid, flammable.Damage * flammable.FireStacks * ev.Multiplier * LIMB_DAMAGE_MULTIPLIER, interruptsDoAfters: false); // Far Horizons
 
                     AdjustFireStacks(uid, flammable.FirestackFade * (flammable.Resisting ? 15f : 1f), flammable, flammable.OnFire);
                 }

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -63,6 +63,8 @@ public sealed partial class ExplosionSystem
 
     private List<EntityUid> _anchored = new();
 
+    private const float LIMB_DAMAGE_MULTIPLIER = 4f; // Far Horizons - deal this much more damage to limbs as dealt to torso (damage is randomly split between all available limbs)
+
     private void OnMapRemoved(MapRemovedEvent ev)
     {
         // If a map was deleted, check the explosion currently being processed belongs to that map.
@@ -455,7 +457,7 @@ public sealed partial class ExplosionSystem
 
                 // Far Horizons
                 if (_limbDamageableQuery.TryComp(entity, out var damageableLimb))
-                    _limbDamage.ChangeDamageAll((entity, damageableLimb), damage, ignoreResistances: true, ignoreGlobalModifiers: true);
+                    _limbDamage.ChangeDamageRandom((entity, damageableLimb), damage * LIMB_DAMAGE_MULTIPLIER, ignoreResistances: true, ignoreGlobalModifiers: true);
                 
                 // TODO EXPLOSIONS turn explosions into entities, and pass the the entity in as the damage origin.
                 _damageableSystem.TryChangeDamage((entity, damageable), damage, ignoreResistances: true, ignoreGlobalModifiers: true);

--- a/Content.Server/Temperature/Systems/TemperatureSystem.Damage.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.Damage.cs
@@ -52,6 +52,8 @@ public sealed partial class TemperatureSystem
     /// </summary>
     public static readonly float MinAlertTemperatureScale = 0.33f;
 
+    private const float LIMB_DAMAGE_MULTIPLIER = 2f; // Far Horizons - deal this much more damage to limbs as dealt to torso (damage is randomly split between all available limbs)
+
     private void InitializeDamage()
     {
         SubscribeLocalEvent<AlertsComponent, OnTemperatureChangeEvent>(ServerAlert);
@@ -115,7 +117,7 @@ public sealed partial class TemperatureSystem
             var diff = Math.Abs(temperature.CurrentTemperature - heatDamageThreshold);
             var tempDamage = c / (1 + a * Math.Pow(Math.E, -heatK * diff)) - y;
             _damageable.TryChangeDamage(entity.Owner, entity.Comp.HeatDamage * tempDamage * deltaTime.TotalSeconds, ignoreResistances: true, interruptsDoAfters: false);
-            _limbDamage.ChangeDamageAll(entity.Owner, entity.Comp.HeatDamage * tempDamage * deltaTime.TotalSeconds, ignoreResistances: true, interruptsDoAfters: false); // Far Horizons
+            _limbDamage.ChangeDamageRandom(entity.Owner, entity.Comp.HeatDamage * tempDamage * deltaTime.TotalSeconds * LIMB_DAMAGE_MULTIPLIER, ignoreResistances: true, interruptsDoAfters: false); // Far Horizons
         }
         else if (temperature.CurrentTemperature <= coldDamageThreshold)
         {
@@ -129,7 +131,7 @@ public sealed partial class TemperatureSystem
             var tempDamage =
                 Math.Sqrt(diff * (Math.Pow(entity.Comp.DamageCap.Double(), 2) / coldDamageThreshold));
             _damageable.TryChangeDamage(entity.Owner, entity.Comp.ColdDamage * tempDamage * deltaTime.TotalSeconds, ignoreResistances: true, interruptsDoAfters: false);
-            _limbDamage.ChangeDamageAll(entity.Owner, entity.Comp.ColdDamage * tempDamage * deltaTime.TotalSeconds, ignoreResistances: true, interruptsDoAfters: false); // Far Horizons
+            _limbDamage.ChangeDamageRandom(entity.Owner, entity.Comp.ColdDamage * tempDamage * deltaTime.TotalSeconds * LIMB_DAMAGE_MULTIPLIER, ignoreResistances: true, interruptsDoAfters: false); // Far Horizons
         }
         else if (entity.Comp.TakingDamage)
         {

--- a/Content.Server/_FarHorizons/Telegraphs/Effects/TelegraphDealDamageOnTriggerSystem.cs
+++ b/Content.Server/_FarHorizons/Telegraphs/Effects/TelegraphDealDamageOnTriggerSystem.cs
@@ -13,6 +13,8 @@ public sealed partial class TelegraphDealDamageOnTriggerSystem : EntitySystem
     [Dependency] private DamageableSystem _damage = default!;
     [Dependency] private LimbDamageSystem _limbDamage = default!;
 
+    private const float RANDOM_LIMB_DAMAGE_MULTIPLIER = 2f; // Deal this much more damage to limbs as dealt to torso (damage is randomly split between all available limbs), when dealt randomly
+
     public override void Initialize()
     {
         base.Initialize();
@@ -30,9 +32,15 @@ public sealed partial class TelegraphDealDamageOnTriggerSystem : EntitySystem
         {
             _damage.TryChangeDamage(targetEnt.AsNullable(), ent.Comp.Damage, ent.Comp.IgnoreResistances);
 
+            LimbDamageableComponent? limbDamage = null;
+
             if (ent.Comp.AllLimbs &&
-                TryComp<LimbDamageableComponent>(targetEnt, out var limbDamage))
+                Resolve(targetEnt, ref limbDamage))
                 _limbDamage.ChangeDamageAll((targetEnt, limbDamage), ent.Comp.Damage, ent.Comp.IgnoreResistances);
+            else
+            if (ent.Comp.RandomLimbs &&
+                Resolve(targetEnt, ref limbDamage))
+                _limbDamage.ChangeDamageRandom((targetEnt, limbDamage), ent.Comp.Damage * RANDOM_LIMB_DAMAGE_MULTIPLIER, ent.Comp.IgnoreResistances);
         }
     }
 }

--- a/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.API.cs
+++ b/Content.Shared/_FarHorizons/LimbDamage/LimbDamageSystem.API.cs
@@ -6,8 +6,10 @@ using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
 using Content.Shared.Medical.Healing;
+using Content.Shared.Random.Helpers;
 using Content.Shared.Tag;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
 namespace Content.Shared._FarHorizons.LimbDamage;
@@ -71,6 +73,48 @@ public partial class LimbDamageSystem
         foreach (var limb in allLimbs)
             _damageable.ChangeDamage(limb.Owner, damage, ignoreResistances, interruptsDoAfters, origin,
                 ignoreGlobalModifiers, armorPenetration, canHeal);
+    }
+
+    public void ChangeDamageRandom(Entity<LimbDamageableComponent?> target, DamageSpecifier damage,
+        bool ignoreResistances = false, bool interruptsDoAfters = true, EntityUid? origin = null,
+        bool ignoreGlobalModifiers = false, float armorPenetration = 0, bool canHeal = true)
+    {
+        if (!Resolve(target, ref target.Comp, false))
+            return;
+        
+        var allLimbs = GetAllDamageable(target);
+        if (allLimbs.Count == 0)
+            return;
+        
+        var random = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(target.Owner));
+
+        if (allLimbs.Count == 1)
+        {
+            _damageable.ChangeDamage(allLimbs[0].Owner, damage, ignoreResistances, interruptsDoAfters, origin,
+                ignoreGlobalModifiers, armorPenetration, canHeal);
+            return;
+        }
+
+        var weights = new float[allLimbs.Count];
+        var totalWeight = 0f;
+        const float Min = 0.05f;
+        const float Max = 1.0f;
+
+        for (var i = 0; i < weights.Length; i++)
+        {
+            var weight = Min + (random.NextSingle() * (Max - Min));
+            weights[i] = weight;
+            totalWeight += weight;
+        }
+
+        for (var i = 0; i < allLimbs.Count; i++)
+        {
+            var proportion = weights[i] / totalWeight;
+            var limbDamage = damage * proportion;
+
+            _damageable.ChangeDamage(allLimbs[i].Owner, limbDamage, ignoreResistances, interruptsDoAfters, origin,
+                ignoreGlobalModifiers, armorPenetration, canHeal);
+        }
     }
 
     public DamageSpecifier HealAllEvenly(Entity<LimbDamageableComponent?> target, FixedPoint2 amount,

--- a/Content.Shared/_FarHorizons/Telegraphs/Effects/TelegraphDealDamageOnTriggerComponent.cs
+++ b/Content.Shared/_FarHorizons/Telegraphs/Effects/TelegraphDealDamageOnTriggerComponent.cs
@@ -7,5 +7,6 @@ public sealed partial class TelegraphDealDamageOnTriggerComponent : Component
 {
     [DataField(required: true)] public DamageSpecifier Damage;
     [DataField] public bool IgnoreResistances;
-    [DataField] public bool AllLimbs = true;
+    [DataField] public bool AllLimbs;
+    [DataField] public bool RandomLimbs;
 }

--- a/Resources/Prototypes/_FarHorizons/Body/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/ipc.yml
@@ -239,7 +239,7 @@
       - Inorganic
 
 - type: entity
-  parent: [ DamageableLimbVisualsIPC, OrganBaseHeadVitalNonEdible, OrganIPCExternal ]
+  parent: [ DamageableLimbVisualsIPC, OrganBaseHeadNonVitalNonEdible, OrganIPCExternal ]
   id: OrganIPCHead
   components:
   - type: Sprite
@@ -252,6 +252,21 @@
   - type: Tag
     tags:
       - Inorganic
+  - type: LimbDamageEffect
+    effects:
+      - effect: !type:LimbEffectDetach
+        condition: !type:LimbConditionSpecificDamage
+          damageType: Slash
+          damageAmount: 100 # -50 over base since it's non vital
+      - effect: !type:LimbEffectDestroy
+        condition: !type:LimbConditionOr
+          conditions:
+            - !type:LimbConditionSpecificDamage
+              damageType: Blunt
+              damageAmount: 250
+            - !type:LimbConditionSpecificDamage
+              damageType: Heat
+              damageAmount: 2000 # +500 over base
 
 - type: entity
   parent: [ DamageableLimbVisualsIPC, OrganBaseArmLeftNonEdible, OrganIPCExternal ]
@@ -280,7 +295,7 @@
               damageAmount: 250
             - !type:LimbConditionSpecificDamage
               damageType: Heat
-              damageAmount: 500
+              damageAmount: 750 # + 250 over base
   - type: Tag
     tags:
       - Inorganic
@@ -312,7 +327,7 @@
               damageAmount: 250
             - !type:LimbConditionSpecificDamage
               damageType: Heat
-              damageAmount: 500
+              damageAmount: 750 # + 250 over base
   - type: Tag
     tags:
       - Inorganic
@@ -344,7 +359,7 @@
               damageAmount: 150
             - !type:LimbConditionSpecificDamage
               damageType: Heat
-              damageAmount: 300
+              damageAmount: 500 # +200 over base
   - type: Tag
     tags:
       - Inorganic
@@ -376,7 +391,7 @@
               damageAmount: 150
             - !type:LimbConditionSpecificDamage
               damageType: Heat
-              damageAmount: 300
+              damageAmount: 500 # +200 over base
   - type: Tag
     tags:
       - Inorganic
@@ -411,7 +426,7 @@
               damageAmount: 250
             - !type:LimbConditionSpecificDamage
               damageType: Heat
-              damageAmount: 500
+              damageAmount: 750 # + 250 over base
   - type: Tag
     tags:
       - Inorganic
@@ -446,7 +461,7 @@
               damageAmount: 250
             - !type:LimbConditionSpecificDamage
               damageType: Heat
-              damageAmount: 500
+              damageAmount: 750 # + 250 over base
   - type: Tag
     tags:
       - Inorganic
@@ -481,7 +496,7 @@
               damageAmount: 150
             - !type:LimbConditionSpecificDamage
               damageType: Heat
-              damageAmount: 300
+              damageAmount: 500 # +200 over base
   - type: Tag
     tags:
       - Inorganic
@@ -516,7 +531,7 @@
               damageAmount: 150
             - !type:LimbConditionSpecificDamage
               damageType: Heat
-              damageAmount: 300
+              damageAmount: 500 # +200 over base
   - type: Tag
     tags:
       - Inorganic

--- a/Resources/Prototypes/_FarHorizons/Entities/Telegraphs/elder.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Telegraphs/elder.yml
@@ -110,6 +110,7 @@
           Blunt: 20
           Cold: 10
           Structural: 100
+      randomLimbs: true
     - type: TelegraphSpawnVFXEntityOnTrigger
       entity: EffectGravityPulse
     - type: TelegraphPlaySoundOnTrigger
@@ -418,6 +419,7 @@
           Blunt: 15
           Cold: 5
           Structural: 100
+      randomLimbs: true
     - type: TelegraphFollowupAttackOnTrigger
       entity: TelegraphBossElderWarningShotLingering
     - type: TelegraphSpawnVFXEntityOnTrigger
@@ -533,6 +535,7 @@
           Blunt: 10
           Cold: 10
           Structural: 50
+      randomLimbs: true
     - type: TelegraphSpawnVFXEntityOnTrigger
       entity: EffectGravityPulse
     - type: TelegraphPlaySoundOnTrigger
@@ -856,6 +859,7 @@
           Blunt: 40
           Cold: 130
           Structural: 200
+      randomLimbs: true
     - type: TelegraphElderBossHealingDecoy
       decoy: MobElderDecoy
       numDecoys: 3
@@ -984,6 +988,7 @@
           Blunt: 20
           Cold: 10
           Structural: 50
+      randomLimbs: true
     - type: TelegraphSpawnVFXEntityOnTrigger
       entity: EffectGravityPulse
     - type: TelegraphDeleteEntityOnTrigger
@@ -1184,6 +1189,7 @@
           Blunt: 50
           Cold: 30
           Structural: 50
+      randomLimbs: true
 
 - type: entity
   id: TelegraphBossElderFinalShowdownLingering


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Less situations when people lose all limbs at once, which is really not fun

## Why we need to add this
fewer nuggets, especially metal kind.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/eec388a9-8302-47a7-9ca7-e919c9d4ecfc


https://github.com/user-attachments/assets/16299427-e7ac-4777-ab85-7b6d8783c8ff



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- add: Fire, temperature, explosions and salvage boss now damage limbs for less total damage and spread that damage around randomly
- remove: Salvage boss' lingering attacks will no longer damage limbs at all
- tweak: IPC head is no longer vital (pretty sure taking head off wouldn't kill you before, but now it won't try)
- tweak: Base IPC limbs have higher damage at which they will ash to account for heat weakness
