### PR TITLE
bag rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -1,40 +1,24 @@
+# FH start
 - type: entity
-  parent: [Clothing, ContentsExplosionResistanceBase]
+  parent: ClothingBackpackSatchel
   id: ClothingBackpack
-  name: Backpack #Far Horizons - The Great Capitalization Crusade
+  name: Backpack
   description: You wear this on your back and put items into it.
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/backpack.rsi
     state: icon
-  - type: Item
-    size: Ginormous #FH
-  - type: Clothing
-    quickEquip: false
-    slots:
-    - back
   - type: Storage
     grid:
-    - 0,0,6,3
-    maxItemSize: Ginormous #FH - Fix for not being able to fit storage containers that hold "huge" items, like guns.
-  - type: ContainerContainer
-    containers:
-      storagebase: !type:Container
-        ents: []
-  - type: UserInterface
-    interfaces:
-      enum.StorageUiKey.Key:
-        type: StorageBoundUserInterface
-  - type: SwitchableEquipMode # Starlight
-  # to prevent bag open/honk spam
-  - type: UseDelay
-    delay: 0.5
-  - type: ExplosionResistance
-    damageCoefficient: 0.9
-  - type: Tag
-    tags:
-    - WhitelistChameleon
-    - Backpack
+    - 0,0,1,3
+    - 3,0,6,5
+    - 8,0,9,3
+    maxItemSize: Ginormous
+  - type: ClothingSpeedModifier
+    walkModifier: 1
+    sprintModifier: 0.95
+  - type: HeldSpeedModifier
+# FH end
 
 - type: entity
   parent: ClothingBackpack

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -10,9 +10,9 @@
     state: icon
   - type: Storage
     grid:
-    - 0,0,1,3
+    - 0,2,1,5
     - 3,0,6,5
-    - 8,0,9,3
+    - 0,2,9,5
     maxItemSize: Ginormous
   - type: ClothingSpeedModifier
     walkModifier: 1

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -9,7 +9,7 @@
   - type: Storage
     maxItemSize: Ginormous #FH - Fix for not being able to fit storage containers that hold "huge" items, like guns.
     grid:
-    - 0,0,7,4
+    - 0,0,8,4 # FH
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 0.9

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -1,16 +1,43 @@
+# FH start
 - type: entity
-  parent: ClothingBackpack
+  parent: [Clothing, ContentsExplosionResistanceBase]
   id: ClothingBackpackSatchel
-  name: Satchel #Far Horizons - The Great Capitalization Crusade
+  name: Satchel
   description: A trendy looking satchel.
   components:
   - type: Sprite
     sprite: Clothing/Back/Satchels/satchel.rsi
+  - type: Item
+    size: Ginormous
+  - type: Clothing
+    quickEquip: false
+    slots:
+    - back
   - type: Storage
     grid:
     - 0,0,1,3
     - 3,0,6,3
     - 8,0,9,3
+    maxItemSize: Ginormous
+  - type: ContainerContainer
+    containers:
+      storagebase: !type:Container
+        ents: []
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
+  - type: SwitchableEquipMode
+  # to prevent bag open/honk spam
+  - type: UseDelay
+    delay: 0.5
+  - type: ExplosionResistance
+    damageCoefficient: 0.9
+  - type: Tag
+    tags:
+    - WhitelistChameleon
+    - Backpack
+# FH end
 
 - type: entity
   parent: ClothingBackpackSatchel

--- a/Resources/Prototypes/Entities/Clothing/Belt/waist_bags.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/waist_bags.yml
@@ -8,6 +8,8 @@
     sprite: Clothing/Belt/waistbag_leather.rsi
   - type: Clothing
     sprite: Clothing/Belt/waistbag_leather.rsi
+    slots:
+      - rig
   - type: Storage
     grid:
     - 0,0,3,1


### PR DESCRIPTION
## Short description
rebalancing bags (duffel gets a bit more space, backpack becomes an option between satchel and duffel instead of worse satch) + moving waist bag to the rig slot

## Why we need to add this
makes backpacks less useless and gives a non-job-specific rig slot option
discussion in https://discord.com/channels/1407077238876147783/1543745809672052816

## Media (Video/Screenshots)
satchel
<img width="360" height="135" alt="2026-09-02-201339_hyprshot" src="https://github.com/user-attachments/assets/e33fcb69-5565-4dff-a21a-bf6e2e304f45" />
backpack
<img width="362" height="201" alt="2026-09-02-201231_hyprshot" src="https://github.com/user-attachments/assets/a7644069-6b32-4aa6-a7fa-158707670c35" />
duffel bag
<img width="330" height="172" alt="2026-09-02-201246_hyprshot" src="https://github.com/user-attachments/assets/a1364a8c-3a65-44ec-a059-4cb0dcfbc719" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**

:cl: Killer Tamashi & qriqii
- tweak: Rebalanced backpacks to give them more space than satchels, at the cost of a 5% speed reduction.
- tweak: Increased duffel bag size by one column.
- tweak: Moved waist bag to rig slot.