### PR TITLE
Updated Manor to have a zookeeper station beacon

### DIFF
--- a/Resources/Maps/_FarHorizons/Stations/Manor.yml
+++ b/Resources/Maps/_FarHorizons/Stations/Manor.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 288.1.0
   forkId: ""
   forkVersion: ""
-  time: 08/20/2026 02:34:12
-  entityCount: 33875
+  time: 09/03/2026 06:44:05
+  entityCount: 33876
 maps:
 - 1
 grids:
@@ -85776,6 +85776,16 @@ entities:
     - type: Transform
       parent: 2
       pos: 21.5,4.5
+  - uid: 33876
+    components:
+    - type: Transform
+      parent: 2
+      pos: -29.5,16.5
+    - type: NavMapBeacon
+      text: Zookeepers Office
+      color: '#2EB82EFF'
+    - type: WarpPoint
+      location: Zookeepers Office
 - proto: DefaultStationBeaconSolars
   entities:
   - uid: 14297


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds a station beacon to Manor, allowing the Zookeepers office to be marked. This is one of four PR's making such a change to the various maps that have a zoo.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Generally going to make any zookeeper that latejoins have an easier time.
Also, gives me hope that yall wont do what SL did and nuke zookeepers due to low map maintenance around them.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="990" height="369" alt="image" src="https://github.com/user-attachments/assets/4ca88434-8438-4711-8905-635056e710c7" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: idkAnAlliasYetTbh
- add: (MANOR) Added a Station Beacon to the Zookeepers office.
