### PR TITLE
Make Quartermasters, Concord Liaisons and Affairs Officials show up in CommandFriends

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Medical/handheld_corpsman_crew_monitor.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Medical/handheld_corpsman_crew_monitor.yml
@@ -97,6 +97,8 @@
   - type: CrewMonitoringFilter
     shownDepartments:
     - "Command Jobs - Cybersun and Major Executives From Leading Companies"
+    - "Command Jobs"
+    - "Space Law Jobs - Concord Frontier Authority"
     alwaysShowTrackingImplants: true
 
 - type: entity

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/handheld_bso_crew_monitor.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/handheld_bso_crew_monitor.yml
@@ -23,6 +23,8 @@
   - type: CrewMonitoringFilter
     shownDepartments:
     - "Command Jobs - NT Executives" #FH
+    - "Command Jobs" #FH
+    - "Space Law Jobs - Concord Frontier Authority" #FH
     alwaysShowTrackingImplants: true
   - type: DeviceNetwork
     deviceNetId: Wireless


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
The way CommandFriends are currently coded makes it so only Command members from the same corporation show up (NT CommandFriend only shows NT Command, and viceversa).

However, that leaves behind Quartermasters and Concord Liaisons, who are also Command members and under the Blueshield/Redsword's protection, but belong to neither NanoTrasen or NeoSol, so they won't show up on CommandFriends unless they have a Tracker injected in them.

This also comes with a small pet peeve of mine, according to SOP, Affairs Officials are also considered Station Management, and as such, are also protected by the Blueshield/Redsword, yet I don't remember them ever appearing on CommandFriends either.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
So all of the Blueshield/Redsword charges show up in the CommandFriend.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1325" height="1075" alt="Captura de pantalla 2026-09-05 042214" src="https://github.com/user-attachments/assets/55cdf9e0-d62a-49e7-87ea-a951a195bad9" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: RubiconLocked
- tweak: CommandFriends now show all of the BSO/RSO's charges, instead of just NT or NS Command.
