### PR TITLE
Mechwright Screwdriver

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Tools/cyberlimb.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Tools/cyberlimb.yml
@@ -61,6 +61,12 @@
       - Screwing
     useSound:
       collection: Screwdriver
+  #FH Start
+  #- type: RandomSprite
+  #  available:
+  #    - enum.DamageStateVisualLayers.Base:
+  #        screwdriver: Rainbow
+  #FH End
   - type: PhysicalComposition
     materialComposition:
       Steel: 100

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Tools/cyberlimb.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Tools/cyberlimb.yml
@@ -61,10 +61,6 @@
       - Screwing
     useSound:
       collection: Screwdriver
-  - type: RandomSprite
-    available:
-      - enum.DamageStateVisualLayers.Base:
-          screwdriver: Rainbow
   - type: PhysicalComposition
     materialComposition:
       Steel: 100


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Removes the random color component from the mechwright arm screwdriver
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bug report: https://discord.com/channels/1407077238876147783/1545591290014466098
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="865" height="114" alt="image" src="https://github.com/user-attachments/assets/f96102e0-b900-4d64-ab0b-1d08352dca21" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Mizuki
- fix: Mechwright screwdriver is no longer randomly colored
