### PR TITLE
Require gravity to spread footprints

### DIFF
--- a/Content.Shared/_FarHorizons/Fluids/SharedFluidFootprintSystem.Spreading.cs
+++ b/Content.Shared/_FarHorizons/Fluids/SharedFluidFootprintSystem.Spreading.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using Content.Shared._FarHorizons.Fluids.Components;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Fluids.Components;
+using Content.Shared.Gravity;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Stunnable;
 using Robust.Shared.Map;
@@ -18,6 +19,8 @@ public abstract partial class SharedFluidFootprintSystem
         if (TerminatingOrDeleted(ent) || TerminatingOrDeleted(args.OtherEntity) ||
             (TryComp<BuckleComponent>(ent, out var buckle) && buckle.BuckledTo != null) ||
             HasComp<KnockedDownComponent>(ent) ||
+            !TryComp<GravityAffectedComponent>(ent, out var gravAffected) ||
+            gravAffected.Weightless ||
             !TryComp<FluidFootprintSourceComponent>(args.OtherEntity, out var source) ||
             !TryComp<PuddleComponent>(args.OtherEntity, out var puddle) ||
             !Solution.ResolveSolution(args.OtherEntity, puddle.SolutionName, ref puddle.Solution) ||
@@ -60,6 +63,8 @@ public abstract partial class SharedFluidFootprintSystem
         if (TerminatingOrDeleted(ent) || TerminatingOrDeleted(args.OtherEntity) ||
             !ent.Comp.BeingPulled ||
             (HasComp<FluidFootprintSpreaderComponent>(ent) && !HasComp<KnockedDownComponent>(ent)) ||
+            !TryComp<GravityAffectedComponent>(ent, out var gravAffected) ||
+            gravAffected.Weightless ||
             !TryComp<FluidFootprintSourceComponent>(args.OtherEntity, out var source) ||
             !TryComp<PuddleComponent>(args.OtherEntity, out var puddle) ||
             !Solution.ResolveSolution(args.OtherEntity, puddle.SolutionName, ref puddle.Solution) ||


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Footsprits won't spread in zero-g or when wearing moon boots

## Why we need to add this
fix?

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/4029d5ae-da8c-41d0-8d96-101ac8003e1c



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- fix: Footprints will not spread for a person that is floating in zero-g
