### PR TITLE
Genpop Automated Radio Announcment

### DIFF
--- a/Content.Server/Access/Systems/IdCardSystem.cs
+++ b/Content.Server/Access/Systems/IdCardSystem.cs
@@ -13,6 +13,9 @@ using Content.Shared.Popups;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Content.Server.Kitchen.EntitySystems;
+using Content.Shared.Security.Components; //FH
+using Content.Server.Radio.EntitySystems; //FH
+
 
 namespace Content.Server.Access.Systems;
 
@@ -23,6 +26,7 @@ public sealed partial class IdCardSystem : SharedIdCardSystem
     [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IAdminLogManager _adminLogger = default!;
     [Dependency] private CookingDeviceSystem _microwave = default!; // Starlight-edit
+    [Dependency] private RadioSystem _radio = default!; //FH
     [Dependency] private ChatSystem _chat = default!;
 
     public override void Initialize()
@@ -114,5 +118,14 @@ public sealed partial class IdCardSystem : SharedIdCardSystem
                 ChatTransmitRange.Normal,
                 true);
         }
+
+        //FH start
+        if (TryComp<IdCardComponent>(ent, out var idcomp) && TryComp<GenpopIdCardComponent>(ent, out var genpopcomp))
+            _radio.SendRadioMessage(ent,
+                Loc.GetString("genpop-prisoner-id-release", ("name", idcomp.FullName ?? "genpop-prisoner-name-default"), ("crime", genpopcomp.Crime)),
+                genpopcomp.RadioChannel,
+                ent,
+                escapeMarkup: false);
+        //FH end
     }
 }

--- a/Content.Server/Security/GenpopSystem.cs
+++ b/Content.Server/Security/GenpopSystem.cs
@@ -26,6 +26,7 @@ public sealed partial class GenpopSystem : SharedGenpopSystem
         {
             id.Crime = crime;
             id.SentenceDuration = TimeSpan.FromMinutes(sentence);
+            id.RadioChannel = ent.Comp.RadioChannel; //FH
             Dirty(uid, id);
         }
         if (sentence <= 0)

--- a/Content.Shared/Security/Components/GenpopIdCardComponent.cs
+++ b/Content.Shared/Security/Components/GenpopIdCardComponent.cs
@@ -1,4 +1,6 @@
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes; // FH
+using Content.Shared.Radio; // FH
 
 namespace Content.Shared.Security.Components;
 
@@ -19,4 +21,12 @@ public sealed partial class GenpopIdCardComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField, AutoPausedField]
     public TimeSpan SentenceDuration;
+
+    //FH start
+    /// <summary>
+    /// Channel to annouce expiration on
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public ProtoId<RadioChannelPrototype> RadioChannel = "Security";
+    //FH end
 }

--- a/Content.Shared/Security/Components/GenpopLockerComponent.cs
+++ b/Content.Shared/Security/Components/GenpopLockerComponent.cs
@@ -1,6 +1,7 @@
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Content.Shared.Radio; // FH
 
 namespace Content.Shared.Security.Components;
 
@@ -23,6 +24,14 @@ public sealed partial class GenpopLockerComponent : Component
     /// </summary>
     [DataField]
     public EntProtoId<GenpopIdCardComponent> IdCardProto = "PrisonerIDCard";
+
+    //FH start
+    /// <summary>
+    /// Channel to annouce expiration of prisoner Id on
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public ProtoId<RadioChannelPrototype> RadioChannel = "Security";
+    //FH end
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/_FarHorizons/access/components/genpop.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/access/components/genpop.ftl
@@ -1,0 +1,2 @@
+genpop-prisoner-id-release = {$name} has served their sentence for {$crime} and has been automatically released.
+genpop-prisoner-name-default = A prisoner

--- a/Resources/Locale/en-US/_FarHorizons/access/components/genpop.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/access/components/genpop.ftl
@@ -1,2 +1,2 @@
-genpop-prisoner-id-release = {CAPITALIZE($ent)} { CONJUGATE-HAVE($ent) } served { POSS-ADJ($ent) } sentence for {$crime} and { CONJUGATE-HAVE($ent) } been automatically released.
+genpop-prisoner-id-release = {$name} has served their sentence for {$crime} and has been automatically released.
 genpop-prisoner-name-default = A prisoner

--- a/Resources/Locale/en-US/_FarHorizons/access/components/genpop.ftl
+++ b/Resources/Locale/en-US/_FarHorizons/access/components/genpop.ftl
@@ -1,2 +1,2 @@
-genpop-prisoner-id-release = {$name} has served their sentence for {$crime} and has been automatically released.
+genpop-prisoner-id-release = {CAPITALIZE($ent)} { CONJUGATE-HAVE($ent) } served { POSS-ADJ($ent) } sentence for {$crime} and { CONJUGATE-HAVE($ent) } been automatically released.
 genpop-prisoner-name-default = A prisoner

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Storage/lockers.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Storage/lockers.yml
@@ -780,6 +780,8 @@
   - type: AccessReader
     access: [["SecurityNS"]]
     examinationText: access-reader-examination-functionality-restricted
+  - type: GenpopLocker
+    radioChannel: SyndiSec
 
 
 - type: entity


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
adds a radio announcement for when a prisoner is released so security knows when someone leaves genpop
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
https://discord.com/channels/1407077238876147783/1545255151021990009
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="551" height="45" alt="dotnet_RgjZxcmoxv" src="https://github.com/user-attachments/assets/aa245cfe-cc71-4b69-93d5-5bb09d016fc3" />
<img width="558" height="73" alt="image" src="https://github.com/user-attachments/assets/2749ac7e-1fee-42af-88af-95b19b18dc16" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: KarusKardin
- add: Added an automated radio message for when a prisoner is released from genpop
