### PR TITLE
Fix NeoSol Drozd Sprites

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -197,9 +197,9 @@
         - state: mag-0
           map: ["enum.GunVisualLayers.Mag"]
     - type: Clothing
-      sprite: _FarHorizons/Objects/Weapons/Guns/Rifles/NS_Drozd/ns_drozd_x32.rsi
+      sprite: _FarHorizons/Objects/Weapons/Guns/SMGs/NS_Drozd/ns_drozd_x32.rsi
     - type: Item
-      sprite: _FarHorizons/Objects/Weapons/Guns/Rifles/NS_Lecter/ns_drozd_x32.rsi
+      sprite: _FarHorizons/Objects/Weapons/Guns/SMGs/NS_Drozd/ns_drozd_x32.rsi
     - type: Wieldable
       unwieldOnUse: false
     - type: GunWieldBonus # 1-5 Deviation / Long Barrel & Heavy Stock/Grip


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
The sprites for holding and wielding the NeoSol Drozd are currently broken, because the path that the game is using to search for those sprites is wrong, so its trying to pull them from a folder that doesn't exist.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions well as Bug Reports here. Please describe how this will change the game balance. -->
[Fixes](https://discord.com/channels/1407077238876147783/1543690764234793081)
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
### Before
<img width="380" height="647" alt="Captura de pantalla 2026-09-06 160026" src="https://github.com/user-attachments/assets/b9fee2f1-9a5d-4555-8486-ab907d5543ad" />

### After
<img width="375" height="586" alt="Captura de pantalla 2026-09-06 155802" src="https://github.com/user-attachments/assets/d50265d5-bc33-43fa-83e7-8ebeccb1b643" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: RubiconLocked
- fix: Drozd Type-S is now visible when held/wielded.
