### PR TITLE
bag rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -13,10 +13,14 @@
     quickEquip: false
     slots:
     - back
+  # FH start
   - type: Storage
     grid:
-    - 0,0,6,3
-    maxItemSize: Ginormous #FH - Fix for not being able to fit storage containers that hold "huge" items, like guns.
+    - 0,2,1,5
+    - 3,0,6,5
+    - 8,2,9,5
+    maxItemSize: Ginormous
+  # FH end
   - type: ContainerContainer
     containers:
       storagebase: !type:Container
@@ -29,6 +33,12 @@
   # to prevent bag open/honk spam
   - type: UseDelay
     delay: 0.5
+  # FH start
+  - type: ClothingSpeedModifier
+    walkModifier: 1
+    sprintModifier: 0.95
+  - type: HeldSpeedModifier
+  # FH end
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: Tag
@@ -340,6 +350,11 @@
     maxItemSize: Ginormous #FH
     grid:
     - 0,0,19,9
+  # FH start
+  - type: ClothingSpeedModifier
+    sprintModifier: 1 # makes its stats identical to other variants of bag of holding
+  - type: HeldSpeedModifier
+  # FH end
 
 - type: entity
   parent: ClothingBackpackClown

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -9,7 +9,7 @@
   - type: Storage
     maxItemSize: Ginormous #FH - Fix for not being able to fit storage containers that hold "huge" items, like guns.
     grid:
-    - 0,0,7,4
+    - 0,0,8,4 # FH
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 0.9
@@ -186,7 +186,7 @@
     damageCoefficient: 0.1
   - type: Storage
     grid:
-    - 0,0,8,4
+    - 0,0,9,4 # FH
 
 - type: entity
   parent: [ ClothingBackpackDuffelSyndicate, BaseSyndicateContraband ]

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -11,6 +11,11 @@
     - 0,0,1,3
     - 3,0,6,3
     - 8,0,9,3
+  # FH start
+  - type: ClothingSpeedModifier
+    sprintModifier: 1
+  - type: HeldSpeedModifier
+  # FH end
 
 - type: entity
   parent: ClothingBackpackSatchel

--- a/Resources/Prototypes/Entities/Clothing/Back/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/specific.yml
@@ -78,7 +78,7 @@
     exactVolume: true
 
 - type: entity
-  parent: ClothingBackpack
+  parent: ClothingBackpackSatchel
   id: ClothingBagPet
   name: pet bag
   description: A small bag designed for use by pets and small animals.
@@ -124,7 +124,7 @@
         location: Middle
 
 - type: entity
-  parent: ClothingBackpack
+  parent: ClothingBackpackSatchel
   id: XenoborgMaterialBag
   name: silicon storage square
   description: A knockoff version of a bluespace bag, can vacumn up select materials, unfit for use by humanoids due to harmful emissions.

--- a/Resources/Prototypes/Entities/Clothing/Belt/waist_bags.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/waist_bags.yml
@@ -8,6 +8,8 @@
     sprite: Clothing/Belt/waistbag_leather.rsi
   - type: Clothing
     sprite: Clothing/Belt/waistbag_leather.rsi
+    slots:
+      - rig
   - type: Storage
     grid:
     - 0,0,3,1


### PR DESCRIPTION
## Short description
rebalancing bags (duffel gets a bit more space, backpack becomes an option between satchel and duffel instead of worse satch) + moving waist bag to the rig slot

## Why we need to add this
makes backpacks less useless and gives a non-job-specific rig slot option
discussion in https://discord.com/channels/1407077238876147783/1543745809672052816

## Media (Video/Screenshots)
satchel
<img width="360" height="135" alt="2026-09-02-201339_hyprshot" src="https://github.com/user-attachments/assets/e33fcb69-5565-4dff-a21a-bf6e2e304f45" />
backpack
<img width="362" height="201" alt="image" src="https://github.com/user-attachments/assets/c65148d8-1c23-4d9a-9ca5-9e570debf354" />
duffel bag
<img width="330" height="172" alt="2026-09-02-201246_hyprshot" src="https://github.com/user-attachments/assets/a1364a8c-3a65-44ec-a059-4cb0dcfbc719" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

**Changelog**

:cl: Killer Tamashi & qriqii
- tweak: Rebalanced backpacks to give them more space than satchels, at the cost of a 5% speed reduction.
- tweak: Increased duffel bag size by one column.
- tweak: Moved waist bag to rig slot.