### PR TITLE
Give the RSO access to their gun

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -794,7 +794,6 @@
     fireCost: 100
   - type: BatteryWeaponFireModes
     fireModes:
-# FH - Removal of Disabler mode
     - proto: TaserBolt
       fireCost: 100
       magState: stun

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -757,3 +757,58 @@
     tags:
     - Sidearm
     - Dominator
+
+- type: entity
+  name: X-01 Multiphase Energy Gun
+  suffix: NS
+  parent: [ BaseWeaponBatterySmall, BaseBlueshieldContraband ]
+  id: WeaponMultiphaseGunNS
+  description: This is an expensive, modern version of the antique laser pistol, with several unique fire modes.
+  components:
+  - type: Appearance
+  - type: Sprite
+    sprite: _Starlight/Objects/Weapons/Guns/Battery/multiphase_gun.rsi
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: disable-unshaded
+      map: ["enum.FireModesLayers.FireMode"]
+      shader: unshaded
+    - state: disable-unshaded-0
+      map: ["enum.GunVisualLayers.MagUnshaded"]
+      shader: unshaded
+  - type: Lock
+    mindShieldLock: true
+  - type: AccessReader
+    access: [["RedSword"]]
+  - type: Item
+    size: Small
+    shape:
+    - 0, 0, 1, 1
+  - type: MagazineVisuals
+    magState: disable
+    steps: 5
+    zeroVisible: true
+  - type: BatteryAmmoProvider
+    proto: TaserBolt
+    fireCost: 100
+  - type: BatteryWeaponFireModes
+    fireModes:
+# FH - Removal of Disabler mode
+    - proto: TaserBolt
+      fireCost: 100
+      magState: stun
+      visualState: stun-unshaded
+    - proto: RedLaserBeam
+      fireCost: 75
+      magState: kill
+      visualState: kill-unshaded
+    - proto: DestroyBeam
+      fireCost: 750
+      magState: destroy
+      visualState: destroy-unshaded
+  - type: Battery
+    maxCharge: 1500
+    startingCharge: 1500
+  - type: BatterySelfRecharger
+    autoRechargeRate: 20

--- a/Resources/Prototypes/_FarHorizons/Factions/Loadouts/syndie_startingGear.yml
+++ b/Resources/Prototypes/_FarHorizons/Factions/Loadouts/syndie_startingGear.yml
@@ -18,7 +18,7 @@
     id: RedSwordPDA
     belt: ClothingBeltRedSwordWebbingFilled
     gloves: ClothingHandsGlovesCombat
-    pocket1: WeaponMultiphaseGun
+    pocket1: WeaponMultiphaseGunNS
     pocket2: HandheldBSOCrewMonitorNS
   storage:
     back:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -162,6 +162,7 @@
 
 - type: entity
   name: X-01 Multiphase Energy Gun #Far Horizons - The Great Capitalization Crusade
+  suffix: NT #FH
   parent: [ BaseWeaponBatterySmall, BaseBlueshieldContraband ] # FH
   id: WeaponMultiphaseGun
   description: This is an expensive, modern version of the antique laser pistol, with several unique fire modes.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Since the RSO was added, they have spawned with the X-01 Multiphase Energy Gun that the BSO also has, but there is one small problem. The gun is still locked behind BSO only access, so the RSO spawns with an useless gun. 

This PR fixes that, by making an EXACT COPY of the X-01 but with RSO access instead of BSO. 

Before you bring up that maybe it would have been easier to give the X-01 both BSO and RSO access instead of making an exact copy of it, I tried that, and the game would straight up not start until I undid that change.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Because the RSO can't use the gun they spawn with.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="518" height="671" alt="Captura de pantalla 2026-09-07 092649" src="https://github.com/user-attachments/assets/3119a505-b313-4f39-a610-e66006aad86f" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: RubiconLocked
- fix: RedSword Operatives now spawn with a X-01 with the proper RSO access.