### PR TITLE
SKB Implants can now extract all Mindshields

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -405,7 +405,7 @@
 - type: entity
   parent: BaseSubdermalImplant
   id: MindShieldImplant
-  name: mindshield implant
+  name: Mindshield Implant (NT) # FH
   description: This implant will ensure protection against mind control devices. # FH
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Misc/subdermal_implants.yml
@@ -100,7 +100,7 @@
 - type: entity
   parent: MindShieldImplant
   id: MindShieldImplantNS
-  name: mindshield implant (NS)
+  name: Mindshield Implant (NS)
   description: This implant will ensure protection against mind control devices. # FH
   categories: [ HideSpawnMenu ]
   components:
@@ -110,7 +110,7 @@
 - type: entity
   parent: MindShieldImplant
   id: MindShieldImplantGSL
-  name: mindshield implant (GSL)
+  name: Mindshield Implant (GSL)
   description: This implant will ensure protection against mind control devices. # FH
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Misc/implanters.yml
@@ -45,6 +45,8 @@
     implantOnly: false
     deimplantWhitelist:
     - MindShieldImplant
+    - MindShieldImplantNS
+    - MindShieldImplantGSL
     deimplantFailureDamage:
         types:
           Heat: 30


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Currently SKB implanters can only remove NT Implants, meaning that revolutionaries cant take out Mindshields of the GSL and NS. This PR makes it so SKB implanters can be cycled between NT, NS and GSL.

It also capitalizes the Mindshield Implants.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Because currently revolutions on NS stations cant convert security or command, and no revolution can convert Salvage or the QM without having to use regular implant extractors.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="426" height="249" alt="Captura de pantalla 2026-09-08 200135" src="https://github.com/user-attachments/assets/b5e05fde-ecba-4dc2-b83e-1872e492e3b9" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: RubiconLocked
- fix: SKB Implants can now extract all Mindshield types.
