### PR TITLE
Give NeoSol Engineering Cyborgs the Diagnostic HUD

### DIFF
--- a/Resources/Prototypes/_FarHorizons/borg_types.yml
+++ b/Resources/Prototypes/_FarHorizons/borg_types.yml
@@ -123,6 +123,16 @@
   radioChannels:
   - SyndiEngi
   - SyndiSci
+  
+   # Starlight start: Engiborg hud, access
+  addComponents:
+  - type: ShowHealthBars
+    damageContainers:
+    - Inorganic
+    - Silicon
+    - Robotic #FH
+  - type: ShowAccessReaderSettings
+  # Starlight end
 
   # Visual
   inventoryTemplateId: borgShort

--- a/Resources/Prototypes/_FarHorizons/borg_types.yml
+++ b/Resources/Prototypes/_FarHorizons/borg_types.yml
@@ -124,15 +124,13 @@
   - SyndiEngi
   - SyndiSci
   
-   # Starlight start: Engiborg hud, access
   addComponents:
   - type: ShowHealthBars
     damageContainers:
     - Inorganic
     - Silicon
-    - Robotic #FH
+    - Robotic
   - type: ShowAccessReaderSettings
-  # Starlight end
 
   # Visual
   inventoryTemplateId: borgShort


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
When making the NeoSol engineering cyborg chassis, they were given almost everything the regular engi chassis has, except for the diagnostic HUD for some reason? This PR gives them the diagnostic HUD to have them be in par with the NT engi chassis.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
For parity between the two chassis. Also, pretty sure this is a bug.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1919" height="1079" alt="Captura de pantalla 2026-09-08 210238" src="https://github.com/user-attachments/assets/b13b0bcf-e53d-4eda-b90b-88d6c377ebc2" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: RubiconLocked
- fix: NeoSol engineering cyborgs now have a diagnostic HUD, like their NanoTrasen counterparts.
