### PR TITLE
Small tweaks

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Body/Cybernetic/limbs.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Cybernetic/limbs.yml
@@ -1237,14 +1237,6 @@
         path: /Audio/Mecha/sound_mecha_powerloader_step.ogg
         params:
           volume: -10
-    - type: RoundstartImplantable
-      cost: 2
-      iconScale: 3
-      iconOffset: -45, -68
-      description:
-        - roundstart-cybernetics-hydraulic-description
-        - roundstart-cybernetics-foot-attached-description
-        - roundstart-cybernetics-generic-limb-description
 
 - type: entity
   id: RightLegCyberHydraulic
@@ -1265,14 +1257,6 @@
         path: /Audio/Mecha/sound_mecha_powerloader_step.ogg
         params:
           volume: -10
-    - type: RoundstartImplantable
-      cost: 2
-      iconScale: 3
-      iconOffset: -25, -68
-      description:
-        - roundstart-cybernetics-hydraulic-description
-        - roundstart-cybernetics-foot-attached-description
-        - roundstart-cybernetics-generic-limb-description
 
 # Pilebunker Legs
 - type: entity

--- a/Resources/Prototypes/_FarHorizons/Research/research_nodes_nt.yml
+++ b/Resources/Prototypes/_FarHorizons/Research/research_nodes_nt.yml
@@ -478,6 +478,8 @@
     - RightLegCyber
     - LeftFootCyber
     - RightFootCyber
+    - LeftLegCyberHydraulic
+    - RightLegCyberHydraulic
   announceTo:
     - Medical
 
@@ -1202,8 +1204,6 @@
   - RightArmCyberHerakles
   - LeftArmCyberRipper
   - RightArmCyberRipper
-  - LeftLegCyberHydraulic
-  - RightLegCyberHydraulic
   - LeftLegCyberCargo
   - RightLegCyberCargo
 

--- a/Resources/Prototypes/_FarHorizons/Space/planets.yml
+++ b/Resources/Prototypes/_FarHorizons/Space/planets.yml
@@ -3,7 +3,7 @@
   id: PlanetTypeGasGiant
   orbit: [ OuterWarm]
   shader: GasGiant
-  basePrettiness: 30 # Pretty nice
+  basePrettiness: 25
   ringProbability: 0.45
   earthMass:
     min: 100.0
@@ -37,7 +37,7 @@
   id: PlanetTypeIceGiant
   orbit: [ OuterCold ]
   shader: IceGiant
-  basePrettiness: 15 # Eh
+  basePrettiness: 25
   ringProbability: 0.45
   earthMass:
     min: 10.0
@@ -69,7 +69,7 @@
   id: PlanetTypeVolcanic
   orbit: [ InnerHot ]
   shader: RockyPlanet
-  basePrettiness: 10 # Could be fine when it has lava
+  basePrettiness: 10
   ringProbability: 0.05
   earthMass:
     min: 0.1
@@ -139,7 +139,7 @@
   id: PlanetTypeDesert
   orbit: [ InnerHot, InnerHabitable ]
   shader: RockyPlanet
-  basePrettiness: 0 # Eh
+  basePrettiness: 10
   ringProbability: 0.05
   earthMass:
     min: 0.5
@@ -160,7 +160,7 @@
   id: PlanetTypeIce
   orbit: [ InnerHabitable, InnerCold ]
   shader: RockyPlanet
-  basePrettiness: 0 # Eh
+  basePrettiness: 15
   ringProbability: 0.15
   earthMass:
     min: 0.5
@@ -183,7 +183,7 @@
   id: PlanetTypeHabitable
   orbit: [ InnerHabitable ]
   shader: RockyPlanet
-  basePrettiness: 15 # Neat
+  basePrettiness: 15
   ringProbability: 0.10
   earthMass:
     min: 0.8


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Hydraulic removal from being roundstart as discussed in https://discord.com/channels/1407077238876147783/1546259482076647496

And higher chance for station to spawn at planets other than gas giant

## Why we need to add this
speed meta is kill
and planets are just nice for variety

## Media (Video/Screenshots)
<img width="501" height="268" alt="image" src="https://github.com/user-attachments/assets/fed4730a-a662-4aa4-a2ac-3ad9b5f58fd0" />
<img width="965" height="595" alt="image" src="https://github.com/user-attachments/assets/06ab586c-f597-44c3-bf18-753e6f50f386" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: princess_gurchi
- remove: Hydraulic leg is no longer roundstart implantable. It became a meta selection that people felt they had to take because others took it, and this was never an intention for roundstart cybernetics.
- tweak: Hydraulic leg moved to earlier research until it's reworked
- tweak: Higher chance for station to spawn at planets other than gas giant
