### PR TITLE
Give the Extended ZOZ a whitelist

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -348,3 +348,10 @@
     slots:
       gun_magazine:
         startingItem: MagazineShotgunTozExtended
+        priority: 2 #FH
+        whitelist: #FH
+          tags: #FH
+          - MagazineShotgunToz #FH
+        whitelistFailPopup: gun-magazine-whitelist-fail #FH
+        insertSound: /Audio/Weapons/Guns/MagIn/smg_magin.ogg #FH
+        ejectSound: /Audio/Weapons/Guns/MagOut/smg_magout.ogg #FH


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
There are currently two different ZOZ shotguns in game, one spawns with a regular magazine inside, the other spawns with an extended magazine, problem is, the ZOZ that spawns with the extended magazine doesnt have a whitelist, so you can put literally anything in the magazine slot. 

This PR adds the whitelist from the regular ZOZ to the extended ZOZ.

(Also adds some sounds that were on the original ZOZ but not the extended.)
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
[Bugfixes](https://discord.com/channels/1407077238876147783/1543707040067620894) and such.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/faf4db54-215e-4aef-b715-35d7653b0cf8



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: RubiconLocked
- fix: The ZOZ Shotgun that spawns with a extended magazine now only accepts ZOZ magazines and sounds like a regular ZOZ would.
