### PR TITLE
Remove the requirement of having ears for resomi... i guess

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Body/Species/resomi.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Species/resomi.yml
@@ -11,8 +11,7 @@
       required: false
     enum.HumanoidVisualLayers.HeadSide:
       limit: 1
-      required: true
-      default: [ ResomiEars ]
+      required: false
     enum.HumanoidVisualLayers.HeadTop:
       limit: 4
       required: false


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR removes the requirement for resomi to have ears.

## Why we need to add this
Some resomi players were a little distressed about the fact that they need to be able to hear from a mile away. This also allows resomi players to only select upper or lower ears from ear accessories. 

## Media (Video/Screenshots)
<img width="1438" height="747" alt="image" src="https://github.com/user-attachments/assets/6cf7da6e-e17d-40e2-8dcb-53a9d88febde" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: Fasuh
- tweak: Changed resomi to allow them to be bald.
