### PR TITLE
MA Repair Changes

### DIFF
--- a/Content.Shared/_FarHorizons/PowerArmor/SharedPowerArmorSystems.cs
+++ b/Content.Shared/_FarHorizons/PowerArmor/SharedPowerArmorSystems.cs
@@ -77,7 +77,7 @@ public abstract partial class SharedPowerArmorSystem : EntitySystem
         SubscribeLocalEvent<PowerArmorPartComponent, EntGotInsertedIntoContainerMessage>(OnPartInserted);
         SubscribeLocalEvent<PowerArmorPartComponent, EntGotRemovedFromContainerMessage>(OnPartEjected);
         SubscribeLocalEvent<PowerArmorPartComponent, BreakageEventArgs>(OnPartBroken);
-        SubscribeLocalEvent<PowerArmorPartComponent, RepairedEvent>(OnRepair);
+        SubscribeLocalEvent<PowerArmorPartComponent, RepairDoAfterEvent>(OnRepair);
         SubscribeLocalEvent<PowerArmorPartComponent, AfterInteractEvent>(OnInteractUsing);
 
         SubscribeLocalEvent<PowerArmorModuleComponent, EntGotInsertedIntoContainerMessage>(OnModuleInstalled);
@@ -452,21 +452,24 @@ public abstract partial class SharedPowerArmorSystem : EntitySystem
         _movement.RefreshMovementSpeedModifiers(paComp.Wearer.Value);
     }
 
-    private void OnRepair(Entity<PowerArmorPartComponent> ent, ref RepairedEvent args)
+    private void OnRepair(Entity<PowerArmorPartComponent> ent, ref RepairDoAfterEvent args)
     {
-        if(!_container.TryGetContainingContainer(ent.Owner, out var container) 
-        || !TryComp<PowerArmorComponent>(container.Owner, out var paComp)) return;
-
-        paComp.TotalSpeedModifier = (float) Math.Round(paComp.TotalSpeedModifier - ent.Comp.SpeedModifier, 2);
+        if(args.Cancelled) return;
         
-        _appearance.SetData(ent.Owner, PowerArmorPartVisuals.PowerArmor, GetNetEntity(container.Owner));
-        _appearance.SetData(ent.Owner, PowerArmorPartVisuals.Visible, true);
+        if(_container.TryGetContainingContainer(ent.Owner, out var container) 
+        && TryComp<PowerArmorComponent>(container.Owner, out var paComp))
+        {
+            paComp.TotalSpeedModifier = (float) Math.Round(paComp.TotalSpeedModifier - ent.Comp.SpeedModifier, 2);
+        
+            _appearance.SetData(ent.Owner, PowerArmorPartVisuals.PowerArmor, GetNetEntity(container.Owner));
+            _appearance.SetData(ent.Owner, PowerArmorPartVisuals.Visible, true);
+
+            if(paComp.Wearer != null) 
+                _movement.RefreshMovementSpeedModifiers(paComp.Wearer.Value);
+        }
+
         ent.Comp.isBroken = false;
         Dirty(ent);
-
-        if(paComp.Wearer == null) return;
-
-        _movement.RefreshMovementSpeedModifiers(paComp.Wearer.Value);
     }
 
     private void OnInteractUsing(Entity<PowerArmorPartComponent> ent, ref AfterInteractEvent args)

--- a/Resources/Prototypes/_FarHorizons/Entities/PowerArmor/parts.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/PowerArmor/parts.yml
@@ -13,10 +13,6 @@
     partType: Head
   - type: Damageable
     damageContainer: LimbDamageContainer
-  - type: Repairable
-    damageValue: -15 
-    doAfterDelay: 1
-    fuelCost: 0.5
     
 
 #region Base Parts
@@ -144,6 +140,10 @@
           collection: MetalBreak
       - !type:DoActsBehavior
         acts: ["Breakage"]
+  - type: Repairable
+    damageValue: -20 
+    doAfterDelay: 1
+    fuelCost: 5.0
 
 #region Head
 
@@ -163,6 +163,10 @@
           collection: MetalBreak
       - !type:DoActsBehavior
         acts: ["Breakage"]
+  - type: Repairable
+    damageValue: -20 
+    doAfterDelay: 1
+    fuelCost: 5.0
 
 #region Chest
 
@@ -182,6 +186,10 @@
           collection: MetalBreak
       - !type:DoActsBehavior
         acts: ["Breakage"]
+  - type: Repairable
+    damageValue: -40 
+    doAfterDelay: 1
+    fuelCost: 5.0
 
 #region Arms
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Tweaks a little the code of how repairs are handled for Modular Armor. 
Instead of waiting for the full repair event armor will be repaired after the first do after but will still have low health.
Changed how many times you need to repair the parts from 0 to 100 to just 5 loops. 
Fixed a bug where PA required to be equipped to be repaired else it'd be bricked for the rest of round.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Fixes.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT license](https://github.com/Far-Horizons-SS14/Far-Horizons-SS14/blob/Far-Horizons/LICENSE.TXT).

<!-- This is a placeholder. Replace "FAR HORIZONS TEAM" with your name and the rest with your changelog! -->
**Changelog**

:cl: AthenaAI
- tweak: Instead of waiting for the full repair event armor will be repaired after the first do after but will still have low health.
- tweak: Changed how many times you need to repair the parts from 0 to 100 to just 5 loops. 
- fix: Fixed a bug where PA required to be equipped to be repaired else it'd be bricked for the rest of round.
